### PR TITLE
Query password by zenity

### DIFF
--- a/ros/run
+++ b/ros/run
@@ -28,7 +28,13 @@ elif [ $(which konsole) ]; then
 fi
 
 echo "Process Manager"
-sudo python $MY_PATH/src/util/packages/runtime_manager/scripts/proc_manager.py &
+PROC_MGR_PATH=$MY_PATH/src/util/packages/runtime_manager/scripts/proc_manager.py
+
+PASS=$(zenity --password)
+PROC_MANAGERS=$(ps aux |\grep "proc_manager.py"|\grep -v grep |awk '{print $2}')
+echo $PASS | sudo -S -- kill $PROC_MANAGERS
+
+echo $PASS | sudo -S -- python $MY_PATH/src/util/packages/runtime_manager/scripts/proc_manager.py &
 
 # boot ros-master
 ${TERMINAL} ${OPTION_CORE_GEOMETRY} ${OPTION_TITLE}="roscore" --${OPTION_WORKING_DIR}=${MY_PATH} ${OPTION_COMMAND}="bash -c 'source ./devel/setup.bash; roscore'"&


### PR DESCRIPTION
This is necessary when run script is launched from file manager.
And kill other proc_manager.py before starting it.
#### Demo

![run-script](https://cloud.githubusercontent.com/assets/554281/12318972/0199874a-bae2-11e5-8939-ceab7f807ddc.gif)
