### PR TITLE
Runtime Manager, update for tree checkbox, for wrong scrolling at che…

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -92,6 +92,7 @@ from runtime_manager.msg import indicator_cmd
 from runtime_manager.msg import lamp_cmd
 from runtime_manager.msg import traffic_light
 from runtime_manager.msg import adjust_xy
+from types import MethodType
 
 SCHED_OTHER = 0
 SCHED_FIFO = 1
@@ -1833,6 +1834,10 @@ class MyFrame(rtmgr.MyFrame):
 		if tree is None:
 			style = wx.TR_HAS_BUTTONS | wx.TR_NO_LINES | wx.TR_HIDE_ROOT | wx.TR_DEFAULT_STYLE | wx.SUNKEN_BORDER
 			tree = CT.CustomTreeCtrl(parent, wx.ID_ANY, agwStyle=style)
+
+			# for disable wrong scrolling at checked
+			tree.AcceptsFocus = MethodType(lambda self: False, tree, CT.CustomTreeCtrl)
+
 			item = tree.AddRoot(name, data=tree)
 			tree.Bind(wx.EVT_MOTION, self.OnTreeMotion)
 		else:


### PR DESCRIPTION
Runtime Manager Computingタブについて

チェックボックスをON時に、コマンドを起動する直前にモーダルダイアログが表示されるコマンドの場合に、
モーダルダイアログを閉じると、チェックボックスのツリーに不要なスクロール動作が発生する事がありました。
上記の不具合に関する更新です。

不要なスクロール動作の前後では、チェックボックスツリー部品(CustomTreeCtrl)のキーフォーカス関連のメソッド呼び出しがあり、キーフォーカスを受けない設定に変更したところ、問題の現象は出なくなりました。

チェックボックスツリー部品をキーで操作する事は稀であるため、本対策を回避策とします。