### PR TITLE
Runtime Manager, save param.yaml first at quit

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -484,11 +484,6 @@ class MyFrame(rtmgr.MyFrame):
 		pass
 
 	def OnClose(self, event):
-		# kill_all
-		for proc in self.all_procs[:]: # copy
-			(_, obj) = self.proc_to_cmd_dic_obj(proc)
-			self.launch_kill(False, 'dmy', proc, obj=obj)
-
 		save_dic = {}
 		for (name, pdic) in self.load_dic.items():
 			if pdic and pdic != {}:
@@ -507,6 +502,11 @@ class MyFrame(rtmgr.MyFrame):
 			#print 'save\n', s # for debug
 			f.write(s)
 			f.close()
+
+		# kill_all
+		for proc in self.all_procs[:]: # copy
+			(_, obj) = self.proc_to_cmd_dic_obj(proc)
+			self.launch_kill(False, 'dmy', proc, obj=obj)
 
 		shutdown_proc_manager()
 


### PR DESCRIPTION
Runtime Manager終了時にフリーズし強制終了した場合、パラメータがparam.yamlへ保存されずに失われる問題の対策です。
終了時に、まず最初にparam.yamlへセーブするように処理順を変更しました。