### PR TITLE
Runtime Manager Topics tab, fix for alias of bottom btns

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -384,6 +384,12 @@ class MyFrame(rtmgr.MyFrame):
 		self.label_top_cmd.SetFont(font)
 
 		#
+		# for Topics tab
+		#
+		tab = self.tab_topics
+		self.all_tabs.append(tab)
+
+		#
 		# for All
 		#
 		self.nodes_dic = self.nodes_dic_get()


### PR DESCRIPTION
Topics tab

下部のボタン ROSBAG, RViz, RQT について
Topics tabのみ連動動作しない状態となっている問題の修正。

申し訳ありません。
2016/May/25に行った上記ボタンにTooltipによるdesc表示を追加する更新で、
Topics tabのみ不具合を含む状態となっておりました。
