### PR TITLE
Runtime Manager Simulation tab, add rosbag info thread

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1163,10 +1163,13 @@ class MyFrame(rtmgr.MyFrame):
 	def rosbag_info_hook(self, v):
 		if not v:
 			return
+		th_start(self.rosbag_info_hook_th, {'v':v} )
+
+	def rosbag_info_hook_th(self, ev, v):  # thread
 		err = subprocess.STDOUT
 		s = subprocess.check_output([ 'rosbag', 'info', v ], stderr=err).strip()
-		self.label_rosbag_info.SetLabel(s)
-		self.label_rosbag_info.GetParent().FitInside()
+		wx.CallAfter(self.label_rosbag_info.SetLabel, s)
+		wx.CallAfter(self.label_rosbag_info.GetParent().FitInside)
 
 	#
 	# Data Tab


### PR DESCRIPTION
Simulation タブ

rosbagファイルのパスを指定した際に、内部でrosbag infoコマンドを実行して情報を取得し、GUIに表示しています。

大きなrosbagファイルを指定した場合、rosbag infoコマンドの実行時間長くかかり、GUIのイベントハンドラ実行時間が長すぎて画面が暗くなり固まる問題がありました。

この問題に対し、rosbag infoコマンドを別スレッドで実行するように修正して対策しています。
