### PR TITLE
Runtime Manager, update for remote rviz

### DIFF
--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ $# -lt 1 ]; then
-  echo "Usage $0 <start|stop>"
-  exit 0
-fi
-
 DIR=$(cd $(dirname $0) ; pwd)
 
 REMOTE=""
@@ -21,16 +16,13 @@ fi
 #echo KEYFILE=[$KEYFILE]
 
 if [ x"$REMOTE" = x ]; then
-  if [ $1 = start ]; then
     rosrun rviz rviz
-  fi
 else
   KEYOPT=""
   if [ x"$KEYFILE" != x ]; then
     KEYOPT="-i $KEYFILE"
   fi
-  if [ $1 = start ]; then
-    cat <<EOF | ssh $KEYOPT $REMOTE
+  ssh -tt $KEYOPT $REMOTE <<EOF
     [ -d /opt/ros/indigo ] && . /opt/ros/indigo/setup.bash
     [ -d /opt/ros/jade ] && . /opt/ros/jade/setup.bash
     [ -d $DIR/../../../devel ] && . $DIR/../../../devel/setup.bash || \
@@ -42,10 +34,6 @@ else
     rosrun rviz rviz
     #xeyes
 EOF
-  else
-    ssh $KEYOPT $REMOTE pkill rviz
-    #ssh $KEYOPT $REMOTE pkill xeyes
-  fi
 fi
 
 # EOF

--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -41,8 +41,7 @@ buttons :
 
   rviz_qs :
     #run : rosrun rviz rviz
-    run  : sh -c '$(rospack find runtime_manager)/../../../.config/rviz/cmd.sh start'
-    stop : sh -c '$(rospack find runtime_manager)/../../../.config/rviz/cmd.sh stop'
+    run  : sh -c '$(rospack find runtime_manager)/../../../.config/rviz/cmd.sh'
 
   rqt_qs :
     run : rqt

--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -98,7 +98,6 @@ class MyFrame(rtmgr.MyFrame):
 		self.all_procs = []
 		self.all_procs_nodes = {}
 		self.all_cmd_dics = []
-		self.stop_dic = {}
 		self.load_dic = self.load_yaml('param.yaml', def_ret={})
 		self.config_dic = {}
 		self.selector = {}
@@ -517,10 +516,6 @@ class MyFrame(rtmgr.MyFrame):
 		self.pub.publish(data.data)
 		r.sleep()
 
-	def try_setup_obj_stop(self, obj, dic):
-		if 'stop' in dic:
-			self.stop_dic[ obj ] = dic.get('stop')
-
 	def setup_buttons(self, d, run_dic):
 		for (k,d2) in d.items():
 			pfs = [ 'button_', 'button_launch_', 'checkbox_' ]
@@ -535,7 +530,6 @@ class MyFrame(rtmgr.MyFrame):
 				continue
 			if 'run' in d2:
 				run_dic[obj] = (d2['run'], None)
-			self.try_setup_obj_stop(obj, d2);
 			gdic = self.gdic_get_1st(d2)
 			if 'param' in d2:
 				pdic = self.load_dic_pdic_setup(k, d2)
@@ -1066,7 +1060,6 @@ class MyFrame(rtmgr.MyFrame):
 				probe_dic[obj] = (dic['probe'], None)
 			if 'run' in dic:
 				run_dic[obj] = (dic['run'], None)
-			self.try_setup_obj_stop(obj, dic);
 			if 'param' in dic:
 				obj = self.add_config_link(dic, panel, obj)
 			else:
@@ -1953,7 +1946,6 @@ class MyFrame(rtmgr.MyFrame):
 				szr = sizer_wrap(add_objs, wx.HORIZONTAL, parent=pnl)
 				szr.Fit(pnl)
 				tree.SetItemWindow(item, pnl)
-			self.try_setup_obj_stop(item, items);
 
 		for sub in items.get('subs', []):
 			self.create_tree(parent, sub, tree, item, cmd_dic)
@@ -2079,9 +2071,6 @@ class MyFrame(rtmgr.MyFrame):
 				self.all_procs_nodes.pop(proc, None)
 			proc = None
 
-			stop_cmd = self.stop_dic.get(obj)
-			if stop_cmd:
-				subprocess.call( shlex.split(stop_cmd) )
 		return proc
 
 	def is_boot(self, obj):


### PR DESCRIPTION
ros/src/.config/rviz/host ファイルを設定し、リモートでRVizを起動する処理について

sshでリモートホスト上にRVizを起動後、終了処理でsshを終了してもRVizプロセスが残るため、これまで終了処理として cmd.sh stop コマンドでリモートホスト側でpkillを実行してRVizプロセスを終了させていました。

起動時のsshに-ttオプションを追加して強制的に擬似端末を割り当てることで、終了時にsshを終了するとRVizプロセスにもシグナル-HUPが送られ、終了させる修正を行いました。

これにより、リモートRVizの場合も他のコマンドと同様に、qs.yamlファイルに終了時用のコマンドを記述する必要がなくなりました。
