### PR TITLE
Add 'use_vmap' mode in obj_fusion

### DIFF
--- a/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   jsk_rviz_plugins
   rosinterface
   cv_bridge
+  vector_map
   vector_map_server
 )
 
@@ -115,7 +116,7 @@ target_link_libraries(vscan_filling ${catkin_LIBRARIES} ${PCL_LIBRARIES})
 #Object Fusion
 add_executable(obj_fusion nodes/obj_fusion/obj_fusion.cpp)
 target_link_libraries(obj_fusion ${catkin_LIBRARIES} ${PCL_LIBRARIES} m)
-add_dependencies(obj_fusion ${catkin_EXPORTED_TARGETS})
+add_dependencies(obj_fusion ${catkin_EXPORTED_TARGETS} vector_map_server_generate_messages_cpp)
 
 # Vscan Track
 execute_process(

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/obj_fusion/obj_fusion.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/obj_fusion/obj_fusion.cpp
@@ -51,6 +51,13 @@ struct obj_label_t
 };
 obj_label_t obj_label;
 
+enum ObjLabel
+{
+  Car,
+  Person,
+  Unknown
+};
+
 static double euclid_distance(const geometry_msgs::Point pos1, const geometry_msgs::Point pos2)
 {
   return sqrt(pow(pos1.x - pos2.x, 2) + pow(pos1.y - pos2.y, 2) + pow(pos1.z - pos2.z, 2));
@@ -169,15 +176,15 @@ void fusion_cb(const autoware_msgs::obj_label::ConstPtr &obj_label_msg,
     v_cloud_cluster.at(obj_indices.at(i)).label = object_type;
     if (object_type == "car")
     {
-      v_cloud_cluster.at(obj_indices.at(i)).bounding_box.label = 0;
+      v_cloud_cluster.at(obj_indices.at(i)).bounding_box.label = Car;
     }
     else if (object_type == "person")
     {
-      v_cloud_cluster.at(obj_indices.at(i)).bounding_box.label = 1;
+      v_cloud_cluster.at(obj_indices.at(i)).bounding_box.label = Person;
     }
     else
     {
-      v_cloud_cluster.at(obj_indices.at(i)).bounding_box.label = 2;
+      v_cloud_cluster.at(obj_indices.at(i)).bounding_box.label = Unknown;
       v_cloud_cluster.at(obj_indices.at(i)).label = "unknown";
     }
 

--- a/ros/src/data/packages/vector_map/lib/vector_map/vector_map.cpp
+++ b/ros/src/data/packages/vector_map/lib/vector_map/vector_map.cpp
@@ -557,162 +557,162 @@ void VectorMap::registerSubscriber(ros::NodeHandle& nh, category_t category)
 {
   if (category & POINT)
   {
-    point_.registerSubscriber(nh, "vector_map_info/point");
+    point_.registerSubscriber(nh, "/vector_map_info/point");
     point_.registerUpdater(updatePoint);
   }
   if (category & VECTOR)
   {
-    vector_.registerSubscriber(nh, "vector_map_info/vector");
+    vector_.registerSubscriber(nh, "/vector_map_info/vector");
     vector_.registerUpdater(updateVector);
   }
   if (category & LINE)
   {
-    line_.registerSubscriber(nh, "vector_map_info/line");
+    line_.registerSubscriber(nh, "/vector_map_info/line");
     line_.registerUpdater(updateLine);
   }
   if (category & AREA)
   {
-    area_.registerSubscriber(nh, "vector_map_info/area");
+    area_.registerSubscriber(nh, "/vector_map_info/area");
     area_.registerUpdater(updateArea);
   }
   if (category & POLE)
   {
-    pole_.registerSubscriber(nh, "vector_map_info/pole");
+    pole_.registerSubscriber(nh, "/vector_map_info/pole");
     pole_.registerUpdater(updatePole);
   }
   if (category & BOX)
   {
-    box_.registerSubscriber(nh, "vector_map_info/box");
+    box_.registerSubscriber(nh, "/vector_map_info/box");
     box_.registerUpdater(updateBox);
   }
   if (category & DTLANE)
   {
-    dtlane_.registerSubscriber(nh, "vector_map_info/dtlane");
+    dtlane_.registerSubscriber(nh, "/vector_map_info/dtlane");
     dtlane_.registerUpdater(updateDTLane);
   }
   if (category & NODE)
   {
-    node_.registerSubscriber(nh, "vector_map_info/node");
+    node_.registerSubscriber(nh, "/vector_map_info/node");
     node_.registerUpdater(updateNode);
   }
   if (category & LANE)
   {
-    lane_.registerSubscriber(nh, "vector_map_info/lane");
+    lane_.registerSubscriber(nh, "/vector_map_info/lane");
     lane_.registerUpdater(updateLane);
   }
   if (category & WAY_AREA)
   {
-    way_area_.registerSubscriber(nh, "vector_map_info/way_area");
+    way_area_.registerSubscriber(nh, "/vector_map_info/way_area");
     way_area_.registerUpdater(updateWayArea);
   }
   if (category & ROAD_EDGE)
   {
-    road_edge_.registerSubscriber(nh, "vector_map_info/road_edge");
+    road_edge_.registerSubscriber(nh, "/vector_map_info/road_edge");
     road_edge_.registerUpdater(updateRoadEdge);
   }
   if (category & GUTTER)
   {
-    gutter_.registerSubscriber(nh, "vector_map_info/gutter");
+    gutter_.registerSubscriber(nh, "/vector_map_info/gutter");
     gutter_.registerUpdater(updateGutter);
   }
   if (category & CURB)
   {
-    curb_.registerSubscriber(nh, "vector_map_info/curb");
+    curb_.registerSubscriber(nh, "/vector_map_info/curb");
     curb_.registerUpdater(updateCurb);
   }
   if (category & WHITE_LINE)
   {
-    white_line_.registerSubscriber(nh, "vector_map_info/white_line");
+    white_line_.registerSubscriber(nh, "/vector_map_info/white_line");
     white_line_.registerUpdater(updateWhiteLine);
   }
   if (category & STOP_LINE)
   {
-    stop_line_.registerSubscriber(nh, "vector_map_info/stop_line");
+    stop_line_.registerSubscriber(nh, "/vector_map_info/stop_line");
     stop_line_.registerUpdater(updateStopLine);
   }
   if (category & ZEBRA_ZONE)
   {
-    zebra_zone_.registerSubscriber(nh, "vector_map_info/zebra_zone");
+    zebra_zone_.registerSubscriber(nh, "/vector_map_info/zebra_zone");
     zebra_zone_.registerUpdater(updateZebraZone);
   }
   if (category & CROSS_WALK)
   {
-    cross_walk_.registerSubscriber(nh, "vector_map_info/cross_walk");
+    cross_walk_.registerSubscriber(nh, "/vector_map_info/cross_walk");
     cross_walk_.registerUpdater(updateCrossWalk);
   }
   if (category & ROAD_MARK)
   {
-    road_mark_.registerSubscriber(nh, "vector_map_info/road_mark");
+    road_mark_.registerSubscriber(nh, "/vector_map_info/road_mark");
     road_mark_.registerUpdater(updateRoadMark);
   }
   if (category & ROAD_POLE)
   {
-    road_pole_.registerSubscriber(nh, "vector_map_info/road_pole");
+    road_pole_.registerSubscriber(nh, "/vector_map_info/road_pole");
     road_pole_.registerUpdater(updateRoadPole);
   }
   if (category & ROAD_SIGN)
   {
-    road_sign_.registerSubscriber(nh, "vector_map_info/road_sign");
+    road_sign_.registerSubscriber(nh, "/vector_map_info/road_sign");
     road_sign_.registerUpdater(updateRoadSign);
   }
   if (category & SIGNAL)
   {
-    signal_.registerSubscriber(nh, "vector_map_info/signal");
+    signal_.registerSubscriber(nh, "/vector_map_info/signal");
     signal_.registerUpdater(updateSignal);
   }
   if (category & STREET_LIGHT)
   {
-    street_light_.registerSubscriber(nh, "vector_map_info/street_light");
+    street_light_.registerSubscriber(nh, "/vector_map_info/street_light");
     street_light_.registerUpdater(updateStreetLight);
   }
   if (category & UTILITY_POLE)
   {
-    utility_pole_.registerSubscriber(nh, "vector_map_info/utility_pole");
+    utility_pole_.registerSubscriber(nh, "/vector_map_info/utility_pole");
     utility_pole_.registerUpdater(updateUtilityPole);
   }
   if (category & GUARD_RAIL)
   {
-    guard_rail_.registerSubscriber(nh, "vector_map_info/guard_rail");
+    guard_rail_.registerSubscriber(nh, "/vector_map_info/guard_rail");
     guard_rail_.registerUpdater(updateGuardRail);
   }
   if (category & SIDE_WALK)
   {
-    side_walk_.registerSubscriber(nh, "vector_map_info/side_walk");
+    side_walk_.registerSubscriber(nh, "/vector_map_info/side_walk");
     side_walk_.registerUpdater(updateSideWalk);
   }
   if (category & DRIVE_ON_PORTION)
   {
-    drive_on_portion_.registerSubscriber(nh, "vector_map_info/drive_on_portion");
+    drive_on_portion_.registerSubscriber(nh, "/vector_map_info/drive_on_portion");
     drive_on_portion_.registerUpdater(updateDriveOnPortion);
   }
   if (category & CROSS_ROAD)
   {
-    cross_road_.registerSubscriber(nh, "vector_map_info/cross_road");
+    cross_road_.registerSubscriber(nh, "/vector_map_info/cross_road");
     cross_road_.registerUpdater(updateCrossRoad);
   }
   if (category & SIDE_STRIP)
   {
-    side_strip_.registerSubscriber(nh, "vector_map_info/side_strip");
+    side_strip_.registerSubscriber(nh, "/vector_map_info/side_strip");
     side_strip_.registerUpdater(updateSideStrip);
   }
   if (category & CURVE_MIRROR)
   {
-    curve_mirror_.registerSubscriber(nh, "vector_map_info/curve_mirror");
+    curve_mirror_.registerSubscriber(nh, "/vector_map_info/curve_mirror");
     curve_mirror_.registerUpdater(updateCurveMirror);
   }
   if (category & WALL)
   {
-    wall_.registerSubscriber(nh, "vector_map_info/wall");
+    wall_.registerSubscriber(nh, "/vector_map_info/wall");
     wall_.registerUpdater(updateWall);
   }
   if (category & FENCE)
   {
-    fence_.registerSubscriber(nh, "vector_map_info/fence");
+    fence_.registerSubscriber(nh, "/vector_map_info/fence");
     fence_.registerUpdater(updateFence);
   }
   if (category & RAIL_CROSSING)
   {
-    rail_crossing_.registerSubscriber(nh, "vector_map_info/rail_crossing");
+    rail_crossing_.registerSubscriber(nh, "/vector_map_info/rail_crossing");
     rail_crossing_.registerUpdater(updateRailCrossing);
   }
 }


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Added 'use_vmap' mode, adjusting orientations of object along the nearest lane. autowarefoundation/autoware_ai#951
This mode needs vector_map_server.
( implemented with @kuriking )

## Steps to Test or Reproduce
### Launch 
```
$ rosrun vector_map_server vector_map_server
$ roslaunch lidar_tracker obj_fusion.launch
```
### Rviz
- Bounding box of tracked objects
  - topic: /obj_(car|person)/obj_pose
  - type: jsk_recognition_msgs::BoundinBoxArray
- Pose and whether the object is adjusted or not
  - topic: /obj_(car|person)/obj_pose_arrow
  - type: visualization_msgs::MarkerArray

If the object has the nearby lane, the white ball is displayed.

![screenshot from 2017-07-28 19-26-39](https://user-images.githubusercontent.com/1531482/28767353-5499ab8a-760e-11e7-965c-6d5071c9c03d.png)
