### PR TITLE
Add frame_id to BoundingBoxArray

### DIFF
--- a/ros/src/computing/perception/detection/packages/cv_tracker/nodes/obj_reproj/obj_reproj.cpp
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/nodes/obj_reproj/obj_reproj.cpp
@@ -204,6 +204,7 @@ static visualization_msgs::MarkerArray convert_marker_array(const cv_tracker::ob
 static jsk_recognition_msgs::BoundingBoxArray convertJskBoundingBoxArray(const cv_tracker::obj_label& src)
 {
   jsk_recognition_msgs::BoundingBoxArray ret;
+  ret.header.frame_id ="map";
 
   for (const auto& reproj_pos : src.reprojected_pos)
     {

--- a/ros/src/computing/perception/detection/packages/cv_tracker/nodes/obj_reproj/obj_reproj.cpp
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/nodes/obj_reproj/obj_reproj.cpp
@@ -490,7 +490,7 @@ int main(int argc, char **argv){
   marker_pub = n.advertise<visualization_msgs::MarkerArray>("obj_label_marker", 1);
 
 #ifdef HAVE_JSK_PLUGIN
-  jsk_bounding_box_pub = n.advertise<jsk_recognition_msgs::BoundingBoxArray>("obj_lavel_bounding_box", 1);
+  jsk_bounding_box_pub = n.advertise<jsk_recognition_msgs::BoundingBoxArray>("obj_label_bounding_box", 1);
 #endif
 
   ros::Subscriber projection = n.subscribe(projectionMat_topic_name, 1, projection_callback);


### PR DESCRIPTION
When I tested `ros-indigo-jsk-rviz-plugins`, I found that rviz could not visualize `/obj_car/obj_lavel_bounding_box` topic.
I think the reason is that `/obj_car/obj_lavel_bounding_box` has no frame_id.
Once I added frame_id , rviz was able to visualize. 

In addition, corrected typo.

@manato 
Would you please check this change?
Thank you for your always help!
