### PR TITLE
Add model data for simulation

### DIFF
--- a/ros/src/.config/model/sim_default.urdf
+++ b/ros/src/.config/model/sim_default.urdf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<robot name="car">
+  <link name="sim_base_link">
+    <visual name="base_visual">
+      <origin xyz="1 0 0.0" rpy="1.57 0 4.71" />
+      <geometry>
+        <mesh filename="package://model_publisher/../../../.config/model/CAR_original.dae" scale="1.0 1.0 1.0"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/launch/wf_simulator.launch
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/launch/wf_simulator.launch
@@ -1,11 +1,6 @@
 <!-- -->
 <launch>
 
-	<include file="$(find model_publisher)/launch/vehicle_model.launch">
-	<arg name="topic_name" default="sim_vehicle_model"/>
-	<arg name="base_frame" default="sim_base_link"/>
-	</include>
-	
 	<arg name="initialize_source" default="Rviz"/>
     <node pkg="waypoint_follower" type="wf_simulator" name="wf_simulator" output="screen">
     	<param name="initialize_source" value="$(arg initialize_source)"/>


### PR DESCRIPTION
Add model data for simulation with wf_simulator
You can choose sim_default.urdf at [Vehicle Model] in Setup tab when want to simulate.

Delete launch command for old model publisher in wl_simulator.launch
