### PR TITLE
Runtime Manager Computing tab, fix remain link at item hide

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1715,7 +1715,7 @@ class MyFrame(rtmgr.MyFrame):
 				add_objs += [ wx.StaticText(pnl, wx.ID_ANY, ')') ]
 				szr = sizer_wrap(add_objs, wx.HORIZONTAL, 0, wx.LEFT, 12, pnl)
 				szr.Fit(pnl)
-				item.SetWindow(pnl)
+				tree.SetItemWindow(item, pnl)
 
 		for sub in items.get('subs', []):
 			self.create_tree(parent, sub, tree, item, cmd_dic)


### PR DESCRIPTION
Computingタブ

treeアイテムを畳むとlinkの表示が残る不具合を対策しました。
