### PR TITLE
Goodbye hydro hello jade

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Open-source software for urban autonomous driving. The following functions are s
 ## Requirements
 
 - ROS indigo(Ubuntu 14.04) or ROS jade(Ubuntu 15.04)
-- OpenCV 2.4.8 or higher
+- OpenCV 2.4.8 or higher **NOTE: Autoware does not support OpenCV 3. Please use OpenCV 2**
 - Qt 5.2.1 or higher
 - CUDA(Optional)
 - FlyCapture2(optional)
 - Armadillo
 
-**NOTE: Autoware does not support OpenCV 3. Please use OpenCV 2**
+**Please use checkout revision before 2015/OCT/21 if you use Autoware on ROS hydro or Ubuntu 13.04, 13.10.**
 
 ### Install dependencies for Ubuntu 14.04 indigo
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ Open-source software for urban autonomous driving. The following functions are s
 
 ## Requirements
 
-- ROS indigo(Ubuntu 13.10, 14.04) or ROS hydro(Ubuntu 13.04)
+- ROS indigo(Ubuntu 14.04) or ROS jade(Ubuntu 15.04)
 - OpenCV 2.4.8 or higher
 - Qt 5.2.1 or higher
 - CUDA(Optional)
 - FlyCapture2(optional)
 - Armadillo
+
+**NOTE: Autoware does not support OpenCV 3. Please use OpenCV 2**
 
 ### Install dependencies for Ubuntu 14.04 indigo
 
@@ -44,56 +46,12 @@ Open-source software for urban autonomous driving. The following functions are s
 **NOTE: Please do not install ros-indigo-velodyne-pointcloud package. Please uninstall it if you already installed.**
 
 
-### Install dependencies for Ubuntu 13.10 indigo and Ubuntu 13.04 hydro
+### Install dependencies for Ubuntu 15.04 jade
 
 ```
-% sudo apt-get install ros-hydro-desktop-full ros-hydro-nmea-msgs ros-hydro-sound-play
-% sudo apt-get install libnlopt-dev freeglut3-dev libssh2-1-dev libarmadillo-dev libpcap-dev
+% sudo apt-get install ros-jade-desktop-full ros-jade-nmea-msgs ros-jade-nmea-navsat-driver ros-jade-sound-play
+% sudo apt-get install libnlopt-dev freeglut3-dev qt5-default libqt5opengl5-dev libssh2-1-dev libarmadillo-dev libpcap-dev
 ```
