### PR TITLE
Euclidean Clustering can optionally publish filtered point cloud and/or filtered ground points

### DIFF
--- a/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
@@ -1,7 +1,8 @@
 <!-- -->
 <launch>
-	<arg name="points_node" default="/vscan_filling_cloud" />
-
+	<arg name="points_node" default="/points_raw" /><!--CHANGE THIS TO READ WHETEHER FROM VSCAN OR POINTS_RAW -->
+	<arg name="publish_ground" default="true" />
+	<arg name="publish_filtered" default="true" />
 
 	<!-- rosrun lidar_tracker vscan_filling -->
 	<node pkg="lidar_tracker" type="vscan_filling" name="vscan_filling" />
@@ -9,6 +10,8 @@
 	<!-- rosrun lidar_tracker euclidean_cluster _points_node:="" -->
 	<node pkg="lidar_tracker" type="euclidean_cluster" name="euclidean_cluster">
 		<param name="points_node" value="$(arg points_node)" />
+		<param name="publish_ground" value="$(arg publish_ground)" /><!--GROUND FILTERING LIKELY WONT WORK ON VSCAN (for obvious reasons)-->
+		<param name="publish_filtered" value="$(arg publish_filtered)" /><!--POINTS FILTERING LIKELY WONT WORK ON VSCAN (for obvious reasons)-->
 	</node>
 
 </launch>

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
@@ -1,6 +1,6 @@
 <!-- -->
 <launch>
-	<arg name="points_node" default="/points_raw" /><!--CHANGE THIS TO READ WHETEHER FROM VSCAN OR POINTS_RAW -->
+	<arg name="points_node" default="/points_raw" /><!--CHANGE THIS TO READ WHETHER FROM VSCAN OR POINTS_RAW -->
 	<arg name="publish_ground" default="true" />
 	<arg name="publish_filtered" default="true" />
 

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
@@ -226,20 +226,20 @@ int main (int argc, char** argv)
 	}
 	else
 	{
-		ROS_INFO("euclidean_cluster > No points node received, defaulting to velodyne_points, you can use _points_node:=YOUR_TOPIC");
+		ROS_INFO("euclidean_cluster > No points node received, defaulting to points_raw, you can use _points_node:=YOUR_TOPIC");
 		points_topic = "/points_raw";
 	}
 	publish_ground = false;
 	if (private_nh.getParam("publish_ground", publish_ground))
 	{
 		ROS_INFO("Publishing /points_ground point cloud...");
-		pub_filtered = h.advertise<sensor_msgs::PointCloud2>("/points_filtered",1);
+		pub_ground = h.advertise<sensor_msgs::PointCloud2>("/points_ground",1);
 	}
 	publish_filtered = false;
 	if (private_nh.getParam("publish_filtered", publish_filtered))
 	{
 		ROS_INFO("Publishing /points_filtered point cloud...");
-		pub_ground = h.advertise<sensor_msgs::PointCloud2>("/points_ground",1);
+		pub_filtered = h.advertise<sensor_msgs::PointCloud2>("/points_filtered",1);
 	}
 
 	// Create a ROS subscriber for the input point cloud

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
@@ -34,9 +34,14 @@ using namespace cv;
 
 std::vector<cv::Scalar> _colors;
 ros::Publisher pub;
+ros::Publisher pub_filtered;
+ros::Publisher pub_ground;
 ros::Publisher centroid_pub;
 ros::Publisher marker_pub;
 visualization_msgs::Marker marker;
