### PR TITLE
Runtime Manager, add booted_cmd to param.yaml and select dialog at boot

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -487,23 +487,20 @@ class MyFrame(rtmgr.MyFrame):
 
 	def boot_booted_cmds(self):
 		names = self.load_dic.get('booted_cmds', {}).get('names', [])
-		if not names:
+		lst = [ ( name, self.cfg_dic( { 'name': name } ).get('obj') ) for name in names ]
+		lst = [ (name, obj) for (name, obj) in lst if obj ]
+		if not lst:
 			return
 
-		dlg = wx.MultiChoiceDialog(self, 'boot command ?', '', names)
+		choices = [ obj.GetLabel() if hasattr(obj, 'GetLabel') else name for (name, obj) in lst ]
+		dlg = wx.MultiChoiceDialog(self, 'boot command ?', '', choices)
 		dlg.SetSelections( range( len(names) ) )
 		if dlg.ShowModal() != wx.ID_OK:
 			return
-		sidxs = dlg.GetSelections()
-		names = [ name for (i, name) in enumerate(names) if i in sidxs ]
-		if not names:
-			return
 
-		for name in names:
-			obj = self.cfg_dic( { 'name': name } ).get('obj')
-			if not obj:
-				continue
-			post_evt_toggle_obj(self, obj, True)
+		for i in dlg.GetSelections():
+			(_, obj) = lst[i]
+                        post_evt_toggle_obj(self, obj, True)
 
 	def OnClose(self, event):
 		if self.quit_select() != 'quit':
@@ -581,6 +578,8 @@ class MyFrame(rtmgr.MyFrame):
 			names.append(name)
 		if names:
 			save_dic['booted_cmds'] = { 'names': names }
+		elif 'booted_cmds' in save_dic:
+			del save_dic['booted_cmds']
 
 		if save_dic != {}:
 			dir = rtmgr_src_dir()


### PR DESCRIPTION
Runtime Manager起動時に、前回終了時に起動していたコマンドを、まとめて起動する変更です。

Runtime Manager終了時に、起動しているコマンドの情報をparam.yaml内に保存します。
次回起動時に、それらのコマンドを起動するか選択するダイアログを表示します。
OKボタンでダイアログを閉じると、選択されているコマンドを起動します。
Cancelボタンでダイアログを閉じると、コマンドを起動しません。
----
上記の機能を有効にするか無効にするかを、Quit Selectのメニューから切り替えるためのcommitを追加しました。
デフォルトでは上記の機能は無効で、Runtime Manager起動時は従来通りコマンドを起動しません。

Runtime Managerのクローズボックスをダブルクリックして Enable booted commands menu を選択すると、切り替え確認のダイアログが表示されます。
(OK)ボタンでダイアログを閉じると、上記の機能が有効に切り替わります。
以降のRuntime Managerの起動時では、前回終了時に起動していたコマンドを起動しなおすか問い合わせるダイアログが表示されます。

上記機能を無効に戻すには、クローズボックスをダブルクリックし、同様の手順でDisable booted commands menu を選択して設定を無効に切り替えます。

上記機能の有効/無効の情報は、param.yaml内に booted_cmds: 以下の enable: xxx として、xxx に true または false が書き出されます。
param.yamlを直接編集しても、上記機能の有効/無効を切り替える事ができます。