### PR TITLE
Fix qs map load ok

### DIFF
--- a/ros/src/data/packages/map_file/nodes/points_map_loader/points_map_loader.cpp
+++ b/ros/src/data/packages/map_file/nodes/points_map_loader/points_map_loader.cpp
@@ -355,7 +355,7 @@ sensor_msgs::PointCloud2 create_pcd(const std::vector<std::string>& pcd_paths, i
 	return pcd;
 }
 
-void publish_pcd(sensor_msgs::PointCloud2 pcd, int* errp = NULL)
+void publish_pcd(sensor_msgs::PointCloud2 pcd, const int* errp = NULL)
 {
 	if (pcd.width != 0) {
 		pcd.header.frame_id = "map";

--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -191,8 +191,6 @@ class MyFrame(rtmgr.MyFrame):
 		self.label_point_cloud_bar = BarLabel(tab, '  Loading...  ')
 		self.label_point_cloud_bar.Enable(False)
 
-		self.pcd_loaded = False
-
 		def hook1G(args):
 			for f in args.get('func')().split(','):
 				sz = os.path.getsize(f)
@@ -653,8 +651,6 @@ class MyFrame(rtmgr.MyFrame):
 		self.route_cmd_waypoint = data.point
 
 	def stat_callback(self, msg, k):
-		if k == 'pmap' and msg.data and not self.pcd_loaded:
-			return
 		self.stat_dic[k] = msg.data
 		if k == 'pmap':
 			v = self.stat_dic.get(k)
@@ -1899,7 +1895,6 @@ class MyFrame(rtmgr.MyFrame):
 		if n == 0:
 			return
 		i = 0
-		self.pcd_loaded = False
 		while not ev.wait(0):
 			s = self.stdout_file_search(file, 'load ')
 			if not s:
@@ -1910,7 +1905,6 @@ class MyFrame(rtmgr.MyFrame):
 			else:
 				i -= 1
 				print s
-			self.pcd_loaded = (i == n)
 			wx.CallAfter(self.label_point_cloud_bar.set, 100 * i / n)
 		wx.CallAfter(self.label_point_cloud_bar.clear)
 


### PR DESCRIPTION
Quick StartタブでMapボタン実行後、OKの表示が出ない状態となっていた不具合を修正しました。
不具合の原因は、2015/11/17 のMapタブでの対策が、Quick Startタブからのロードを考慮してない状態でなされていたためです。
先の対策を一旦戻し、points_map_loader側に対策を追加するよう修正しました。
