### PR TITLE
Fix compile warnings

### DIFF
--- a/ros/src/computing/planning/motion/packages/driving_planner/nodes/lattice_trajectory_gen/lattice_trajectory_gen.cpp
+++ b/ros/src/computing/planning/motion/packages/driving_planner/nodes/lattice_trajectory_gen/lattice_trajectory_gen.cpp
@@ -397,32 +397,6 @@ static void displayNextWaypoint(int i)
 }
 
 /////////////////////////////////////////////////////////////////
-// obtain the linear/angular velocity toward the next waypoint.
-/////////////////////////////////////////////////////////////////
-static geometry_msgs::Twist calcTwist(int next_waypoint)
-{
-  //std::cout << "calculate" << std::endl;
-  geometry_msgs::Twist twist;
-
-  double radius = _path_pp.calcRadius(next_waypoint);
-  twist.linear.x = _path_pp.getCmdVelocity();
-
-  double current_velocity = _current_velocity;
-
-  if (radius > 0 || radius < 0)
-  {
-    twist.angular.z = current_velocity / radius;
-  }
-  else
-  {
-    twist.angular.z = 0;
-  }
-  return twist;
-}
-
-
-
-/////////////////////////////////////////////////////////////////
 // Safely stop the vehicle.
 /////////////////////////////////////////////////////////////////
 static geometry_msgs::Twist stopControl()

--- a/ros/src/computing/planning/motion/packages/driving_planner/nodes/lattice_twist_convert/lattice_twist_convert.cpp
+++ b/ros/src/computing/planning/motion/packages/driving_planner/nodes/lattice_twist_convert/lattice_twist_convert.cpp
@@ -209,7 +209,6 @@ void splineCallback(const std_msgs::Float64MultiArray::ConstPtr& spline)
     }
 
     // Reset elapsed time to 0, if called...
-    double start_time = ros::Time::now().toSec();
     int i = 0;
 
     for(std::vector<double>::const_iterator it = spline->data.begin(); it != spline->data.end(); ++it)

--- a/ros/src/data/packages/map_db/CMakeLists.txt
+++ b/ros/src/data/packages/map_db/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
 add_message_files(
   FILES

--- a/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp
+++ b/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp
@@ -61,7 +61,6 @@ GetFile::GetFile(const std::string& host_name, int port)
 
 int GetFile::ConnectHTTP()
 {
-	int r;
 	unsigned int **addrptr;
 
 #if 0
@@ -167,7 +166,6 @@ int GetFile::GetHTTPFile(const std::string& value)
 	snprintf(send_buf, sizeof(send_buf), "\r\n");
 	write(sock, send_buf, strlen(send_buf));
 
-	int r_head = 1;
 	while(1) {
 		n = read(sock, recvdata, sizeof(recvdata)-1);
 		if (n < 0) {
@@ -189,7 +187,7 @@ int GetFile::GetHTTPFile(const std::string& value)
 
 	std::istringstream ss(res);
 	std::string tbuf;
-	for(int i; i < 10; i++) {
+	for(int i = 0; i < 10; i++) {
 		std::getline(ss, tbuf);	// ignore http header
 		if(tbuf.size() <= 1) break;
 	}


### PR DESCRIPTION
I got following compile warnings.

```
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp: In member function ‘int GetFile::ConnectHTTP()’:
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp:64:6: warning: unused variable ‘r’ [-Wunused-variable]
  int r;
      ^
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp: In member function ‘int GetFile::GetHTTPFile(const string&)’:
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp:170:6: warning: unused variable ‘r_head’ [-Wunused-variable]
  int r_head = 1;
      ^
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp:164:41: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
  write(sock, send_buf, strlen(send_buf));
                                         ^
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp:166:41: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
  write(sock, send_buf, strlen(send_buf));
                                         ^
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp:168:41: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
  write(sock, send_buf, strlen(send_buf));
                                         ^
/home/syohei/work/Autoware/ros/src/data/packages/map_db/lib/map_db/GetFile.cpp:192:2: warning: ‘i’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  for(int i; i < 10; i++) {
  ^

...

/home/syohei/work/Autoware/ros/src/computing/planning/motion/packages/driving_planner/nodes/lattice_trajectory_gen/lattice_trajectory_gen.cpp:402:29: warning: ‘geometry_msgs::Twist calcTwist(int)’ defined but not used [-Wunused-function\
]
 static geometry_msgs::Twist calcTwist(int next_waypoint)
                             ^
Linking CXX executable /home/syohei/work/Autoware/ros/devel/lib/driving_planner/lattice_trajectory_gen
[ 98%] Built target lattice_trajectory_gen
Scanning dependencies of target lattice_twist_convert
[ 98%] Building CXX object computing/planning/motion/packages/driving_planner/CMakeFiles/lattice_twist_convert.dir/nodes/lattice_twist_convert/lattice_twist_convert.cpp.o
/home/syohei/work/Autoware/ros/src/computing/planning/motion/packages/driving_planner/nodes/lattice_twist_convert/lattice_twist_convert.cpp: In function ‘void splineCallback(const ConstPtr&)’:
/home/syohei/work/Autoware/ros/src/computing/planning/motion/packages/driving_planner/nodes/lattice_twist_convert/lattice_twist_convert.cpp:212:12: warning: unused variable ‘start_time’ [-Wunused-variable]
     double start_time = ros::Time::now().toSec();
            ^
```
