### PR TITLE
Runtime Manager Quick Start tab, fix rviz/cmd.sh

### DIFF
--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -31,8 +31,10 @@ else
   fi
   if [ $1 = start ]; then
     cat <<EOF | ssh $KEYOPT $REMOTE
-    ROS_IP=192.168.0.2
-    ROS_MASTER_URI=$ROS_MASER_URI
+    [ -d /opt/ros/indigo ] && . /opt/ros/indigo/setup.bash
+    [ -d /opt/ros/jade ] && . /opt/ros/jade/setup.bash
+    ROS_IP=$REMOTE
+    ROS_MASTER_URI=$ROS_MASTER_URI
     DISPLAY=:0
     export ROS_IP ROS_MASTER_URI DISPLAY
     rosrun rviz rviz


### PR DESCRIPTION
Quick Startタブ

Rvizリモート起動用のスクリプトファイル.config/rviz/cmd.sh について、
typoを含め、臼田さんからの指摘を反映しました。

なお、以下の制限があります。
・hostファイルのhost:行の指定は、IPアドレスによる指定しか確認できてません。
・ROSのバージョンが上がる度に修正が必要です。
・ROSのバージョンが複数ある場合、動作するかわかりません。
