### PR TITLE
Publish initial light color as green

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -2058,7 +2058,7 @@ params :
     vars  :
     - name  : traffic_light
       desc  : traffic_light desc sample
-      v     : 0
+      v     : 1
     - name  : lane_stop
       v     : False
 


### PR DESCRIPTION
Fix to publish light color GREEN when we run the lane_stop node at first.