### PR TITLE
Hotfix in range_fusion

### DIFF
--- a/ros/src/computing/perception/detection/packages/cv_tracker/nodes/range_fusion/range_fusion.cpp
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/nodes/range_fusion/range_fusion.cpp
@@ -42,9 +42,9 @@ bool ready_ = false;
 
 static void DetectedObjectsCallback(const cv_tracker::image_obj& image_object)
 {
+    sensor_header = image_object.header;
+    setDetectedObjects(image_object);
     if (ready_) {
-		sensor_header = image_object.header;
-        setDetectedObjects(image_object);
         fuse();
         publishTopic();
         ready_ = false;
@@ -64,9 +64,9 @@ static void DetectedObjectsCallback(const cv_tracker::image_obj& image_object)
 
 static void PointsImageCallback(const points2image::PointsImage& points_image)
 {
+    sensor_header = points_image.header;
+    setPointsImage(points_image);
     if (ready_) {
-		sensor_header = points_image.header;
-		setPointsImage(points_image);
 		fuse();
 		publishTopic();
         ready_ = false;


### PR DESCRIPTION
dpmとpoints2imageからトピックが交互にくるとrange_fusionが機能しないようになってました。
