### PR TITLE
Fix off-by-one error

### DIFF
--- a/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/gpu_function.cu
+++ b/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/gpu_function.cu
@@ -493,9 +493,9 @@ void calculateNorm(
     const int x = blockDim.x * blockIdx.x + threadIdx.x;
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
 
-    if(y <= sizeY)
+    if(y < sizeY)
     {
-        if(x <= sizeX)
+        if(x < sizeX)
         {
             int i, j, p, pos;
             float valOfNorm = 0.0f;


### PR DESCRIPTION
`cuda-memcheck` reported an out-of-bounds read here, which would be followed by an out-of-bounds write. I think changing from `<=` to `<` is sufficient.
