### PR TITLE
Update NVIDIA docker version from pre-release to latest release

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-ubuntu14.04
+FROM nvidia/cuda:8.0-devel-ubuntu14.04
 MAINTAINER Yuki Iida <aiueo.0409@gmail.com>
 
 RUN apt-get update && apt-get install -y \

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,9 +15,9 @@ sudo apt-get update
 sudo apt-get install docker-engine
 ```
 
-## Install NVIDIA Docker
+## Install nvidia-docker and nvidia-docker-plugin
 ```
-wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.0-rc.3/nvidia-docker_1.0.0.rc.3-1_amd64.deb
+wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.0/nvidia-docker_1.0.0-1_amd64.deb
 sudo dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
 ```
 


### PR DESCRIPTION
## Update NVIDIA docker version from pre-release to latest release

**Docker Release 1.0.0 includes:**

- Support for Docker 1.13
- Fix CPU affinity reporting on systems where NUMA is disabled
- Fix premature EOF in the remote API responses
- Add support for the VolumeDriver.Capabilities plugin endpoint
- Enable ppc64le library lookup
- Fix parsing of DOCKER_HOST for unix domain sockets

For more info: [nvidia-docker releases](https://github.com/NVIDIA/nvidia-docker/releases)