### PR TITLE
Runtime Manager, fix func overwrite at dialog close

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2119,6 +2119,8 @@ class ParamPanel(wx.Panel):
 			if name not in self.gdic:
 				self.gdic[ name ] = {}
 			gdic_v = self.gdic.get(name)
+
+			bak_stk_push(gdic_v, 'func')
 			if gdic_v.get('func'):
 				continue
 
@@ -2199,7 +2201,7 @@ class ParamPanel(wx.Panel):
 			name = var.get('name')
 			gdic_v = self.gdic.get(name, {})
 			if 'func' in gdic_v:
-				del gdic_v['func']
+				bak_stk_pop(gdic_v, 'func')
 
 	def in_msg(self, var):
 		if 'topic' not in self.prm or 'msg' not in self.prm:
@@ -2971,6 +2973,25 @@ def dic_list_pop(dic, key):
 
 def dic_list_get(dic, key, def_ret=None):
 	return dic.get(key, [def_ret])[-1]
+
+def bak_stk_push(dic, key):
+	if key in dic:
+		k = key + '_bak_str'
+		if k not in dic:
+			dic[k] = []
+		dic[k].append( dic.get(key) )
+
+def bak_stk_pop(dic, key):
+	k = key + '_bak_str'
+	stk = dic.get(k, [])
+	if len(stk) > 0:
+		dic[key] = stk.pop()
+	else:
+		del dic[key]
+
+def bak_stk_set(dic, key, v):
+	bak_str_push(dic, key)
+	dic[key] = v
 
 
 def get_top(lst, def_ret=None):


### PR DESCRIPTION
設定ダイアログを閉じる際、GUI部品からパラメータの値を取得するメソッド登録箇所について、
一部のケースで、登録内容の復帰処理に不具合があり、修正しました。
