### PR TITLE
Runtime Manager, fix old gui theme at RViz remote

### DIFF
--- a/ros/src/.config/rviz/cmd.sh
+++ b/ros/src/.config/rviz/cmd.sh
@@ -37,6 +37,7 @@ else
     ROS_MASTER_URI=http://\$FROM_IP:11311
     [ "$REMOTE_DISPLAY" != "-" ] && DISPLAY=$REMOTE_DISPLAY
     export ROS_IP ROS_MASTER_URI DISPLAY
+    export GNOME_DESKTOP_SESSION_ID="this-is-deprecated"
     rosrun rviz rviz
     #xeyes
 EOF


### PR DESCRIPTION
RViz をリモート起動した際に、古いGUIテーマで表示される不具合の対策。
