### PR TITLE
Runtime Manager, fix lane_stop dialog button color

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -3064,11 +3064,23 @@ def OnButtonColorHdr(event):
 		button_color_change(btn, v)
 	event.Skip()
 
+btn_null_bgcol = None
+
+def is_btn_null_bgcol(btn):
+	global btn_null_bgcol
+	bak = btn.GetBackgroundColour()
+	if btn_null_bgcol is None:
+		btn.SetBackgroundColour(wx.NullColour)
+		btn_null_bgcol = btn.GetBackgroundColour()
+		if bak != btn_null_bgcol:
+			btn.SetBackgroundColour(bak)
+	return bak == btn_null_bgcol
+
 def button_color_hdr_setup(btn):
 	hdr = OnButtonColorHdr
 	if type(btn) is wx.ToggleButton:
 		btn.Bind(wx.EVT_TOGGLEBUTTON, hdr)
-	elif type(btn) is wx.Button:
+	elif type(btn) is wx.Button and is_btn_null_bgcol(btn):
 		btn.Bind(wx.EVT_LEFT_DOWN, hdr)
 		btn.Bind(wx.EVT_LEFT_UP, hdr)
 


### PR DESCRIPTION
lane_stop の [app] linkで開くダイアログについて

red, green ボタンを押すと、ボタンの背景色がグレーに設定される不具合を修正しました。
#259 でのfile save dialogでのsegfault回避策として、gtkパッケージを使用しないよう変更した際、本不具合の混入がありました。
