### PR TITLE
Runtime Manager Map tab, fix pcd load OK msg at filed

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -163,6 +163,8 @@ class MyFrame(rtmgr.MyFrame):
 		self.label_point_cloud_bar = BarLabel(tab, '  Loading...  ')
 		self.label_point_cloud_bar.Enable(False)
 
+		self.pcd_loaded = False
+
 		#
 		# for Sensing tab
 		#
@@ -584,6 +586,8 @@ class MyFrame(rtmgr.MyFrame):
 		self.route_cmd_waypoint = data.point
 
 	def stat_callback(self, msg, k):
+		if k == 'pmap' and msg.data and not self.pcd_loaded:
+			return
 		self.stat_dic[k] = msg.data
 		if k == 'pmap':
 			v = self.stat_dic.get(k)
@@ -1601,6 +1605,7 @@ class MyFrame(rtmgr.MyFrame):
 		if n == 0:
 			return
 		i = 0
+		self.pcd_loaded = False
 		while not ev.wait(0):
 			s = self.stdout_file_search(file, 'load ')
 			if not s:
@@ -1611,6 +1616,7 @@ class MyFrame(rtmgr.MyFrame):
 			else:
 				i -= 1
 				print s
+			self.pcd_loaded = (i == n)
 			wx.CallAfter(self.label_point_cloud_bar.set, 100 * i / n)
 		wx.CallAfter(self.label_point_cloud_bar.clear)
 


### PR DESCRIPTION
Mapタブ

pcdファイルのロードに失敗しbarが100%に至らない場合でも、OK表示が出る不具合を対策しました。

100%に至らない場合に pmap からの status topic True を受信した場合は、
無視するように変更しました。
