### PR TITLE
Develop waypoint loader

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_loader/waypoint_loader.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_loader/waypoint_loader.cpp
@@ -155,6 +155,30 @@ double decelerate(tf::Vector3 v1, tf::Vector3 v2, double original_velocity_kmh)
   return vel;
 }
 
+
+bool verifyFileConsistency(const char *filename)
+{
+
+  std::ifstream ifs(filename);
+
+  if (!ifs)
+  {
+    return false;
+  }
+
+  std::string line;
+  std::getline(ifs, line);
+  size_t ncol = countColumn(line);
+
+  while (std::getline(ifs, line))
+  {
+    if (countColumn(line) != ncol + 1)
+      return false;
+  }
+  return true;
+}
+
+
 waypoint_follower::lane createLaneWaypoint(std::vector<WP> waypoints)
 {
   waypoint_follower::lane lane_waypoint;

--- a/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_loader/waypoint_loader.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_loader/waypoint_loader.cpp
@@ -219,10 +219,28 @@ int main(int argc, char **argv)
   ROS_INFO_STREAM("decelerate :" << _decelerate);
 
   ros::Publisher lane_pub = nh.advertise<waypoint_follower::LaneArray>("lane_waypoints_array", 10, true);
-
   waypoint_follower::LaneArray lane_array;
-  lane_array.lanes.push_back(createLaneWaypoint(readWaypoint(driving_lane_csv.c_str())));
-  lane_array.lanes.push_back(createLaneWaypoint(readWaypoint(passing_lane_csv.c_str())));
+
+  if (!verifyFileConsistency(driving_lane_csv.c_str()))
+  {
+    ROS_ERROR("driving lane data is something wrong...");
+    exit(-1);
+  }
+  else
+  {
+    ROS_INFO("driving lane data is valid. publishing...");
+    lane_array.lanes.push_back(createLaneWaypoint(readWaypoint(driving_lane_csv.c_str())));
+  }
+
+  if (!verifyFileConsistency(passing_lane_csv.c_str()))
+  {
+    ROS_INFO("no passing lane data...");
+  }
+  else
+  {
+    ROS_INFO("passing lane data is valid. publishing...");
+    lane_array.lanes.push_back(createLaneWaypoint(readWaypoint(passing_lane_csv.c_str())));
+  }
 
   lane_pub.publish(lane_array);
 


### PR DESCRIPTION
経路データの整合性判定の関数を作りました。
ファイルがオープンできなかったり、ファイル中にありえないカラムが混ざっている場合はfalseになります。
また、passingの経路データを指定しない場合に落ちるバグを修正しました。
