### PR TITLE
Runtime Manager, add kill_children flag to RViz cmd for remote termin…

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/qs.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/qs.yaml
@@ -59,6 +59,8 @@ buttons :
     desc : rviz_qs desc sample
     #run : rosrun rviz rviz
     run  : sh -c '$(rospack find runtime_manager)/../../../.config/rviz/cmd.sh'
+    gui  :
+      flags : [ kill_children ]
 
   rqt_qs :
     desc: rqt_qs desc sample


### PR DESCRIPTION
…ation

RVizのリモート起動について
#405 の対応で、RVizをリモート起動した場合

( src/.config/rviz/host ファイルでRViz起動マシンを指定する場合 )
(RViz)ボタンOFFによる終了で固まる現象の不具合がありまた。

qs.yamlファイルのRVizのコマンドに kill_childrenフラグを追加し、
RVizの起動コマンドについては、#405 対応前の設定になるように修正します。