-
-You cannot not build **Autoware/ros** source code with those OpenCV and Qt5 packages,
-because they are too old. So you have to install newer versions of OpenCV and Qt5.
-
-#### Install OpenCV
-
-You can download the source code from [here](http://sourceforge.net/projects/opencvlibrary/).
-
-```
-% unzip opencv-2.4.8.zip
-% cd opencv-2.4.8
-% cmake .
-% make
-% make install
-```
-
-**NOTE: Autoware does not support OpenCV 3. Please use OpenCV 2**
-
-#### Install Qt 5
-
-The installation document is [here](http://qt-project.org/wiki/Building_Qt_5_from_Git).
-
-First you have to install Qt5 dependencies.
-
-```
-% sudo apt-get build-dep qt5-default
-% sudo apt-get install build-essential perl python git
-% sudo apt-get install "^libxcb.*" libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev
-% sudo apt-get install flex bison gperf libicu-dev libxslt-dev ruby
-% sudo apt-get install libssl-dev libxcursor-dev libxcomposite-dev libxdamage-dev libxrandr-dev libfontconfig1-dev
-% sudo apt-get install libasound2-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev
-```
-
-```
-% git clone git://code.qt.io/qt/qt5.git
-% cd qt5
-% git checkout v5.2.1 # <- Same as Ubuntu 14.04 'qtbase5-dev'
-% perl init-repository --no-webkit # <- webkit is very too large
-% ./configure -developer-build -opensource -nomake examples -nomake tests # And accept the license 
-% make -j # You may take a few hours
-% make install
-% sudo cp -r qtbase /usr/local/qtbase5
-```
-[This page](http://code.qt.io/cgit/qt/qtbase.git/commit/?id=9d2edfe5248fce8b16693fad8304f94a1f101bab) could help you when `make` returns error.
 
 ## How to Build
 

--- a/ros/src/computing/perception/detection/lib/fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lib/fusion/CMakeLists.txt
@@ -11,7 +11,7 @@ catkin_package(
   LIBRARIES fusion
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   include

--- a/ros/src/computing/perception/detection/lib/image/dpm_ocv/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lib/image/dpm_ocv/CMakeLists.txt
@@ -17,7 +17,7 @@ generate_messages(
   std_msgs
 )
 
-SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -std=c++0x -DUSE_GPU -DCUBIN_PATH=${CATKIN_DEVEL_PREFIX}/lib/gpu_function.cubin ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -std=c++11 -DUSE_GPU -DCUBIN_PATH=${CATKIN_DEVEL_PREFIX}/lib/gpu_function.cubin ${CMAKE_CXX_FLAGS}")
 SET(CMAKE_NVCC_FLAGS "-use_fast_math")
 
 catkin_package(

--- a/ros/src/computing/perception/detection/lib/image/dpm_ttic/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lib/image/dpm_ttic/CMakeLists.txt
@@ -20,7 +20,7 @@ catkin_package(
 )
 
 SET(CMAKE_C_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_C_FLAGS}")
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 IF(EXISTS "/usr/local/cuda")
 INCLUDE_DIRECTORIES(

--- a/ros/src/computing/perception/detection/lib/image/kf/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lib/image/kf/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(src)

--- a/ros/src/computing/perception/detection/lib/libvectormap/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lib/libvectormap/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 # find_package(Boost REQUIRED COMPONENTS system)
 find_package (Eigen3 REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html

--- a/ros/src/computing/perception/detection/packages/cv_tracker/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/CMakeLists.txt
@@ -45,7 +45,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -DROS ${CMAKE_CXX_FLAGS}")
 
 INCLUDE_DIRECTORIES(
   ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
@@ -90,7 +90,7 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ###########
 ## Build ##

--- a/ros/src/computing/perception/detection/packages/road_wizard/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/road_wizard/CMakeLists.txt
@@ -36,7 +36,7 @@ catkin_package(
   CATKIN_DEPENDS std_msgs message_runtime libvectormap runtime_manager
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ###########
 ## Build ##

--- a/ros/src/computing/perception/detection/packages/road_wizard/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/road_wizard/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(road_wizard)
 
+include(FindPkgConfig)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
@@ -13,6 +14,9 @@ find_package(catkin REQUIRED COMPONENTS
   )
 find_package(OpenCV REQUIRED)
 find_package (Eigen3 REQUIRED)
+
+pkg_check_modules(Qt5Core REQUIRED Qt5Core)
+pkg_check_modules(Qt5Widgets REQUIRED Qt5Widgets)
 
 ## Generate added messages and services with any dependencies listed here
 add_message_files(FILES
@@ -78,28 +82,18 @@ runtime_manager_generate_messages_cpp
 road_wizard_generate_messages_cpp
 )
 
-### tlr_tuner ###
-if(EXISTS /usr/local/qtbase5)
-# Self install version
-set(Qt5INCLUDE "/usr/local/qtbase5/include")
-set(Qt5BIN "/usr/local/qtbase5/bin")
-set(Qt5LIBROOT "/usr/local/qtbase5/lib")
-else()
-# Ubuntu Qt5 package
-set(Qt5INCLUDE "/usr/include/qt5")
-set(Qt5BIN "/usr/lib/x86_64-linux-gnu/qt5/bin")
-set(Qt5LIBROOT "/usr/lib/x86_64-linux-gnu")
-endif()
+EXECUTE_PROCESS(
+  COMMAND pkg-config --variable=host_bins Qt5Core
+  OUTPUT_VARIABLE Qt5BIN
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
   include
-  noddes/tlr_tuner/
-  ${Qt5INCLUDE}
-  ${Qt5INCLUDE}/QtCore
-  ${Qt5INCLUDE}/QtGui
-  ${Qt5INCLUDE}/QtOpenGL
-  ${Qt5INCLUDE}/QtWidgets
+  nodes/tlr_tuner/
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
 )
 
 add_custom_command(
@@ -137,8 +131,6 @@ add_dependencies(tlr_tuner
 
 target_link_libraries(tlr_tuner
   ${catkin_LIBRARIES}
-  ${Qt5LIBROOT}/libQt5Core.so
-  ${Qt5LIBROOT}/libQt5Gui.so
-  ${Qt5LIBROOT}/libQt5OpenGL.so
-  ${Qt5LIBROOT}/libQt5Widgets.so
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
   )

--- a/ros/src/computing/perception/detection/packages/viewers/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/viewers/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   runtime_manager
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 find_package(OpenCV REQUIRED)
 
 ###################################

--- a/ros/src/computing/perception/localization/packages/gnss_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/gnss_localizer/CMakeLists.txt
@@ -22,7 +22,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/CMakeLists.txt
@@ -32,7 +32,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 

--- a/ros/src/computing/planning/mission/packages/freespace_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/freespace_planner/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   gnss
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   #INCLUDE_DIRS include

--- a/ros/src/computing/planning/mission/packages/lane_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/lane_planner/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   gnss
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   INCLUDE_DIRS include

--- a/ros/src/computing/planning/motion/packages/driving_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/driving_planner/CMakeLists.txt
@@ -58,7 +58,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   include

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
@@ -57,7 +57,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   include

--- a/ros/src/computing/planning/motion/packages/waypoint_maker/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/waypoint_maker/CMakeLists.txt
@@ -25,7 +25,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   ${catkin_INCLUDE_DIRS}

--- a/ros/src/data/packages/map_db/CMakeLists.txt
+++ b/ros/src/data/packages/map_db/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
 add_message_files(
   FILES

--- a/ros/src/data/packages/map_file/CMakeLists.txt
+++ b/ros/src/data/packages/map_file/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 add_message_files(
   FILES

--- a/ros/src/data/packages/obj_db/CMakeLists.txt
+++ b/ros/src/data/packages/obj_db/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ###################################
 ## catkin specific configuration ##

--- a/ros/src/data/packages/pos_db/CMakeLists.txt
+++ b/ros/src/data/packages/pos_db/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ###################################
 ## catkin specific configuration ##

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 find_package(OpenCV REQUIRED)
 
 ###################################

--- a/ros/src/sensing/drivers/lidar/packages/hokuyo/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/hokuyo/CMakeLists.txt
@@ -10,17 +10,7 @@ catkin_package(
     DEPENDS roscpp sensor_msgs
 )
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-	message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif()
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_executable(hokuyo_3d nodes/hokuyo_3d/hokuyo_3d.cpp nodes/hokuyo_3d/vssp.hpp)

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(calibration_camera_lidar)
 
+include(FindPkgConfig)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rosconsole
@@ -15,6 +16,10 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(OpenCV REQUIRED)
+
+pkg_check_modules(Qt5Core REQUIRED Qt5Core)
+pkg_check_modules(Qt5Widgets REQUIRED Qt5Widgets)
+pkg_check_modules(Qt5OpenGL REQUIRED Qt5OpenGL)
 
 add_message_files(
   FILES
@@ -35,17 +40,11 @@ catkin_package(
 
 set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall -g -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
-if(EXISTS /usr/local/qtbase5)
-# Self install version
-set(Qt5INCLUDE "/usr/local/qtbase5/include")
-set(Qt5BIN "/usr/local/qtbase5/bin")
-set(Qt5LIBROOT "/usr/local/qtbase5/lib")
-else()
-# Ubuntu Qt5 package
-set(Qt5INCLUDE "/usr/include/qt5")
-set(Qt5BIN "/usr/lib/x86_64-linux-gnu/qt5/bin")
-set(Qt5LIBROOT "/usr/lib/x86_64-linux-gnu")
-endif()
+EXECUTE_PROCESS(
+  COMMAND pkg-config --variable=host_bins Qt5Core
+  OUTPUT_VARIABLE Qt5BIN
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
@@ -54,11 +53,9 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
   CalibrationToolkit
   nodes/calibration_toolkit
-  ${Qt5INCLUDE}
-  ${Qt5INCLUDE}/QtCore
-  ${Qt5INCLUDE}/QtGui
-  ${Qt5INCLUDE}/QtOpenGL
-  ${Qt5INCLUDE}/QtWidgets
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${Qt5OpenGL_INCLUDE_DIRS}
 )
 
 add_custom_command(
@@ -99,7 +96,9 @@ target_link_libraries(calibrationtoolkit
   glviewer
   rosinterface
   nlopt
-  ${Qt5LIBROOT}/libQt5OpenGL.so
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+  ${Qt5OpenGL_LIBRARIES}
 )
 
 add_custom_command(
@@ -127,11 +126,9 @@ include_directories(
 
   CalibrationToolkit
   nodes/calibration_toolkit
-  ${Qt5INCLUDE}
-  ${Qt5INCLUDE}/QtCore
-  ${Qt5INCLUDE}/QtGui
-  ${Qt5INCLUDE}/QtOpenGL
-  ${Qt5INCLUDE}/QtWidgets
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${Qt5OpenGL_INCLUDE_DIRS}
 )
 
 ## 2D
@@ -179,11 +176,10 @@ target_link_libraries(calibration_toolkit
   calibrationtoolkit
   glut
   GLU
-  ${Qt5LIBROOT}/libQt5Core.so
-  ${Qt5LIBROOT}/libQt5Gui.so
-  ${Qt5LIBROOT}/libQt5OpenGL.so
-  ${Qt5LIBROOT}/libQt5Widgets.so
   nlopt
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
+  ${Qt5OpenGL_LIBRARIES}
 )
 
 # calibration_publisher

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
@@ -33,7 +33,7 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall -g -Wno-unused-result ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall -g -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
 if(EXISTS /usr/local/qtbase5)
 # Self install version

--- a/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
@@ -44,7 +44,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
 if(EXISTS /usr/local/qtbase5)
 # Self install version

--- a/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(points2image)
 
+include(FindPkgConfig)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rosinterface
@@ -16,6 +17,9 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(OpenCV REQUIRED)
+
+pkg_check_modules(Qt5Core REQUIRED Qt5Core)
+pkg_check_modules(Qt5Widgets REQUIRED Qt5Widgets)
 
 ################################################
 ## Declare ROS messages, services and actions ##
@@ -46,26 +50,17 @@ catkin_package(
 
 SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
-if(EXISTS /usr/local/qtbase5)
-# Self install version
-set(Qt5INCLUDE "/usr/local/qtbase5/include")
-set(Qt5BIN "/usr/local/qtbase5/bin")
-set(Qt5LIBROOT "/usr/local/qtbase5/lib")
-else()
-# Ubuntu Qt5 package
-set(Qt5INCLUDE "/usr/include/qt5")
-set(Qt5BIN "/usr/lib/x86_64-linux-gnu/qt5/bin")
-set(Qt5LIBROOT "/usr/lib/x86_64-linux-gnu")
-endif()
+EXECUTE_PROCESS(
+  COMMAND pkg-config --variable=host_bins Qt5Core
+  OUTPUT_VARIABLE Qt5BIN
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
   include
-  ${Qt5INCLUDE}
-  ${Qt5INCLUDE}/QtCore
-  ${Qt5INCLUDE}/QtGui
-  ${Qt5INCLUDE}/QtOpenGL
-  ${Qt5INCLUDE}/QtWidgets
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
 )
 
 # library
@@ -111,11 +106,9 @@ add_dependencies(points2vscan
 target_link_libraries(points2vscan
   ${catkin_LIBRARIES}
   rosinterface
-  ${Qt5LIBROOT}/libQt5Core.so
-  ${Qt5LIBROOT}/libQt5Gui.so
-  ${Qt5LIBROOT}/libQt5OpenGL.so
-  ${Qt5LIBROOT}/libQt5Widgets.so
   nlopt
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
 )
 
 # points2image

--- a/ros/src/sensing/polygon/packages/points2polygon/CMakeLists.txt
+++ b/ros/src/sensing/polygon/packages/points2polygon/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(PCL 1.2 REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS runtime_manager

--- a/ros/src/socket/packages/tablet_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/tablet_socket/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   gnss
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 add_message_files(
   FILES

--- a/ros/src/socket/packages/vehicle_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/vehicle_socket/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 add_message_files(
   FILES

--- a/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++0x -O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
 if(EXISTS /usr/local/qtbase5)
 # Self install version

--- a/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(fastvirtualscan)
 
+include(FindPkgConfig)
 find_package(catkin)
+
+pkg_check_modules(Qt5Core REQUIRED Qt5Core)
 
 ###################################
 ## catkin specific configuration ##
@@ -18,26 +21,10 @@ catkin_package(
 
 SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
-if(EXISTS /usr/local/qtbase5)
-# Self install version
-set(Qt5INCLUDE "/usr/local/qtbase5/include")
-set(Qt5BIN "/usr/local/qtbase5/bin")
-set(Qt5LIBROOT "/usr/local/qtbase5/lib")
-else()
-# Ubuntu Qt5 package
-set(Qt5INCLUDE "/usr/include/qt5")
-set(Qt5BIN "/usr/lib/x86_64-linux-gnu/qt5/bin")
-set(Qt5LIBROOT "/usr/lib/x86_64-linux-gnu")
-endif()
-
 include_directories(
   ${catkin_INCLUDE_DIRS}
   include/fastvirtualscan
-  ${Qt5INCLUDE}
-  ${Qt5INCLUDE}/QtCore
-  ${Qt5INCLUDE}/QtGui
-  ${Qt5INCLUDE}/QtOpenGL
-  ${Qt5INCLUDE}/QtWidgets
+  ${Qt5Core_INCLUDE_DIRS}
 )
 
 add_library(fastvirtualscan

--- a/ros/src/util/packages/RobotSDK/glviewer/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/glviewer/CMakeLists.txt
@@ -1,10 +1,15 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(glviewer)
 
+include(FindPkgConfig)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   pcl_ros
 )
+
+pkg_check_modules(Qt5Core REQUIRED Qt5Core)
+pkg_check_modules(Qt5Widgets REQUIRED Qt5Widgets)
+pkg_check_modules(Qt5OpenGL REQUIRED Qt5OpenGL)
 
 ###################################
 ## catkin specific configuration ##
@@ -26,27 +31,19 @@ EXECUTE_PROCESS(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if(EXISTS /usr/local/qtbase5)
-# Self install version
-set(Qt5INCLUDE "/usr/local/qtbase5/include")
-set(Qt5BIN "/usr/local/qtbase5/bin")
-set(Qt5LIBROOT "/usr/local/qtbase5/lib")
-else()
-# Ubuntu Qt5 package
-set(Qt5INCLUDE "/usr/include/qt5")
-set(Qt5BIN "/usr/lib/x86_64-linux-gnu/qt5/bin")
-set(Qt5LIBROOT "/usr/lib/x86_64-linux-gnu")
-endif()
+EXECUTE_PROCESS(
+  COMMAND pkg-config --variable=host_bins Qt5Core
+  OUTPUT_VARIABLE Qt5BIN
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
-if("${ARCHITECTURE}" STREQUAL "x86_64")
+if("${ARCHITECTURE}" STREQUAL "x86_64" OR "${ARCHITECTURE}" STREQUAL "i686")
 include_directories(
   ${catkin_INCLUDE_DIRS}
   include/glviewer
-  ${Qt5INCLUDE}
-  ${Qt5INCLUDE}/QtCore
-  ${Qt5INCLUDE}/QtGui
-  ${Qt5INCLUDE}/QtOpenGL
-  ${Qt5INCLUDE}/QtWidgets
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${Qt5OpenGL_INCLUDE_DIRS}
 )
 
 add_custom_command(

--- a/ros/src/util/packages/RobotSDK/rosinterface/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/rosinterface/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosinterface)
 
+include(FindPkgConfig)
 find_package(catkin REQUIRED)
+
+pkg_check_modules(Qt5Core REQUIRED Qt5Core)
+pkg_check_modules(Qt5Widgets REQUIRED Qt5Widgets)
 
 ###################################
 ## catkin specific configuration ##
@@ -24,38 +28,17 @@ catkin_package(
 ###########
 
 EXECUTE_PROCESS(
-  COMMAND uname -m
-  OUTPUT_VARIABLE ARCHITECTURE
+  COMMAND pkg-config --variable=host_bins Qt5Core
+  OUTPUT_VARIABLE Qt5BIN
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-
-if(EXISTS /usr/local/qtbase5)
-# Self install version
-set(Qt5INCLUDE "/usr/local/qtbase5/include")
-set(Qt5BIN "/usr/local/qtbase5/bin")
-set(Qt5LIBROOT "/usr/local/qtbase5/lib")
-else()
-
-# Ubuntu Qt5 package
-set(Qt5INCLUDE "/usr/include/qt5")
-if("${ARCHITECTURE}" STREQUAL "x86_64")
-  set(Qt5LIBROOT "/usr/lib/x86_64-linux-gnu")
-  set(Qt5BIN "/usr/lib/x86_64-linux-gnu/qt5/bin")
-elseif("${ARCHITECTURE}" MATCHES "^arm")
-  set(Qt5LIBROOT "/usr/lib/arm-linux-gnueabihf")
-  set(Qt5BIN "/usr/lib/arm-linux-gnueabihf/qt5/bin")
-endif()
-
-endif()
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
   include/rosinterface
-  ${Qt5INCLUDE}
-  ${Qt5INCLUDE}/QtCore
-  ${Qt5INCLUDE}/QtGui
-  ${Qt5INCLUDE}/QtWidgets
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
 )
 
 add_custom_command(
@@ -74,9 +57,8 @@ add_library(rosinterface
 
 target_link_libraries(rosinterface
   ${catkin_LIBRARIES}
-  ${Qt5LIBROOT}/libQt5Core.so
-  ${Qt5LIBROOT}/libQt5Gui.so
-  ${Qt5LIBROOT}/libQt5Widgets.so
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
 )
 
 ## Add cmake target dependencies of the executable/library

--- a/ros/src/util/packages/fake_drivers/CMakeLists.txt
+++ b/ros/src/util/packages/fake_drivers/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(OpenCV REQUIRED)
 

--- a/ros/src/util/packages/requirements_version_checker/CMakeLists.txt
+++ b/ros/src/util/packages/requirements_version_checker/CMakeLists.txt
@@ -7,10 +7,10 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if (NOT "${ROS_VERSION}" MATCHES "(indigo|hydro)")
+if (NOT "${ROS_VERSION}" MATCHES "(indigo|jade)")
 message(
   FATAL_ERROR
-  "You must need ROS indigo or hydro(Your ROS version is '${ROS_VERSION}')"
+  "You must need ROS indigo or jade(Your ROS version is '${ROS_VERSION}')"
 )
 endif()
 

--- a/ros/src/util/packages/sample_data/CMakeLists.txt
+++ b/ros/src/util/packages/sample_data/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
 #  INCLUDE_DIRS include


### PR DESCRIPTION
- Update ROS version checker
- Use `-std=c++11` option instead of `-std=c++0x` option, because we can use newer g++
- Update document. Remove hydro and  add jade information
- Clean up Qt5 configuration. Use pkg-config as possible and remove absolute pathes.

I confirmed build is success on following platforms.
- Ubuntu 14.04 x86_64 ROS indigo
- Ubuntu 14.04 i386 ROS indigo
- Ubuntu 15.04 x86_64 ROS jade
- Ubuntu 15.04 i386 ROS jade
