### PR TITLE
Runtime Manager Sensing tab, update filter cmd for Synchronization bu…

### DIFF
--- a/ros/src/sensing/data_filter/packages/points_filter/launch/filter.launch
+++ b/ros/src/sensing/data_filter/packages/points_filter/launch/filter.launch
@@ -1,0 +1,8 @@
+<launch>
+  <arg name="sync" default="false" />
+  <arg name="node_name" default="voxel_grid_filter" />
+
+  <node pkg="points_filter" name="$(arg node_name)" type="$(arg node_name)">
+    <remap from="/points_raw" to="/sync_drivers/points_raw" if="$(arg sync)" />
+  </node>
+</launch>

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -149,20 +149,32 @@ cmds:
     subs :
     - name : voxel_grid_filter
       desc : voxel_grid_filter desc sample
-      cmd  : rosrun points_filter voxel_grid_filter
+      cmd  : roslaunch points_filter filter.launch node_name:=voxel_grid_filter
       param: voxel_grid_filter
+      gui  :
+        sync :
+          func : self.button_synchronization.GetValue()
     - name : ring_filter
       desc : ring_filter desc sample
-      cmd  : rosrun points_filter ring_filter
+      cmd  : roslaunch points_filter filter.launch node_name:=ring_filter
       param: ring_filter
+      gui  :
+        sync :
+          func : self.button_synchronization.GetValue()
     - name : distance_filter
       desc : distance_filter desc sample
-      cmd  : rosrun points_filter distance_filter
+      cmd  : roslaunch points_filter filter.launch node_name:=distance_filter
       param: distance_filter
+      gui  :
+        sync :
+          func : self.button_synchronization.GetValue()
     - name : random_filter
       desc : random_filter desc sample
-      cmd  : rosrun points_filter random_filter
+      cmd  : roslaunch points_filter filter.launch node_name:=random_filter
       param: random_filter
+      gui  :
+        sync :
+          func : self.button_synchronization.GetValue()
 
 buttons:
   calibration_toolkit :
@@ -303,6 +315,13 @@ params :
       min   : 0
       max   : 10
       v     : 2.0
+    - name      : sync
+      kind      : hide
+      v         : False
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        only_enable : True
 
   - name  : ring_filter
     topic : /config/ring_filter
@@ -320,6 +339,13 @@ params :
       min   : 0
       max   : 10
       v     : 2.0
+    - name      : sync
+      kind      : hide
+      v         : False
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        only_enable : True
 
   - name  : distance_filter
     topic : /config/distance_filter
@@ -331,6 +357,13 @@ params :
       min   : 100
       max   : 30000
       v     : 10000
+    - name      : sync
+      kind      : hide
+      v         : False
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        only_enable : True
 
   - name  : random_filter
     topic : /config/random_filter
@@ -342,6 +375,13 @@ params :
       min   : 100
       max   : 30000
       v     : 10000
+    - name      : sync
+      kind      : hide
+      v         : False
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        only_enable : True
 
   - name  : calibration_publisher
     vars  :


### PR DESCRIPTION
…tton

Sensing tab

filter cmdの起動時に SynchronizationボタンがONの場合、subscribeするtopicを
/points_rawから/sync_drivers/points_rawに変更するように更新しました。

points_filterパッケージにlaunch/filter.launchを追加しました。

以下に仕様に関するメールの抜粋を掲げます。

> また、Sensingタブのvoxel grid filter、ring filter, distance filter, random
> filterの追加により、ノード構成が変わってしまったため、Synchronizationがうまく動作しなくなっています。
> そのため、Synchronizationボタンがオンの時、voxel grid filter、ring filter, distance
> filter, random
> filterがサブスクライブするトピックを/points_rawから/sync_drivers/points_rawに変更していただけないでしょうか？
