### PR TITLE
Fix compile error regarding kitty_player

### DIFF
--- a/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
+++ b/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
@@ -12,7 +12,7 @@ if ("${ROS_VERSION}" MATCHES "(indigo|jade)")
 #SET (ROS_BUILD_TYPE Debug)
 SET (CMAKE_BUILD_TYPE Release)
 SET (ROS_BUILD_TYPE Release)
-SET (CMAKE_CXX_FLAGS "-O3 -std=c++0x")
+SET (CMAKE_CXX_FLAGS "-O3 -std=c++11")
 
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/util/packages/kitti_pkg/kitti_player/src/kitti_player.cpp
+++ b/ros/src/util/packages/kitti_pkg/kitti_player/src/kitti_player.cpp
@@ -1073,7 +1073,9 @@ int main(int argc, char **argv)
                 ifstream timestamps(str_support.c_str());
                 if (!timestamps.is_open())
                 {
-                    ROS_ERROR_STREAM("Fail to open " << timestamps);
+                    string timestamps_string;
+                    timestamps >> timestamps_string;
+                    ROS_ERROR_STREAM("Fail to open " << timestamps_string);
                     node.shutdown();
                     return -1;
                 }
@@ -1097,7 +1099,9 @@ int main(int argc, char **argv)
                 ifstream timestamps(str_support.c_str());
                 if (!timestamps.is_open())
                 {
-                    ROS_ERROR_STREAM("Fail to open " << timestamps);
+                    string timestamps_string;
+                    timestamps >> timestamps_string;
+                    ROS_ERROR_STREAM("Fail to open " << timestamps_string);
                     node.shutdown();
                     return -1;
                 }
@@ -1154,7 +1158,9 @@ int main(int argc, char **argv)
                 ifstream timestamps(str_support.c_str());
                 if (!timestamps.is_open())
                 {
-                    ROS_ERROR_STREAM("Fail to open " << timestamps);
+                    string timestamps_string;
+                    timestamps >> timestamps_string;
+                    ROS_ERROR_STREAM("Fail to open " << timestamps_string);
                     node.shutdown();
                     return -1;
                 }
@@ -1178,7 +1184,9 @@ int main(int argc, char **argv)
                 ifstream timestamps(str_support.c_str());
                 if (!timestamps.is_open())
                 {
-                    ROS_ERROR_STREAM("Fail to open " << timestamps);
+                    string timestamps_string;
+                    timestamps >> timestamps_string;
+                    ROS_ERROR_STREAM("Fail to open " << timestamps_string);
                     node.shutdown();
                     return -1;
                 }
@@ -1208,7 +1216,9 @@ int main(int argc, char **argv)
                 ifstream timestamps(str_support.c_str());
                 if (!timestamps.is_open())
                 {
-                    ROS_ERROR_STREAM("Fail to open " << timestamps);
+                    string timestamps_string;
+                    timestamps >> timestamps_string;
+                    ROS_ERROR_STREAM("Fail to open " << timestamps_string);
                     node.shutdown();
                     return -1;
                 }
@@ -1230,7 +1240,9 @@ int main(int argc, char **argv)
                 ifstream timestamps(str_support.c_str());
                 if (!timestamps.is_open())
                 {
-                    ROS_ERROR_STREAM("Fail to open " << timestamps);
+                    string timestamps_string;
+                    timestamps >> timestamps_string;
+                    ROS_ERROR_STREAM("Fail to open " << timestamps_string);
                     node.shutdown();
                     return -1;
                 }
@@ -1269,7 +1281,9 @@ int main(int argc, char **argv)
                 ifstream timestamps(str_support.c_str());
                 if (!timestamps.is_open())
                 {
-                    ROS_ERROR_STREAM("Fail to open " << timestamps);
+                    string timestamps_string;
+                    timestamps >> timestamps_string;
+                     ROS_ERROR_STREAM("Fail to open " << timestamps_string);
                     node.shutdown();
                     return -1;
                 }


### PR DESCRIPTION
* Change compile flag from `-std=c++0x` to `-std=c++11` as `c++0x` seems to be deprecated later than GCC ver4.7
* Fix `ROS_ERROR_STREAM` usages as `<<` operator in `ROS_ERROR_STREAM` doesn't seem to be able to use with ifstream directly