### PR TITLE
Runtime Manager, fix bottom top5 showing from thread

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1107,8 +1107,8 @@ class MyFrame(rtmgr.MyFrame):
 			
 			for (lb, cmd, load) in zip(self.lb_top5, cmds, loads):
 				col = self.info_col(float(load), rate_per_cpu_yellow, rate_per_cpu, (64,64,64), (200,0,0))
-				lb.SetForegroundColour(col)
-				lb.SetLabel(cmd + ' (' + load + ' %CPU)')
+				wx.CallAfter(lb.SetForegroundColour, col)
+				wx.CallAfter(lb.SetLabel, cmd + ' (' + load + ' %CPU)')
 
 		self.toprc_restore(toprc, backup)
 


### PR DESCRIPTION
高CPU負荷時にRuntime Managerが強制終了する不具合を修正しました。
