### PR TITLE
Update how to get Autoware

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Open-source software for urban autonomous driving. The following functions are s
 
 ```
 $ cd $HOME
-$ git clone --recursive https://github.com/CPFL/Autoware.git
+$ git clone https://github.com/CPFL/Autoware.git
 $ cd ~/Autoware/ros/src
 $ catkin_init_workspace
 $ cd ../


### PR DESCRIPTION
We switched to 'git subtree' so 'git submodule' is no longer used in Autoware.
