### PR TITLE
Runtime Manager, update for immediately reflection of sys CPU setup

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2422,6 +2422,8 @@ class VarPanel(wx.Panel):
 				item_n = eval(item_n)
 			self.obj = Checkboxes(self, item_n, label)
 			self.obj.set(v)
+			for box in self.obj.boxes:
+				self.obj.Bind(wx.EVT_CHECKBOX, self.OnUpdate, box)
 			return
 		if self.kind == 'toggle_button':
 			self.obj = wx.ToggleButton(self, wx.ID_ANY, label)


### PR DESCRIPTION
[sys] link の設定ダイアログについて

CPUチェックボックスの状態を変更した場合、OKボタンを押すまで変更が反映されませんでした。
チェックボックスを操作した時点で、すぐに設定が反映されるように修正しました。

Cancelボタンで閉じて変更を無効にした場合は、ダイアログを開く前の設定に戻されます。
