### PR TITLE
Runtime Manager, fix remote RViz setting

### DIFF
--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -28,7 +28,8 @@ else
     [ -d $DIR/../../../devel ] && . $DIR/../../../devel/setup.bash || \
       echo "$REMOTE:$DIR/../../../devel: no such directory"
     ROS_IP=$REMOTE
-    ROS_MASTER_URI=$ROS_MASTER_URI
+    FROM_IP=\$(echo \$SSH_CONNECTION | cut -d ' ' -f 1)
+    ROS_MASTER_URI=http://\$FROM_IP:11311
     DISPLAY=:0
     export ROS_IP ROS_MASTER_URI DISPLAY
     rosrun rviz rviz


### PR DESCRIPTION
従来は、remote RViz起動の際、master側の環境変数ROS_MASTER_URIの値を、remote側でも設定してました。
例えばmaster側で
$ export ROS_MASTER_URI=http://192.168.1.10:11311
のように直接IPアドレスで指定すると意図した動作となります。
しかしながら、値が http://localhost:11311 の場合、remote側でmaster側を参照できない不具合がありました。
remote RViz起動用のscript cmd.shで、remote側へsshでlogin後に環境変数SSH_CONNECTIONを参照し、ROS_MASTER_URIの値を設定するように修正しました。
