### PR TITLE
points_in to twist_in

### DIFF
--- a/ros/src/system/gazebo/twist_cmd_converter/launch/twist_cmd_converter.launch
+++ b/ros/src/system/gazebo/twist_cmd_converter/launch/twist_cmd_converter.launch
@@ -1,7 +1,7 @@
 <launch>
 	<node pkg="twist_cmd_converter" name="twist_cmd_converter" type="twist_cmd_converter_node" >
-		<remap from="points_in" to="/twist_cmd"/>
-		<remap from="points_out" to="/catvehicle/twist_cmd" />
+		<remap from="twist_in" to="/twist_cmd"/>     
+		<remap from="twist_out" to="/catvehicle/twist_cmd" />
 
 	</node>
 </launch>


### PR DESCRIPTION
should the original  "remap points_in" be "remap twist_in"?
should the original  "remap points_out" be "remap twist_out"?

Btw: it seems that due to below warning the car cannot move in Gazebo. Could you fix this?

[WARN] [WallTime: 1501852467.775585] [121.848000] Could not process inbound connection: topic types do not match: [geometry_msgs/TwistStamped] vs. [geometry_msgs/Twist]{'topic': '/twist_cmd', 'tcp_nodelay': '0', 'md5sum': '98d34b0043a2093cf9d9345ab6eef12e', 'type': 'geometry_msgs/TwistStamped', 'callerid': '/twist_cmd_converter'}

Zheng

## Status
**PRODUCTION / DEVELOPMENT**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
roslaunch pkg_A executable_A
```
The car should move.