### PR TITLE
autoware_msgs does not depend on jsk_rviz_plugin, cmake and package.x…

### DIFF
--- a/ros/src/msgs/autoware_msgs/CMakeLists.txt
+++ b/ros/src/msgs/autoware_msgs/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(catkin REQUIRED COMPONENTS
 	geometry_msgs
 	sensor_msgs
 	jsk_recognition_msgs
-	jsk_rviz_plugins
 )
 
 
@@ -96,8 +95,13 @@ generate_messages(
   geometry_msgs
   sensor_msgs
   jsk_recognition_msgs
-  jsk_rviz_plugins
 )
+
 catkin_package(
-  CATKIN_DEPENDS std_msgs geometry_msgs
+  CATKIN_DEPENDS
+  message_runtime
+  std_msgs
+  geometry_msgs
+  sensor_msgs
+  jsk_recognition_msgs
 )

--- a/ros/src/msgs/autoware_msgs/package.xml
+++ b/ros/src/msgs/autoware_msgs/package.xml
@@ -9,10 +9,13 @@
   <build_depend>message_generation</build_depend> 
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>jsk_recognition_msgs</build_depend>
   <run_depend>message_runtime</run_depend> 
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
-
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>jsk_recognition_msgs</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
autoware_msgs does not depend on jsk_rviz_plugin, cmake and package.xml were not correct.
See also https://github.com/CPFL/Autoware/issues/766#issuecomment-320477718

## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce
`./catkin_make_release`

Compilation should succeed.