### PR TITLE
Runtime Manager Simulation tab, fix showing of rosbag pos remains on …

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1934,6 +1934,8 @@ class MyFrame(rtmgr.MyFrame):
 			wx.CallAfter(self.label_rosbag_play_pos.SetLabel, pos)
 			wx.CallAfter(self.label_rosbag_play_total.SetLabel, total)
 		wx.CallAfter(self.label_rosbag_play_bar.clear)
+		wx.CallAfter(self.label_rosbag_play_pos.SetLabel, '')
+		wx.CallAfter(self.label_rosbag_play_total.SetLabel, '')
 
 	#def OnPauseRosbagPlay(self, event):
 	#	pause_obj = event.GetEventObject()


### PR DESCRIPTION
…stop

Simulation tab

rosbag再生をSTOPボタンで停止しても、再生位置の数値の表示が残る問題を修正しました。
