### PR TITLE
Runtime Manager Computing tab, fix for sync option problem

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2366,6 +2366,10 @@ class ParamPanel(wx.Panel):
 	def detach_func(self):
 		for var in self.prm.get('vars'):
 			name = var.get('name')
+
+			if not gdic_dialog_type_chk(self.gdic, name):
+				continue
+
 			gdic_v = self.gdic.get(name, {})
 			if 'func' in gdic_v:
 				bak_stk_pop(gdic_v, 'func')


### PR DESCRIPTION
Computing tab

Synchronizationボタンの状態が、reprojection.launchのsyncパラメータに反映されない不具合を修正しました。

申し訳ありません。
この不具合は
#214

の対策時に混入し、複数カメラ対応とのマージの段階で顕在化してました。
