### PR TITLE
Convert input image into gray before calibration (fix the issue #694)

### DIFF
--- a/ros/src/computing/perception/detection/packages/viewers/nodes/image_viewer/image_viewer.cpp
+++ b/ros/src/computing/perception/detection/packages/viewers/nodes/image_viewer/image_viewer.cpp
@@ -126,10 +126,10 @@ static void drawDetections(std::vector<cv::Rect> dets, std::vector<float> scores
 			&text_size,
 			&baseline);
 
-		//cvRectangle( &frame,
-			//cvPoint(dets[i].x, dets[i].y),
-			//cvPoint(dets[i].x+dets[i].width, dets[i].y+dets[i].height),
-			//CV_RGB(0, 0, 255), OBJ_RECT_THICKNESS, CV_AA, 0);
+		cvRectangle( &frame,
+			cvPoint(dets[i].x, dets[i].y),
+			cvPoint(dets[i].x+dets[i].width, dets[i].y+dets[i].height),
+			CV_RGB(0, 0, 255), OBJ_RECT_THICKNESS, CV_AA, 0);
 		cvCircle(&frame, cvPoint(dets[i].x+dets[i].width/2, dets[i].y+dets[i].height/2), 30, cvScalar(0,255,0),3);		/* draw object label */
 		CvPoint textOrg = cvPoint(dets[i].x - OBJ_RECT_THICKNESS, dets[i].y - baseline - OBJ_RECT_THICKNESS);
 

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CalibrationToolkit/calibrationtoolkit.cpp
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CalibrationToolkit/calibrationtoolkit.cpp
@@ -1156,7 +1156,8 @@ bool CalibrateCameraVelodyneChessboardROS::refreshImage()
     cameratimestamp=QTime::fromMSecsSinceStartOfDay((msg->header.stamp.sec%(24*60*60))*1000+msg->header.stamp.nsec/1000000);
 
     cv_bridge::CvImagePtr cv_image = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-    calibimage = cv_image->image.clone();
+    cv::Mat tempimage = cv_image->image.clone();
+    cv::cvtColor(tempimage, calibimage, CV_BGR2GRAY);
 
     return CalibrateCameraBase::refreshImage();
 }
@@ -1637,7 +1638,8 @@ bool CalibrateCameraLidarChessboardROS::refreshImage()
     cameratimestamp=QTime::fromMSecsSinceStartOfDay((msg->header.stamp.sec%(24*60*60))*1000+msg->header.stamp.nsec/1000000);
 
     cv_bridge::CvImagePtr cv_image = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-    calibimage = cv_image->image.clone();
+    cv::Mat tempimage = cv_image->image.clone();
+    cv::cvtColor(tempimage, calibimage, CV_BGR2GRAY);
 
     return CalibrateCameraBase::refreshImage();
 }

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CalibrationToolkit/calibrationtoolkit.cpp
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CalibrationToolkit/calibrationtoolkit.cpp
@@ -500,7 +500,8 @@ bool CalibrateCameraChessboardROS::refreshImage()
     cameratimestamp=QTime::fromMSecsSinceStartOfDay((msg->header.stamp.sec%(24*60*60))*1000+msg->header.stamp.nsec/1000000);
 
     cv_bridge::CvImagePtr cv_image = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-    calibimage = cv_image->image.clone();
+    cv::Mat tempimage = cv_image->image.clone();
+    cv::cvtColor(tempimage, calibimage, CV_BGR2GRAY);
 
     return CalibrateCameraBase::refreshImage();
 }


### PR DESCRIPTION
Fix the issue autowarefoundation/autoware_ai#929

By pushing "Grab" button it comes to the error:
"error: (-210) The source image must be 8-bit single-channel (CV_8UC1) in function cvFindCornerSubPix"
Fix this bug by converting the input image into gray scale

The bug was produced with opencv 2.4.8 and ubuntu 14.04.
The fix was tested with opencv 2.4.8 and ubuntu 14.04.