### PR TITLE
Runtime Manager, fix getting proc info in ParamPanel class

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2345,7 +2345,7 @@ class ParamPanel(wx.Panel):
 
 		self.gdic['param_panel'] = self
 
-		obj = self.frame.cfg_prm_to_obj( {'param':self.prm} )
+		obj = self.frame.cfg_prm_to_obj( {'pdic':self.pdic, 'gdic':self.gdic, 'param':self.prm} )
 		(_, _, proc) = self.frame.obj_to_cmd_dic_cmd_proc(obj)
 
 		hszr = None


### PR DESCRIPTION
ParamPanelクラスで関連のコマンド実行情報を取得する際の指定が不完全であった箇所を修正致します。

情報取得の際、コマンドのパラメータのみを指定して探索していましたが、複数のエントリで同一のパラメータが指定されていた場合、常に先に見つかった方の情報が返るため、求めるコマンド情報に一致しない可能性がありました。

ただし、このコマンド情報は後続の処理でパラメータにrosparam指定がある場合しか参照しておらず、現状のYAMLファイルによる設定では問題が顕在化する事はありませんでした。

今後のパラメータ設定の変更に備えて修正致します。
