### PR TITLE
fix save param check, not include sys_prm for check

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -477,9 +477,11 @@ class MyFrame(rtmgr.MyFrame):
 		self.kill_all()
 
 		save_dic = {}
+		sys_prm = self.get_param('sys')
 		for (name, pdic) in self.load_dic.items():
 			if pdic and pdic != {}:
-				prm = next( (cfg.get('param') for cfg in self.config_dic.values() if cfg.get('name') == name), {})
+				prms = [ cfg.get('param') for cfg in self.config_dic.values() if cfg.get('name') == name ]
+				prm = next( (prm for prm in prms if prm != None and prm != sys_prm), {})
 				no_saves = prm.get('no_save_vars', [])
 				pdic = pdic.copy()
 				for k in pdic.keys():


### PR DESCRIPTION
Computingタブ, Dataタブ

param.yamlにパラメータを保存する際に、sysリンク用のconfig辞書が先に参照された場合、no_save_vars による指定が無視される不具合を修正しました。

現状では 、no_save_vars指定はsysリンク用のconfig辞書を保持してないSimulationタブでしか使用されておらず、不具合は現在化していませんでした。
