### PR TITLE
Runtime Manager, fix rosbag record stop

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2728,7 +2728,7 @@ class MyDialogRosbagRecord(rtmgr.MyDialogRosbagRecord):
 	def OnStop(self, event):
 		key_obj = self.button_start
 		(cmd, proc) = self.cmd_dic[ key_obj ]
-		proc = self.parent.launch_kill(False, cmd, proc, sigint=True, obj=key_obj)
+		proc = self.parent.launch_kill(False, cmd, proc, sigint=True, obj=key_obj, kill_children=True)
 		self.cmd_dic[ key_obj ] = (cmd, proc)
 		self.parent.toggle_enables(self.toggles)
 		self.Hide()


### PR DESCRIPTION
申し訳ありません。
コマンドの子プロセス群へのシグナル送出処理の変更 #405 
の際に、ROSBAG Recordダイアログからの(STOP)ボタンによる停止処理箇所に抜けがありました。
修正します。
