### PR TITLE
Runtime Manager, changed wx.Color to wx.Colour for wxPython3

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2561,9 +2561,9 @@ class InfoBarLabel(wx.BoxSizer):
 		self.Layout()
 
 	def bar_set(self, prg):
-		(col1, col2) = (wx.Color(0,0,250), wx.Color(0,0,128))
+		(col1, col2) = (wx.Colour(0,0,250), wx.Colour(0,0,128))
 		if prg >= self.lmt_bar_prg:
-			(col1, col2) = (wx.Color(250,0,0), wx.Color(128,0,0)) 
+			(col1, col2) = (wx.Colour(250,0,0), wx.Colour(128,0,0)) 
 		self.bar.set_col(col1, col2)
 		self.bar.set(prg)
 
@@ -2600,8 +2600,8 @@ class BarLabel(wx.Panel):
 		self.show_lb = show_lb
 		self.prg = -1
 
-		self.dflt_col1 = wx.Color(250,250,250)
-		self.dflt_col2 = wx.Color(128,128,128)
+		self.dflt_col1 = wx.Colour(250,250,250)
+		self.dflt_col2 = wx.Colour(128,128,128)
 		self.col1 = self.dflt_col1
 		self.col2 = self.dflt_col2
 


### PR DESCRIPTION
wxPython2 では、wx.Colour と同様に wx.Color が使用可能でしたが、
wxPython3 では、wx.Colour のみ使用可能となります。。

このため Runtime Manager の wx.Color 使用箇所を、wx.Colour に置き換えます。
