### PR TITLE
Runtime Manager Setup tab, fix PCD Binarizer path

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/setup.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/setup.yaml
@@ -70,10 +70,11 @@ params:
 
   - name: vehicle_model
     vars:
-    - name        : model_patch
+    - name        : model_path
       kind        : path
       relpath_from: $(rospack find model_publisher)
       v           : ''
       cmd_param   :
         dash       : ''
         delim      : ':=package://model_publisher/'
+        default    : $(rospack find model_publisher)/../../../.config/model/default.dae


### PR DESCRIPTION
Setupタブ

Vehicle Model のパスが空の場合に問題がありました。
一旦、仮の対策をとして対応しました。
後ほど、本対策を致します。
