### PR TITLE
Runtime Manager Status tab, que clear at Stdout OFF and Stderr OFF

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1172,6 +1172,14 @@ class MyFrame(rtmgr.MyFrame):
 				continue
 			wx.CallAfter(append_tc_limit, tc, s)
 
+			# que clear
+			if self.checkbox_stdout.GetValue() is False and \
+			   self.checkbox_stderr.GetValue() is False and \
+			   que.qsize() > 0:
+				with que.mutex:
+					que.queue.clear()
+				wx.CallAfter(tc.Clear)
+
 	#
 	# for Topics tab
 	#


### PR DESCRIPTION
Status tab

Stdout, Stderr を共にOFFにした際も、バッファにキューイングされた表示が続くのを防ぐため、
キューと表示領域のクリア処理を追加しました。
