### PR TITLE
Allow dialog fields to be tagged with [nl]

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2146,7 +2146,7 @@ class ParamPanel(wx.Panel):
 					szr = static_box_sizer(self, 'topic : ' + self.prm.get('topic'))
 					bak[0].Add(szr, 0, wx.EXPAND | wx.ALL, 4)
 			targ_szr = szr
-			if vp.is_nl():
+			if vp.is_nl() or 'nl' in var.get('flags', []):
 				hszr = None if hszr else hszr
 				flag |= wx.EXPAND
 			else:


### PR DESCRIPTION
If we have the following `vars` topic with plain text entry fields:

```
- name: foo
  label: 'Foo'
  kind: str
  flags: [nl]
- name: bar
  label: 'Bar'
  kind: str
  flags: [nl]
```

Currently, we get `Foo [____] Bar [____]` on a single line, but with this change the `[nl]` is correctly detected and takes a new line.
