### PR TITLE
Runtime Manager, fix RViz remote setting

### DIFF
--- a/ros/run
+++ b/ros/run
@@ -32,6 +32,8 @@ echo "Process Manager"
 gksudo --message "Please input password for launching process manager" \
        -- $MY_PATH/run_proc_manager &
 
+export ROS_IP=$(hostname -I)
+
 # boot ros-master
 ${TERMINAL} ${OPTION_CORE_GEOMETRY} ${OPTION_TITLE}="roscore" --${OPTION_WORKING_DIR}=${MY_PATH} ${OPTION_COMMAND}="bash -c 'source ./devel/setup.bash; roscore'"&
 

--- a/ros/run
+++ b/ros/run
@@ -32,7 +32,10 @@ echo "Process Manager"
 gksudo --message "Please input password for launching process manager" \
        -- $MY_PATH/run_proc_manager &
 
-export ROS_IP=$(hostname -I)
+ADDR=$($MY_PATH/src/.config/rviz/subnet_chk.py -)
+if [ "$?" == "0" ]; then
+  export ROS_IP=$ADDR
+fi
 
 # boot ros-master
 ${TERMINAL} ${OPTION_CORE_GEOMETRY} ${OPTION_TITLE}="roscore" --${OPTION_WORKING_DIR}=${MY_PATH} ${OPTION_COMMAND}="bash -c 'source ./devel/setup.bash; roscore'"&

--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -23,7 +23,11 @@ else
   if [ x"$KEYFILE" != x ]; then
     KEYOPT="-i $KEYFILE"
   fi
-  setsid ssh -tt $KEYOPT $REMOTE <<EOF
+  [ x"$REMOTE_DISPLAY" = x ] && REMOTE_DISPLAY=:0
+  XOPT=""
+  [ "$REMOTE_DISPLAY" = "-" ] && XOPT="-X"
+
+  setsid ssh -tt $XOPT $KEYOPT $REMOTE <<EOF
     [ -d /opt/ros/indigo ] && . /opt/ros/indigo/setup.bash
     [ -d /opt/ros/jade ] && . /opt/ros/jade/setup.bash
     [ -d $DIR/../../../devel ] && . $DIR/../../../devel/setup.bash || \
@@ -31,7 +35,7 @@ else
     ROS_IP=\$(hostname -I)
     FROM_IP=\$(echo \$SSH_CONNECTION | cut -d ' ' -f 1)
     ROS_MASTER_URI=http://\$FROM_IP:11311
-    DISPLAY=:0
+    [ "$REMOTE_DISPLAY" != "-" ] && DISPLAY=$REMOTE_DISPLAY
     export ROS_IP ROS_MASTER_URI DISPLAY
     rosrun rviz rviz
     #xeyes

--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -6,7 +6,7 @@ REMOTE=""
 KEYFILE=""
 if [ -e $DIR/host ]; then
   REMOTE=$((sed -n 's/^host *: *//p' $DIR/host ; \
-            grep -v -e '^#' -e ':' $DIR/host) | tail -1)
+            grep -v -e '^#' -e ':' -e '^$' $DIR/host) | tail -1)
   if [ "$REMOTE" = "localhost" ]; then
     REMOTE=""
   fi

--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -5,7 +5,8 @@ DIR=$(cd $(dirname $0) ; pwd)
 REMOTE=""
 KEYFILE=""
 if [ -e $DIR/host ]; then
-  REMOTE=$(sed -n 's/^host *: *//p' $DIR/host)
+  REMOTE=$((sed -n 's/^host *: *//p' $DIR/host ; \
+            grep -v -e '^#' -e ':' $DIR/host) | tail -1)
   if [ "$REMOTE" = "localhost" ]; then
     REMOTE=""
   fi
@@ -22,13 +23,14 @@ else
   if [ x"$KEYFILE" != x ]; then
     KEYOPT="-i $KEYFILE"
   fi
