### PR TITLE
Runtime Manager, add top cmd alert level setting

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1058,8 +1058,10 @@ class MyFrame(rtmgr.MyFrame):
 			wx.CallAfter(mem_ibl.lb_set, tx, col)
 			wx.CallAfter(mem_ibl.bar_set, rate)
 
-			is_alert_cpu = ( busy_cpu_cnt >= cpu_n * alert_level.get('rate_cpu_num', 70) / 100 )
-			is_alert = is_alert_cpu or rate >= 90
+			busy_cpu_lmt = int( cpu_n * alert_level.get('rate_cpu_num', 70) / 100 )
+			if busy_cpu_lmt <= 0:
+				busy_cpu_lmt = 1
+			is_alert = busy_cpu_cnt >= busy_cpu_lmt or rate >= 90
 
 			# --> for test
 			if os.path.exists('/tmp/alert_test_on'):

--- a/ros/src/util/packages/runtime_manager/scripts/status.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/status.yaml
@@ -2,7 +2,8 @@ top_cmd_setting :
   interval : 3
   alert_level :
     rate_per_cpu : 90
-    rate_cpu_num : 70
+    rate_cpu_num : -1
+    #rate_cpu_num : 70
 
 log_path : syslog
 


### PR DESCRIPTION
topコマンドで取得したCPU負荷のアラート表示判定の設定を追加しました

status.yamlファイル
 top_cmd_setting :
   alert_level :
     rate_per_cpu : 90
     rate_cpu_num : -1
の
rate_cpu_numとして負の値を設定すると、CPUが1つでも rate_per_cpu に達すると、
赤点滅表示になります。