+
+static bool publish_ground;		//only ground
+static bool publish_filtered;	//pc with no ground
 
 void cloud_cb (const sensor_msgs::PointCloud2ConstPtr& input)
 {
@@ -62,39 +67,36 @@ void cloud_cb (const sensor_msgs::PointCloud2ConstPtr& input)
 	/////////////////////////////////
 
 	float distance = 0.5;//this may be a parameter,so we must tune it
-	/*seg.setOptimizeCoefficients (true);
+	seg.setOptimizeCoefficients (true);
 	seg.setModelType (pcl::SACMODEL_PLANE);
 	seg.setMethodType (pcl::SAC_RANSAC);
 	seg.setMaxIterations (100);
 	seg.setDistanceThreshold (distance);
-
-	int nr_points = (int) cloud1->points.size ();
-	while (cloud1->points.size () > distance * nr_points)
+	// Segment the largest planar component from the remaining cloud
+	seg.setInputCloud (cloud1);
+	seg.segment (*inliers, *coefficients);
+	if (inliers->indices.size () == 0)
 	{
-		// Segment the largest planar component from the remaining cloud
-		seg.setInputCloud (cloud1);
-		seg.segment (*inliers, *coefficients);
-		if (inliers->indices.size () == 0)
-		{
-			std::cout << "Could not estimate a planar model for the given dataset." << std::endl;
-			break;
-		}
-
-		// Extract the planar inliers from the input cloud
-		pcl::ExtractIndices<pcl::PointXYZ> extract;
-		extract.setInputCloud (cloud1);
-		extract.setIndices(inliers);
-		extract.setNegative(false);
-
-		// Get the points associated with the planar surface
-		extract.filter (*cloud_plane);
-
-		// Remove the planar inliers, extract the rest
-		extract.setNegative (true);
-		extract.filter (*cloud_f);
-		*cloud1 = *cloud_f;
+		std::cout << "Could not estimate a planar model for the given dataset." << std::endl;
 	}
-*/
+	else
+	{
+		pcl::copyPointCloud(*cloud1, *inliers, *cloud_plane);
+	}
+
+	// Extract the planar inliers from the input cloud
+	pcl::ExtractIndices<pcl::PointXYZ> extract;
+	extract.setInputCloud (cloud1);
+	extract.setIndices(inliers);
+	extract.setNegative(false);
+
+	// Get the points associated with the planar surface
+	extract.filter (*cloud_plane);
+
+	// Remove the planar inliers, extract the rest
+	extract.setNegative (true);
+	extract.filter (*cloud_f);
+
 	/////////////////////////////////
 	//---	2. Euclidean Clustering
 	/////////////////////////////////
@@ -177,6 +179,22 @@ void cloud_cb (const sensor_msgs::PointCloud2ConstPtr& input)
 	// Publish the data
 	pub.publish (final_cluster);
 
+///////////////////////////////////////////////
+	//4.5 Publish Filtered PointClouds if requested 
+	//////////////////////////////////////////////
+	if(publish_filtered)	//points, no ground
+	{
+		pcl_conversions::toPCL(input->header, cloud_f->header);
+		// Publish the data
+		pub_filtered.publish (cloud_f);
+	}
+	if(publish_ground)		//only ground
+	{
+		pcl_conversions::toPCL(input->header, cloud_plane->header);
+		// Publish the data
+		pub_ground.publish (cloud_plane);
+	}
+
 	centroids.header = input->header;
 	centroid_pub.publish(centroids);
 
@@ -210,6 +228,18 @@ int main (int argc, char** argv)
 	{
 		ROS_INFO("euclidean_cluster > No points node received, defaulting to velodyne_points, you can use _points_node:=YOUR_TOPIC");
 		points_topic = "/points_raw";
+	}
+	publish_ground = false;
+	if (private_nh.getParam("publish_ground", publish_ground))
+	{
+		ROS_INFO("Publishing /points_ground point cloud...");
+		pub_filtered = h.advertise<sensor_msgs::PointCloud2>("/points_filtered",1);
+	}
+	publish_filtered = false;
+	if (private_nh.getParam("publish_filtered", publish_filtered))
+	{
+		ROS_INFO("Publishing /points_filtered point cloud...");
+		pub_ground = h.advertise<sensor_msgs::PointCloud2>("/points_ground",1);
 	}
 
 	// Create a ROS subscriber for the input point cloud


### PR DESCRIPTION
## Modified euclidean clustering to:
1. Publish new topic "/points_ground" of the type sensor_msgs::PointCloud2, outputs the planar points in the ground
2. Publish new topic "/points_filtered" of the type sensor_msgs::PointCloud2, removes the planar points from points_raw
   Both of the added features feed from the customizable 'points_node' argument.
   **Please check the launch file for details.**

The idea is to generate different pointcloud messages to be projected using the new points2image.
#### Example:
- Generate the PC messages

```
% roslaunch lidar_tracker euclidean_clustering.launch
```

This will publish 3 topics, /euclidean_clustering, /points_filtered, /points_ground
- Launch calibration_publisher
- Launch points2image to show the projected result from the desired PC message
  For instance:

```
% rosrun points2image points2image _points_node:=/points_filtered
```

or

```
% rosrun points2image points2image _points_node:=/points_ground
```

etc...
Finally :

```
% rosrun viewers points_image_viewer
```

In summary:
Any PointCloud2 Message --->  Points2Image --->  Viewer

Could @h-ohta or @manato, confirm please with a real rosbag?
**Remember to (1)relay velodyne_points to points_raw, (2)Publish camera_info and the projection matrix, (3) run points2image with /points_filtered or /points_ground**

@syohex Could you please check the correct compilation of this branch? 

Thanks for your kind support

![Image of Euclidean](http://ertl.jp/~amonrroy/images/euc1.png)
![Image of Euclidean2](http://ertl.jp/~amonrroy/images/euc2.png)
