### PR TITLE
sound_player, update about sound file relative path

### DIFF
--- a/ros/src/util/packages/sound_player/scripts/sound_player.py
+++ b/ros/src/util/packages/sound_player/scripts/sound_player.py
@@ -81,7 +81,7 @@ def sound_player():
 				fn = pack_path + '/' + fn
 			else:
 				cmd = 'find ' + pack_path + '/wavs' + ' -name ' + fn
-				fn = subprocess.check_output([ 'sh', '-c', cmd ]).strip()
+				fn = subprocess.check_output([ 'sh', '-c', cmd ]).strip().split('\n')[0]
 		str_fn_dic[k] = fn
 
 	rospy.init_node('sound_player', anonymous=True)

--- a/ros/src/util/packages/sound_player/scripts/sound_player.py
+++ b/ros/src/util/packages/sound_player/scripts/sound_player.py
@@ -69,8 +69,7 @@ def sound_player():
 	else:
 		proc = subprocess.Popen(['rosrun', 'sound_play', 'soundplay_node.py'])
 
-	cmd = '(cd $(rospack find runtime_manager)/../../../../.. ; pwd)'
-	autoware_path = subprocess.check_output([ 'sh', '-c', cmd ]).strip()
+	pack_path = subprocess.check_output([ 'rospack', 'find', 'sound_player' ]).strip()
 
 	global str_fn_dic
 	str_fn_dic = load_yaml('sound_player.yaml', {})
@@ -78,7 +77,11 @@ def sound_player():
 	for (k,fn) in str_fn_dic.items():
 		fn = os.path.expandvars(os.path.expanduser(fn))
 		if not os.path.isabs(fn):
-			fn = autoware_path + '/' + fn
+			if '/' in fn:
+				fn = pack_path + '/' + fn
+			else:
+				cmd = 'find ' + pack_path + '/wavs' + ' -name ' + fn
+				fn = subprocess.check_output([ 'sh', '-c', cmd ]).strip()
 		str_fn_dic[k] = fn
 
 	rospy.init_node('sound_player', anonymous=True)


### PR DESCRIPTION
sound_player

sound_player.yaml ファイルで指定する、音声ファイルパスについて

相対パス指定のときの扱いを更新しました。
相対パス中に '/' を含む場合は、sound_playerパッケージディレクトリからの相対パスとして扱います。
相対パス中に '/' を含まない場合(ファイル名のみの場合)は、
sound_playerパッケージディレクトリのwavs/ ディレクトリ以下をfindコマンドでサーチした結果の先頭のファイルパスとします。
