### PR TITLE
Kill sigint

### DIFF
--- a/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
+++ b/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
@@ -246,6 +246,7 @@ void echoSignals2 (ros::Publisher &pub, bool useOpenGLCoord=false)
 
 void interrupt (int s)
 {
+  ros::shutdown();
   exit(1);
 }
 
@@ -253,7 +254,7 @@ void interrupt (int s)
 int main (int argc, char *argv[])
 {
 
-  ros::init(argc, argv, "feat_proj");
+  ros::init(argc, argv, "feat_proj", ros::init_options::NoSigintHandler);
   ros::NodeHandle rosnode;
   ros::NodeHandle private_nh("~");
   std::string cameraInfo_topic_name;

--- a/ros/src/data/packages/map_file/nodes/points_map_loader/points_map_loader.cpp
+++ b/ros/src/data/packages/map_file/nodes/points_map_loader/points_map_loader.cpp
@@ -350,6 +350,7 @@ sensor_msgs::PointCloud2 create_pcd(const std::vector<std::string>& pcd_paths, i
 			pcd.data.insert(pcd.data.end(), part.data.begin(), part.data.end());
 		}
 		std::cerr << "load " << path << std::endl;
+		if (!ros::ok()) break;
 	}
 
 	return pcd;

--- a/ros/src/socket/packages/tablet_socket/nodes/tablet_receiver/tablet_receiver.cpp
+++ b/ros/src/socket/packages/tablet_socket/nodes/tablet_receiver/tablet_receiver.cpp
@@ -164,6 +164,7 @@ int main(int argc, char *argv[])
 	//get connect to android
 	sock = -1;
 	g_sock_ptr = &sock;
+	signal(SIGINT, my_sigint_hdr);
 	while (getConnect(port, &sock, &asock) != -1) {
 		struct timeval tv[2];
 		double sec;

--- a/ros/src/socket/packages/tablet_socket/nodes/tablet_receiver/tablet_receiver.cpp
+++ b/ros/src/socket/packages/tablet_socket/nodes/tablet_receiver/tablet_receiver.cpp
@@ -123,17 +123,6 @@ void stopChildProcess(int signo)
 	_exit(EXIT_SUCCESS);
 }
 
