### PR TITLE
Need one more convStream element

### DIFF
--- a/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/matching_gpu.cpp
+++ b/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/matching_gpu.cpp
@@ -474,7 +474,7 @@ static void calculationScore(int numLevels, int n, const CvLSVMFeaturePyramid* H
     CUdeviceptr dev_filterIdxTbl[numLevels][n + 1];
     CUdeviceptr dev_filter;
     CUdeviceptr dev_map[2][numLevels];
-    CUstream convStreams[numLevels + 2];
+    CUstream convStreams[numLevels + 3];
     int size[2][numLevels];
     int filterSize[n + 1];
     int filterIdx[n + 1];


### PR DESCRIPTION
The loop starting at 493 is off-by-one without it, as are lines 568 and 569.

Furthermore, if it so happens that the model has lots of parts but few levels (ie a small λ) such that parts ("n" here) is more than two greater than the HOG pyramid levels ("numLevels"), line 580 will overflow. This is TODO, but a higher priority IMO is to redesign the use of streams and texture memory, as texMap prevents parallelisation of part map processing.
