### PR TITLE
Add vector map server to RuntimeManager

### DIFF
--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
@@ -607,7 +607,7 @@ void segmentByDistance(const pcl::PointCloud<pcl::PointXYZ>::Ptr in_cloud_ptr,
 				}
 				else
 				{
-					ROS_INFO("vectormap_filtering: VectorMap Server Call failed. Make sure vectormap_server is running. No filtering performed.");
+					ROS_WARN("vectormap_filtering: VectorMap Server Call failed. Make sure vectormap_server is running. No filtering performed.");
 					final_clusters[i]->SetValidity(true);
 				}
 			}

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
@@ -607,7 +607,7 @@ void segmentByDistance(const pcl::PointCloud<pcl::PointXYZ>::Ptr in_cloud_ptr,
 				}
 				else
 				{
-					ROS_WARN("vectormap_filtering: VectorMap Server Call failed. Make sure vectormap_server is running. No filtering performed.");
+					ROS_WARN_ONCE("vectormap_filtering: VectorMap Server Call failed. Make sure vectormap_server is running. No filtering performed.");
 					final_clusters[i]->SetValidity(true);
 				}
 			}

--- a/ros/src/data/packages/vector_map_server/CMakeLists.txt
+++ b/ros/src/data/packages/vector_map_server/CMakeLists.txt
@@ -66,11 +66,13 @@ include_directories(
 add_executable(vector_map_server nodes/vector_map_server/vector_map_server.cpp)
 target_link_libraries(vector_map_server ${catkin_LIBRARIES})
 add_dependencies(vector_map_server
+  vector_map_server_generate_messages_cpp
   ${catkin_EXPORTED_TARGETS}
 )
 
 add_executable(vector_map_client nodes/vector_map_client/vector_map_client.cpp)
 target_link_libraries(vector_map_client ${catkin_LIBRARIES})
 add_dependencies(vector_map_client
+  vector_map_server_generate_messages_cpp
   ${catkin_EXPORTED_TARGETS}
 )

--- a/ros/src/util/packages/runtime_manager/scripts/data.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/data.yaml
@@ -38,6 +38,11 @@ subs :
           border : 4
           flags  : [ all, no_category, nl ]
 
+    - name : vector_map_server
+      desc : RUN "vector_map_server" Services
+      cmd : rosrun vector_map_server vector_map_server
+      param : other
+
   - name : Position
     subs :
     - name  : pos_downloader


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
FIx VectorMap Server Call failed  autowarefoundation/autoware_ai#940

## Related PRs
Same Pull Request as autowarefoundation/autoware#728 (It was cancelled. )
Re-based on new master branch and tested

## Todos
- [ ] Tests
- [ ] Documentation

Not tested the VectorMap service

## Steps to Test or Reproduce

- Check "vector_map_server" 

![screenshot from 2017-07-14 08 00 04](https://user-images.githubusercontent.com/28831872/28191332-8d00a962-686a-11e7-8213-520e87273b17.png)

- Then this error will not occur. 
`vectormap_filtering: VectorMap Server Call failed. Make sure vectormap_server is running. No filtering performed.`    