-static int *g_sock_ptr = NULL;
-
-static void my_sigint_hdr(int sig)
-{
-	if (g_sock_ptr && *g_sock_ptr >= 0) {
-		close(*g_sock_ptr);
-		g_sock_ptr = NULL;
-	}
-	ros::shutdown();
-}
-
 int main(int argc, char *argv[])
 {
 	ros::Publisher pub[TOPIC_NR];
@@ -148,7 +137,7 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
-	ros::init(argc, argv, NODE_NAME, ros::init_options::NoSigintHandler);
+	ros::init(argc, argv, NODE_NAME);
 	ros::NodeHandle node;
 	pub[0] = node.advertise<tablet_socket::gear_cmd>("gear_cmd", 1);
 	pub[1] = node.advertise<tablet_socket::mode_cmd>("mode_cmd", 1);
@@ -163,8 +152,11 @@ int main(int argc, char *argv[])
 
 	//get connect to android
 	sock = -1;
-	g_sock_ptr = &sock;
-	signal(SIGINT, my_sigint_hdr);
+
+	sigaction(SIGINT, NULL, &act);
+	act.sa_flags &= ~SA_RESTART;
+	sigaction(SIGINT, &act, NULL);
+
 	while (getConnect(port, &sock, &asock) != -1) {
 		struct timeval tv[2];
 		double sec;

--- a/ros/src/socket/packages/tablet_socket/nodes/tablet_sender/tablet_sender.cpp
+++ b/ros/src/socket/packages/tablet_socket/nodes/tablet_sender/tablet_sender.cpp
@@ -34,6 +34,7 @@
 
 #include <ros/ros.h>
 #include <ros/console.h>
+#include <signal.h>
 
 #include <std_msgs/Bool.h>
 #include <tablet_socket/error_info.h>
@@ -304,12 +305,23 @@ static bool send_beacon(void)
 	return true;
 }
 
+static int g_listenfd = -1;
+
+static void my_sigint_hdr(int sig)
+{
+	if (g_listenfd >= 0) {
+		close(g_listenfd);
+		g_listenfd = -1;
+	}
+	ros::shutdown();
+}
+
 int main(int argc, char **argv)
 {
 	int listenfd, on;
 	sockaddr_in addr;
 
-	ros::init(argc, argv, "tablet_sender");
+	ros::init(argc, argv, "tablet_sender", ros::init_options::NoSigintHandler);
 
 	ros::NodeHandle n;
 	n.param<int>("tablet_sender/port", port, DEFAULT_PORT);
@@ -362,12 +374,17 @@ int main(int argc, char **argv)
 
 	ros::Rate loop_rate(SUBSCRIBE_HZ);
 
+	g_listenfd = listenfd;
+	signal(SIGINT, my_sigint_hdr);
+
 	while (true) {
 		connfd = accept(listenfd, (struct sockaddr *)nullptr,
 				nullptr);
 		if (connfd < 0) {
 			ROS_ERROR("accept: %s", strerror(errno));
-			close(listenfd);
+			if (g_listenfd >= 0) {
+				close(listenfd);
+			}
 			return -1;
 		}
 

--- a/ros/src/socket/packages/udon_socket/nodes/udon_receiver/udon_receiver.cpp
+++ b/ros/src/socket/packages/udon_socket/nodes/udon_receiver/udon_receiver.cpp
@@ -30,6 +30,7 @@
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <signal.h>
 
 #include <thread>
 
@@ -127,6 +128,11 @@ int main(int argc, char **argv)
 		goto close_listen_fd;
 	}
 	ROS_INFO_STREAM("listen " << astr << ":" << ntohs(server_addr.sin_port));
+
+	struct sigaction act;
+	sigaction(SIGINT, NULL, &act);
+	act.sa_flags &= ~SA_RESTART;
+	sigaction(SIGINT, &act, NULL);
 
 	int connect_fd;
 	while (true) {

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -255,7 +255,7 @@ subs :
         cmd  : roslaunch road_wizard feat_proj.launch
         param: feat_proj
         gui  :
-          flags : [ need_camera_info, SIGTERM ]
+          flags : [ need_camera_info ]
           sel_cam_dialog_only : [ camera_id ]
           sel_cam_dialog_allow: [ camera_id ]
           camera_id :

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -255,7 +255,7 @@ subs :
         cmd  : roslaunch road_wizard feat_proj.launch
         param: feat_proj
         gui  :
-          flags : [ need_camera_info ]
+          flags : [ need_camera_info, SIGTERM ]
           sel_cam_dialog_only : [ camera_id ]
           sel_cam_dialog_allow: [ camera_id ]
           camera_id :

--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -40,8 +40,6 @@ buttons :
   android_tablet_qs :
     desc: android_tablet_qs desc sample
     run : roslaunch runtime_manager tablet_socket.launch
-    gui   :
-      flags : [ SIGTERM ]
   oculus_rift_qs :
     desc: oculus_rift_qs desc sample
     run : echo 'oculus rift'

--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -12,10 +12,13 @@ buttons :
     param : map_qs
     gui   :
       stat_topic : [ pmap, vmap ]
+      flags : [ SIGTERM ]
   sensing_qs :
     desc  : sensing_qs desc sample
     run   : roslaunch
     param : sensing_qs
+    gui   :
+      flags : [ SIGTERM ]
   localization_qs :
     desc  : localization_qs desc sample
     run   : roslaunch
@@ -24,6 +27,8 @@ buttons :
     desc  : detection_qs desc sample
     run   : roslaunch
     param : detection_qs
+    gui   :
+      flags : [ SIGTERM ]
   mission_planning_qs :
     desc  : mission_planning_qs desc sample
     run   : roslaunch
@@ -36,6 +41,8 @@ buttons :
   android_tablet_qs :
     desc: android_tablet_qs desc sample
     run : roslaunch runtime_manager tablet_socket.launch
+    gui   :
+      flags : [ SIGTERM ]
   oculus_rift_qs :
     desc: oculus_rift_qs desc sample
     run : echo 'oculus rift'

--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -12,7 +12,6 @@ buttons :
     param : map_qs
     gui   :
       stat_topic : [ pmap, vmap ]
-      flags : [ SIGTERM ]
   sensing_qs :
     desc  : sensing_qs desc sample
     run   : roslaunch

--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -26,8 +26,6 @@ buttons :
     desc  : detection_qs desc sample
     run   : roslaunch
     param : detection_qs
-    gui   :
-      flags : [ SIGTERM ]
   mission_planning_qs :
     desc  : mission_planning_qs desc sample
     run   : roslaunch

--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1824,10 +1824,7 @@ class MyFrame(rtmgr.MyFrame):
 		if cmd_dic is None or cmd is None:
 			return
 
-		# ROSBAG Record modify
-		sigint = (key == 'rosbag_record')
-
-		proc = self.launch_kill(False, cmd, proc, sigint=sigint, obj=obj)
+		proc = self.launch_kill(False, cmd, proc, obj=obj)
 		cmd_dic[obj] = (cmd, proc)
 
 		self.toggle_enable_obj(obj)
@@ -2109,7 +2106,7 @@ class MyFrame(rtmgr.MyFrame):
 				return (cmd_dic, obj)
 		return (None, None)
 
-	def launch_kill(self, v, cmd, proc, add_args=None, sigint=False, obj=None):
+	def launch_kill(self, v, cmd, proc, add_args=None, sigint=None, obj=None):
 		msg = None
 		msg = 'already launched.' if v and proc else msg
 		msg = 'already terminated.' if not v and proc is None else msg
@@ -2146,6 +2143,8 @@ class MyFrame(rtmgr.MyFrame):
 				thinf = th_start(f, {'file':proc.stdout})
 				self.all_th_infs.append(thinf)
 		else:
+			if sigint is None:
+				sigint = 'SIGTERM' not in self.obj_to_gdic(obj, {}).get('flags', [])
 			terminate_children(proc, sigint)
 			terminate(proc, sigint)
 			proc.wait()

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -90,6 +90,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_hdl64e_s2.launch
         param: calibration_path
         gui  :
+          flags : [ SIGTERM ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -99,6 +100,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_hdl64e_s3.launch
         param: calibration_path
         gui  :
+          flags : [ SIGTERM ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -108,6 +110,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_hdl32e.launch
         param: calibration_path
         gui  :
+          flags : [ SIGTERM ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -117,6 +120,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_vlp16.launch
         param: calibration_path
         gui  :
+          flags : [ SIGTERM ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -180,6 +184,8 @@ buttons:
   calibration_toolkit :
     desc  : calibration_toolkit desc sample
     run   : rosrun calibration_camera_lidar calibration_toolkit
+    gui   :
+      flags : [ SIGTERM ]
 
   calibration_publisher :
     desc  : calibration_publisher desc sample


### PR DESCRIPTION
Runtime Managerから起動したコマンドを終了させる時に発行するシグナルについて

従来はsubprocess.procクラスのterminate()を使用し、その中でSIGTERMが使われていましたが、
ROSの流儀に合わせ、SIGINTを使用するように変更しました。

コマンドを記述してるyamlファイルの該当箇所に、

```
gui:
  flags: [ SIGTERM ]

```

設定を追加すれば、そのコマンドについては従来通りSIGTERMが使用されます。

SIGINTを使用する場合、ノードがI/O待ちでブロックしてる時に、コマンドの終了に長い時間がかかり、Runtime Managerの反応が悪くなります。

可能なものはノード側で、SIGINTのシグナルハンドラのSA_RESTARTフラグを落とすなどの対策を入れました。
その他のものはyamlファイルに flags: [ SIGTERM ] 設定を追加し、従来通りSIGTERMを使用してます。
