### PR TITLE
Runtime Manager, terminate_children() changed to as option

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -17,7 +17,7 @@ buttons :
     run   : roslaunch
     param : sensing_qs
     gui   :
-      flags : [ SIGTERM ]
+      flags : [ SIGTERM, kill_children ]
   localization_qs :
     desc  : localization_qs desc sample
     run   : roslaunch

--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2106,7 +2106,7 @@ class MyFrame(rtmgr.MyFrame):
 				return (cmd_dic, obj)
 		return (None, None)
 
-	def launch_kill(self, v, cmd, proc, add_args=None, sigint=None, obj=None):
+	def launch_kill(self, v, cmd, proc, add_args=None, sigint=None, obj=None, kill_children=None):
 		msg = None
 		msg = 'already launched.' if v and proc else msg
 		msg = 'already terminated.' if not v and proc is None else msg
@@ -2143,9 +2143,13 @@ class MyFrame(rtmgr.MyFrame):
 				thinf = th_start(f, {'file':proc.stdout})
 				self.all_th_infs.append(thinf)
 		else:
+			flags = self.obj_to_gdic(obj, {}).get('flags', [])
 			if sigint is None:
-				sigint = 'SIGTERM' not in self.obj_to_gdic(obj, {}).get('flags', [])
-			terminate_children(proc, sigint)
+				sigint = 'SIGTERM' not in flags
+			if kill_children is None:
+				kill_children = 'kill_children' in flags
+			if kill_children:
+				terminate_children(proc, sigint)
 			terminate(proc, sigint)
 			proc.wait()
 			if proc in self.all_procs:
@@ -3062,7 +3066,7 @@ class MyDialogRosbagRecord(rtmgr.MyDialogRosbagRecord):
 		args += split_arg + size_arg
 
 		(cmd, proc) = self.cmd_dic[ key_obj ]
-		proc = self.parent.launch_kill(True, cmd, proc, add_args=args, obj=key_obj)
+		proc = self.parent.launch_kill(True, cmd, proc, add_args=args, obj=key_obj, kill_children=True)
 		self.cmd_dic[ key_obj ] = (cmd, proc)
 		self.parent.toggle_enables(self.toggles)
 

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -67,6 +67,8 @@ subs :
         probe: 'lsusb -d 0584: > /dev/null' # probed if serial converter is connected
         run  : rosrun javad_navsat_driver gnss.sh
         param: serial
+        gui  :
+          flags : [ kill_children ]
       - name : Serial GNSS
         desc : Serial GNSS desc sample
         probe:
@@ -90,7 +92,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_hdl64e_s2.launch
         param: calibration_path
         gui  :
-          flags : [ SIGTERM ]
+          flags : [ SIGTERM, kill_children ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -100,7 +102,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_hdl64e_s3.launch
         param: calibration_path
         gui  :
-          flags : [ SIGTERM ]
+          flags : [ SIGTERM, kill_children ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -110,7 +112,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_hdl32e.launch
         param: calibration_path
         gui  :
-          flags : [ SIGTERM ]
+          flags : [ SIGTERM, kill_children ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -120,7 +122,7 @@ subs :
         run  : roslaunch velodyne_pointcloud velodyne_vlp16.launch
         param: calibration_path
         gui  :
-          flags : [ SIGTERM ]
+          flags : [ SIGTERM, kill_children ]
           calibration :
             prop  : 1
             flags : [ center_v ]
@@ -231,7 +233,7 @@ buttons:
     #param : virtual_scan_image
     param : sel_cam_and_sync
     gui   :
-      flags : [ need_camera_info ]
+      flags : [ need_camera_info, kill_children ]
       sel_cam_dialog_only : [ camera_id ]
       camera_id :
         border : 16

--- a/ros/src/util/packages/runtime_manager/scripts/simulation.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/simulation.yaml
@@ -3,6 +3,7 @@ buttons:
     run   : rosbag play
     param : rosbag_play
     gui   :
+      flags : [ kill_children ]
       stdout_func : self.rosbag_play_progress_bar
       ext_toggle_enables :
       - self.label_rosbag_play_bar


### PR DESCRIPTION
> 現在、runtime managerからSIGINTでノードを終了する時に、シグナルハンドラが2度呼ばれる状況になっています。
> これは意図している動作なのでしょうか。

原因および施した対策をお知らせ致します。

原因

Runtime Managerから実行したコマンドを終了する際に、
コマンドのプロセスから実行された子プロセス群を先に終了させてから、
コマンドのプロセスを終了させている事に起因してました。
("プロセスを終了させる処理"では、シグナルSIGINTの送出を行なってます)

実行するコマンドがroslaunchの場合、
launchファイルから起動するノードのプロセスが、子プロセス群に相当します。

まず、Runtime ManagerからノードプロセスにSIGINTが送出され、
次に、Runtime ManagerからroslaunchプロセスにSIGINTが送出されます。
そして、roslaunchプロセスから、自分が起動したノードのプロセスに、SIGINTが送出されます。
その結果、ノードのプロセスには2回SIGINTが送出されていました。

コマンドの子プロセス群を終了させる処理を追加した経緯

rosbag play, rosbag recordコマンド対応のため、処理を追加しておりました。
上記rosbagコマンドの終了処理では、rosbagコマンドから起動される子プロセスに対しても、SIGTERM(あるいはSIGINT)を送出する必要がありました。

rosbagコマンドを起動した端末から、^Cキー入力して終了させる場合では問題ないのですが、例えば別端末からkillコマンドでrosbagコマンドのプロセスにSIGINTを送出する場合では、子プロセスが動作し続けます。

対策

終了時に子プロセス群にSIGINTを送出する処理を削除した場合、
rosbagコマンドの他、いつくかのコマンドで従来と動作が異なりました。

子プロセス群にSIGINTを送出する処理は、オプション扱いとして残し、
.yamlファイルで指定した場合に、実行するよう変更しました。

gui :
  flags : [ kill_children ]
のフラグ指定がある場合のみ、子プロセス群にもSIGINTを送出します。

単に子プロセス群にSIGINTを送出する処理を削除した場合では、
次のコマンドで終了時に固まり画面が暗くなる現象が出ました。
- Quick Startタブ
  Sensingボタン (おそらく内部でVelodyne系ドライバを起動してるため)
- Sensingタブ
  Javad Delta 3 (rosrunコマンドで.shファイルを起動し.shからroslaunchコマンドを起動してる)
  Velodyne系のドライバ
  Virtual Scan Imageボタン (Qt使用?)

上記コマンドの.yamlファイルの対応箇所に、子プロセス群にSIGINTを送出する指定を追加し、従来通りの処理となってます。
