### PR TITLE
add checkbox value of lane_stop parameter to pdic

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -1833,11 +1833,14 @@ params :
   - name  : lane_stop
     topic : /light_color_managed
     msg   : traffic_light
+    no_save_vars : [ lane_stop ]
     vars  :
     - name  : traffic_light
       desc  : traffic_light desc sample
       v     : 0
-      
+    - name  : lane_stop
+      v     : False
+
   - name  : lane_select
     topic : /config/lane_select
     msg   : ConfigLaneSelect

--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2418,6 +2418,11 @@ class MyDialogLaneStop(rtmgr.MyDialogLaneStop):
 		rtmgr.MyDialogLaneStop.__init__(self, *args, **kwds)
 		self.frame = self.GetParent()
 
+		name = 'lane_stop'
+		var = next( ( var for var in self.prm.get('vars', []) if var.get('name') == name ), {} )
+		v = self.pdic.get( name, var.get('v', False) )
+		set_val(self.checkbox_lane_stop, v)
+
 	def update(self):
 		update_func = self.gdic.get('update_func')
 		if update_func:
@@ -2434,10 +2439,9 @@ class MyDialogLaneStop(rtmgr.MyDialogLaneStop):
 	def OnTrafficLightRecognition(self, event):
 		pub = rospy.Publisher('/config/lane_stop', ConfigLaneStop, latch=True, queue_size=10)
 		msg = ConfigLaneStop()
-		if event.GetEventObject().GetValue():
-			msg.manual_detection = False
-		else:
-			msg.manual_detection = True
+		v = event.GetEventObject().GetValue()
+		self.pdic['lane_stop'] = v
+		msg.manual_detection = not v
 		pub.publish(msg)
 
 	def OnOk(self, event):


### PR DESCRIPTION
Computingタブ lane_stop [app] について

appを閉じてから再度開くとチェックが外れているという現象の指摘がありました。

本lane_stopパラメータ設定ダイアログは、特別仕様な部分を含むため、
ダイアログにチェックボックスを新規に追加した時点から、状態を保存する処理は未実装となっていました。

Runtime Manager起動中はチェックボックスのON/OFF状態を保持するよう修正致しました。

ただし、Runtime Manager終了の際、チェックボックスの状態を param.yaml に保存されませんのでご留意ください。
