### PR TITLE
fix to free a NULL window

### DIFF
--- a/ros/src/computing/perception/detection/packages/road_wizard/nodes/region_tlr/region_tlr.cpp
+++ b/ros/src/computing/perception/detection/packages/road_wizard/nodes/region_tlr/region_tlr.cpp
@@ -373,8 +373,11 @@ static void superimpose_cb(const std_msgs::Bool::ConstPtr& config_msg)
   }
 
   if (!show_superimpose_result) {
-    cv::destroyWindow(window_name);
-    cv::waitKey(1);
+	  if (cvGetWindowHandle(window_name.c_str()) != NULL)
+	  {
+		  cv::destroyWindow(window_name);
+		  cv::waitKey(1);
+	  }
   }
 
 } /* static void superimpose_cb() */


### PR DESCRIPTION
I got a SIGSEGV in region_tlr when I uncheck "Display superimpose result" with OpenCV 3.2.0.