### PR TITLE
Runtime Manager, fix bottom area height

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -393,7 +393,7 @@ class MyFrame(rtmgr.MyFrame):
 			self.lb_top5.append(lb)
 		line = wx.StaticLine(self, wx.ID_ANY)
 		ibl = InfoBarLabel(self, 'Memory', bar_orient=wx.HORIZONTAL)
-		szr = sizer_wrap(self.lb_top5 + [ line, ibl ], flag=wx.EXPAND)
+		szr = sizer_wrap(self.lb_top5 + [ line, ibl ], flag=wx.EXPAND | wx.FIXED_MINSIZE)
 		self.sizer_cpuinfo.Add(szr, 2, wx.ALL | wx.EXPAND, 4)
 
 		th_arg = { 'setting':self.status_dic.get('top_cmd_setting', {}),


### PR DESCRIPTION
最下行の領域の高さが増大する事がある問題について
top5表示ラベルの設定で対策してみました。

Runtime Manager全体をdragでresizeで幅を狭めていったとき、
top5ラベルの表示内容が折り返し、部品の高さが増大する現象がありました。

本対策により、その現象については解決します。
