### PR TITLE
Show UVC camera ID

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -39,7 +39,7 @@ subs :
             flags : [ center_v ]
       - name : USB Generic
         probe: 'lsusb -v | grep wTerminalType | grep "Camera Sensor" > /dev/null'
-        run  : rosrun uvc_camera uvc_camera_node
+        run  : roslaunch runtime_manager uvc_camera.launch
       - name : IEEE1394
         probe:
         run  :

--- a/ros/src/util/packages/runtime_manager/scripts/uvc_camera.launch
+++ b/ros/src/util/packages/runtime_manager/scripts/uvc_camera.launch
@@ -1,0 +1,4 @@
+<launch>
+  <node pkg="topic_tools" type="relay" name="relay_image_raw" args="/image_raw /camera0/image_raw"/>
+  <node pkg="uvc_camera" type="uvc_camera_node" name="uvc_camera_node"/>
+</launch>


### PR DESCRIPTION
autowarefoundation/autoware_ai#826 If clicking USB Generic checkbox, regard UVC camera ID as /camera0.
