### PR TITLE
Clear points data after detection

### DIFF
--- a/ros/src/computing/planning/motion/packages/driving_planner/nodes/velocity_set/velocity_set.cpp
+++ b/ros/src/computing/planning/motion/packages/driving_planner/nodes/velocity_set/velocity_set.cpp
@@ -898,6 +898,8 @@ int main(int argc, char **argv)
 
     changeWaypoint(detection_result);
 
+    g_vscan.clear();
+
     loop_rate.sleep();
   }
 


### PR DESCRIPTION
Fix a problem that points data remains when stopping VirtualScan
