### PR TITLE
Fix include path and linked library setting issue on Ubuntu 15.04

### DIFF
--- a/ros/src/computing/perception/detection/lib/image/librcnn/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lib/image/librcnn/CMakeLists.txt
@@ -1,18 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(librcnn)
 
+include(FindPkgConfig)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   std_msgs
 )
-
+FIND_PACKAGE(CUDA)
 find_package(OpenCV REQUIRED)
+
+pkg_check_modules(HDF5 hdf5)
 
 ###########################################CAFFE NEEDS TO BE PREVIOUSLY COMPILED####################
 ##############DONT FORGET TO INSTALL fastrcnn's caffe dynamic libraries to /usr/local/lib	#### 
 set(CAFFE_PATH "$ENV{HOME}/fast-rcnn/caffe-fast-rcnn/distribute")				####
-set(CUDA_INCLUDE_PATH "/usr/local/cuda/include/")						####
 ####################################################################################################
 
 if(EXISTS "${CAFFE_PATH}")
@@ -31,10 +33,17 @@ catkin_package(
 
 set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
 
-include_directories(include ${catkin_INCLUDE_DIRS})
-include_directories(src)
-include_directories(${CAFFE_PATH}/include)
-include_directories(${CUDA_INCLUDE_PATH})
+INCLUDE_DIRECTORIES(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${CAFFE_PATH}/include
+)
+IF(CUDA_FOUND)
+INCLUDE_DIRECTORIES(${CUDA_INCLUDE_DIRS})
+ENDIF()
+IF(HDF5_FOUND)
+INCLUDE_DIRECTORIES(${HDF5_INCLUDE_DIRS})
+ENDIF()
 
 ## Declare a cpp library
 add_library(librcnn

--- a/ros/src/computing/perception/detection/packages/cv_tracker/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cv_tracker)
 
+include(FindPkgConfig)
 FIND_PACKAGE(catkin REQUIRED COMPONENTS
   cv_bridge
   image_transport
@@ -13,7 +14,10 @@ FIND_PACKAGE(catkin REQUIRED COMPONENTS
   fusion
   kf
 )
+FIND_PACKAGE(CUDA)
 FIND_PACKAGE(OpenCV REQUIRED)
+
+pkg_check_modules(HDF5 hdf5)
 
 EXECUTE_PROCESS(
   COMMAND uname -m
@@ -52,8 +56,8 @@ INCLUDE_DIRECTORIES(
   lib
 )
 
-IF(EXISTS "/usr/local/cuda")
-INCLUDE_DIRECTORIES(/usr/local/cuda/include)
+IF(CUDA_FOUND)
+INCLUDE_DIRECTORIES(${CUDA_INCLUDE_DIRS})
 
 IF("${ARCHITECTURE}" MATCHES "^arm")
 LINK_DIRECTORIES(/usr/lib/arm-linux-gnueabihf/tegra)
@@ -74,7 +78,7 @@ TARGET_LINK_LIBRARIES(dpm_ttic
   libdpm_ttic
 )
 
-IF(EXISTS "/usr/local/cuda")
+IF(CUDA_FOUND)
 SET_TARGET_PROPERTIES(dpm_ttic
   PROPERTIES
   COMPILE_FLAGS
@@ -106,7 +110,7 @@ TARGET_LINK_LIBRARIES(dpm_ocv
   #${OpenCV_LIBS}
 )
 
-IF(EXISTS "/usr/local/cuda")
+IF(CUDA_FOUND)
 SET_TARGET_PROPERTIES(dpm_ocv
   PROPERTIES
   COMPILE_FLAGS
@@ -203,18 +207,20 @@ ADD_DEPENDENCIES(klt_track
 
 ###########################################CAFFE NEEDS TO BE PREVIOUSLY COMPILED####################
 ##############DONT FORGET TO INSTALL fastrcnn's caffe dynamic libraries to /usr/local/lib	 	### 
-set(CAFFE_PATH "$ENV{HOME}/fast-rcnn/caffe-fast-rcnn/distribute")								####
-set(CUDA_INCLUDE_PATH "/usr/local/cuda/include/")												####
+set(CAFFE_PATH "$ENV{HOME}/fast-rcnn/caffe-fast-rcnn/distribute")
 ####################################################################################################
 
 if(EXISTS "${CAFFE_PATH}")
   find_package(librcnn)
 
-  include_directories(${librcnn_INCLUDE_DIRS})
-  include_directories(${catkin_INCLUDE_DIRS})
-  include_directories(${CAFFE_PATH}/include)
-  include_directories(${CUDA_INCLUDE_PATH})
-  
+  INCLUDE_DIRECTORIES(
+    ${librcnn_INCLUDE_DIRS}
+    ${CAFFE_PATH}/include
+  )
+IF(HDF5_FOUND)
+  INCLUDE_DIRECTORIES(${HDF5_INCLUDE_DIRS})
+ENDIF()
+
   ADD_EXECUTABLE(rcnn_node
     nodes/rcnn/rcnn_node.cpp
   )
@@ -223,6 +229,9 @@ if(EXISTS "${CAFFE_PATH}")
     librcnn
     ${catkin_LIBRARIES}
     ${OpenCV_LIBS}
+    ${CUDA_LIBRARIES}
+    ${CUDA_CUBLAS_LIBRARIES}
+    ${CUDA_curand_LIBRARY}
   )
 
   ADD_DEPENDENCIES(rcnn_node


### PR DESCRIPTION
Paths of header files and libraries of libhdf5 and CUDA on Ubuntu 15.04 are
different from Ubuntu 14.04. And those paths are set explicitly at compiling
time on Ubuntu 15.04.

And clean up CMake codes by using CMake and pkg-config features instead of
absolute paths.
