### PR TITLE
Runtime Manger, fix camera_id setting at sync on

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -769,6 +769,8 @@ class MyFrame(rtmgr.MyFrame):
 				dic_list_pop(gdic, 'dialog_type')
 				if dlg_ret != 0:
 					return False			
+			else:
+				pdic['camera_id'] = ''
 
 		if 'open_dialog' in gdic.get('flags', []) and msg_box:
 			dic_list_push(gdic, 'dialog_type', 'open')


### PR DESCRIPTION
Computing tab

SynchronizationボタンON時に、camera_idの選択必要とするコマンド(launchファイル)を起動する際、
SynchronizationボタンOFF時の設定が残っており、指定されてしまっていたため修正致します。
