### PR TITLE
Runtime Manager Quick Start tab, Rviz remote

### DIFF
--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -35,12 +35,12 @@ else
     ROS_MASTER_URI=$ROS_MASER_URI
     DISPLAY=:0
     export ROS_IP ROS_MASTER_URI DISPLAY
-    #rosrun rviz rviz
-    xeyes
+    rosrun rviz rviz
+    #xeyes
 EOF
   else
-    #ssh $KEYOPT $REMOTE pkill rviz
-    ssh $KEYOPT $REMOTE pkill xeyes
+    ssh $KEYOPT $REMOTE pkill rviz
+    #ssh $KEYOPT $REMOTE pkill xeyes
   fi
 fi
 

--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+  echo "Usage $0 <start|stop>"
+  exit 0
+fi
+
+DIR=$(cd $(dirname $0) ; pwd)
+
+REMOTE=""
+KEYFILE=""
+if [ -e $DIR/host ]; then
+  REMOTE=$(sed -n 's/^host *: *//p' $DIR/host)
+  if [ $REMOTE = localhost ]; then
+    REMOTE=""
+  fi
+  KEYFILE=$(sed -n 's/^key *: *//p' $DIR/host)
+fi
+
+#echo REMOTE=[$REMOTE]
+#echo KEYFILE=[$KEYFILE]
+
+if [ x"$REMOTE" = x ]; then
+  if [ $1 = start ]; then
+    rosrun rviz rviz
+  fi
+else
+  KEYOPT=""
+  if [ x"$KEYFILE" != x ]; then
+    KEYOPT="-i $KEYFILE"
+  fi
+  if [ $1 = start ]; then
+    cat <<EOF | ssh $KEYOPT $REMOTE
+    ROS_IP=192.168.0.2
+    ROS_MASTER_URI=$ROS_MASER_URI
+    DISPLAY=:0
+    export ROS_IP ROS_MASTER_URI DISPLAY
+    #rosrun rviz rviz
+    xeyes
+EOF
+  else
+    #ssh $KEYOPT $REMOTE pkill rviz
+    ssh $KEYOPT $REMOTE pkill xeyes
+  fi
+fi
+
+# EOF

--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -40,7 +40,9 @@ buttons :
     run : echo 'auto pilot'
 
   rviz_qs :
-    run : rosrun rviz rviz
+    #run : rosrun rviz rviz
+    run  : sh -c '$(rospack find runtime_manager)/../../../.config/rviz/cmd.sh start'
+    stop : sh -c '$(rospack find runtime_manager)/../../../.config/rviz/cmd.sh stop'
 
   rqt_qs :
     run : rqt


### PR DESCRIPTION
Quitck Startタブ

RvizボタンからリモートマシンでRvizを起動する処理を追加しました。
Autoware インストールディレクトリの

リモートマシンのRvizを起動するには、次の設定/変更が必要です。

<pre>
ros/src/.config/rviz/host というファイルで、 次の 2行の内容を設定します。
host:&lt;リモートマシン名&gt;
key:&lt;sshの秘密鍵へのフルパス&gt;
</pre>


上記cmd.shスクリプト実行時に、35行目で環境変数 ROS_MASTER_URIを参照しますので、
ローカルホスト側のIPアドレスを指定した適切な設定がなされている必要があります。

$ export ROS_MASTER_URI=http://192.168.0.1:11311
など
