### PR TITLE
Runtime Manager Computing tab, fix typo points2costmap

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -1680,16 +1680,16 @@ params :
       cmd_param :
         dash      : ''
         delim     : ':='
-    - name      : call_width
-      label     : call_width
+    - name      : cell_width
+      label     : map_size_x
       min       : 0
       max       : 1000
       v         : 500
       cmd_param :
         dash      : ''
         delim     : ':='
-    - name      : call_height
-      label     : call_height
+    - name      : cell_height
+      label     : map_size_y
       min       : 0
       max       : 1000
       v         : 500


### PR DESCRIPTION
Computing tab

points2costmap パラメータのtypoを修正しました。

cell_width, cell_height の GUI表示は、map_size_x, map_size_y に変更しました。
(.launchファイルに渡すために内部で扱う名前は cell_width, cell_heightのままです)
