### PR TITLE
Fix no-GPU platform issue

### DIFF
--- a/ros/src/computing/perception/detection/packages/cv_tracker/nodes/dpm_ocv/dpm_ocv.cpp
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/nodes/dpm_ocv/dpm_ocv.cpp
@@ -73,9 +73,11 @@ objectDetect::objectDetect() :
 		object_class = "car";
 	}
 
+#if defined(HAS_GPU)
 	if (!private_nh_.getParam("use_gpu", use_gpu)) {
 		use_gpu = false;
 	}
+#endif
 
 	std::string default_model;
 	// switch (type) {


### PR DESCRIPTION
'use_gpu' must not be used on no-GPU platform.
This is related to autowarefoundation/autoware_ai#907.