-  ssh -tt $KEYOPT $REMOTE <<EOF
+  setsid ssh -tt $KEYOPT $REMOTE <<EOF
     [ -d /opt/ros/indigo ] && . /opt/ros/indigo/setup.bash
     [ -d /opt/ros/jade ] && . /opt/ros/jade/setup.bash
     [ -d $DIR/../../../devel ] && . $DIR/../../../devel/setup.bash || \
       echo "$REMOTE:$DIR/../../../devel: no such directory"
-    ROS_IP=$REMOTE
-    ROS_MASTER_URI=$ROS_MASTER_URI
+    ROS_IP=\$(hostname -I)
+    FROM_IP=\$(echo \$SSH_CONNECTION | cut -d ' ' -f 1)
+    ROS_MASTER_URI=http://\$FROM_IP:11311
     DISPLAY=:0
     export ROS_IP ROS_MASTER_URI DISPLAY
     rosrun rviz rviz

--- a/ros/src/.config/rviz/subnet_chk.py
+++ b/ros/src/.config/rviz/subnet_chk.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import socket
+import netifaces
+import struct
+
+def get_targ(path):
+	with open(path, 'r') as file:
+		lst = [ l.strip() for l in reversed(file.readlines()) ]
+	lst = [ l for l in lst if l and l[0] != '#' ]
+	vs = []
+	for l in lst:
+		if ':' not in l:
+			return l
+		p = [ a.strip() for a in l.split(':') ]
+		if p[0] == 'host':
+			vs.append(p[1])
+	return next( (v for v in vs), None)
+
+def addr_v(addr):
+	return struct.unpack('!i', socket.inet_aton(addr))[0]
+
+if len(sys.argv) < 2:
+	print "Usage: {} <ipaddr|hostname|->".format(sys.argv[0])
+	sys.exit(0)
+
+targ = sys.argv[1]
+if targ == '-': # read 'host' file
+	path = os.path.join(os.path.dirname(__file__), 'host')
+	if not os.path.exists(path):
+		sys.exit(1)
+	targ = get_targ(path)
+	if not targ or targ == 'localhost':
+		sys.exit(1)
+try:
+	targ = socket.gethostbyname(targ)
+except socket.gaierror:
+	print >> sys.stderr, "%s: cannot convert to ip address" % (targ)
+	sys.exit(2)
+targ_v = addr_v(targ)
+
+lst = [ ifnm for ifnm in netifaces.interfaces() if not ifnm.startswith('lo') ]
+lst = [ netifaces.ifaddresses(ifnm).get(netifaces.AF_INET) for ifnm in lst ]
+lst = [ ( a.get('addr'), a.get('netmask') ) for l in lst if l for a in l ]
+lst = [ p for p in lst if None not in p ]
+
+for (addr, mask_s) in lst:
+	v = addr_v(addr)
+	mask = addr_v(mask_s)
+	if (v & mask) == (targ_v & mask):
+		print addr
+		sys.exit(0)
+sys.exit(1)


### PR DESCRIPTION
起動用runスクリプトにROS_IPの設定を追加しました。
- ros/src/.config/rviz/subnet_chk.py を追加し、hostファイルで指定されたremote hostに対して、適切なIPアドレスがROS_IPに設定されるよう更新しました

RVizのremote起動用スクリプトcmd.shを修正しました。
- hostファイルにkey:指定が無い場合、パスワード入力ダイアログを表示し、パスワード認証を使用する
- hostファイルでremote hostの指定としてIPアドレス以外にホスト名も使用可能とする
- hostファイルに行頭'#'以外で':'を含まない行があれば、優先的にremote host指定として扱う
- remoteマシンでのROS_MASTER_URI設定について、master側の設定に依存しないように修正
- 環境変数REMOTE_DISPLAYが設定されている場合、remote hostの環境変数DISPLAYをその値に設定する処理を追加
- 環境変数REMOTE_DISPLAYが"-"(ハイフン)に設定されている場合は、sshによるlogin時にXポートフォワードオプションを追加し、環境変数DISPLAYを上書きしないように変更(sshによりlocalhost:10.0などに自動的に設定されるため)
