### PR TITLE
Defaults for unset CUDA_CAPABILITY_VERSION

### DIFF
--- a/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
@@ -214,7 +214,7 @@ if(EXISTS "/usr/local/cuda")
   INCLUDE(FindCUDA)
   
   # set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode arch=compute_${CUDA_CAPABILITY_VERSION},code=sm_${CUDA_CAPABILITY_VERSION};-std=c++11)
-  set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-arch=sm_${CUDA_CAPABILITY_VERSION};-std=c++11)
+  set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-arch=${CUDA_ARCH};-std=c++11)
   
   INCLUDE_DIRECTORIES(${Qt5Core_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS})


### PR DESCRIPTION
If CUDA_CAPABILITY_VERSION is empty, then make gets input of arch `sm_`
which causes a failure in compilation

- This allows for a fallback that is similar to rest of the file.

Closes #536