### PR TITLE
Update the check.launch for the tablet_socket 

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/launch_files/check.launch
+++ b/ros/src/util/packages/runtime_manager/scripts/launch_files/check.launch
@@ -10,7 +10,7 @@
 <!-- lane_stop -->
 <node pkg="lane_planner" type="lane_stop" name="lane_stop"/>
 
-<!-- ndt_pcl -->
-<node pkg="points_localizer" type="ndt_pcl" name="ndt_pcl"/>
+<!-- ndt_matching -->
+<node pkg="ndt_localizer" type="ndt_matching" name="ndt_matching"/>
 
 </launch>


### PR DESCRIPTION
The node ndt_pcl was change to ndt_matching but the check.launch wasn't update for the tablet_soscket. I update the check.launch with the new node name.
