### PR TITLE
Fix deprecated code

### DIFF
--- a/ros/src/computing/perception/localization/packages/icp_localizer/nodes/icp_matching/icp_matching.cpp
+++ b/ros/src/computing/perception/localization/packages/icp_localizer/nodes/icp_matching/icp_matching.cpp
@@ -577,7 +577,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
 #ifdef OUTPUT
     // Output log.csv
     std::ofstream ofs_log("log.csv", std::ios::app);
-    if (ofs_log == NULL)
+    if (!ofs_log)
     {
       std::cerr << "Could not open 'log.csv'." << std::endl;
       exit(1);

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_matching/ndt_matching.cpp
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_matching/ndt_matching.cpp
@@ -569,7 +569,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
 #ifdef OUTPUT
     // Output log.csv
     std::ofstream ofs_log("log.csv", std::ios::app);
-    if (ofs_log == NULL)
+    if (!ofs_log)
     {
       std::cerr << "Could not open 'log.csv'." << std::endl;
       exit(1);

--- a/ros/src/sensing/drivers/camera/packages/hexacam/nodes/hexacam/hexacam.cpp
+++ b/ros/src/sensing/drivers/camera/packages/hexacam/nodes/hexacam/hexacam.cpp
@@ -378,7 +378,7 @@ int CamServer::ConfigSequence( seq &a)
 	std::string str;
 	std::stringstream line;
 again:
-	if(std::getline(m_is,str)==0)
+	if(!std::getline(m_is,str))
 		return 0;
 	line.str(str);
 	a.dir = Write;


### PR DESCRIPTION
std::basic_ios does not implement `operator void*` in C++11 specification.
But GCC 4.8 still supports it with `-std=c++11`option, so there is no
problem until now. However newer GCC removes it and we should use
`operator !` or `operator bool` instead of `operator void*` after C++11.

See also
- [http://en.cppreference.com/w/cpp/io/basic_ios/operator_bool](http://en.cppreference.com/w/cpp/io/basic_ios/operator_bool)
- [http://en.cppreference.com/w/cpp/io/basic_ios/operator!](http://en.cppreference.com/w/cpp/io/basic_ios/operator!)
