### PR TITLE
Solution to Qt5 Error linking caused by PCL Bug on several Autoware Packages

### DIFF
--- a/ros/src/computing/perception/localization/packages/icp_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/icp_localizer/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   velodyne_pointcloud
 )
 
+find_package(Qt5Core REQUIRED)
 
 ###################################
 ## catkin specific configuration ##

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/CMakeLists.txt
@@ -8,6 +8,8 @@ execute_process(
 
 find_package(PCL REQUIRED)
 
+find_package(Qt5Core REQUIRED)
+
 IF(NOT (PCL_VERSION VERSION_LESS "1.7.2"))
 SET(FAST_PCL_PACKAGES filters registration)
 ENDIF(NOT (PCL_VERSION VERSION_LESS "1.7.2"))

--- a/ros/src/computing/perception/semantics/packages/object_map/CMakeLists.txt
+++ b/ros/src/computing/perception/semantics/packages/object_map/CMakeLists.txt
@@ -19,6 +19,8 @@ if (OPENMP_FOUND)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
+find_package(Qt5Core REQUIRED)
+
 ###################################
 ## catkin specific configuration ##
 ###################################

--- a/ros/src/computing/planning/mission/packages/way_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/way_planner/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   autoware_msgs
 )
 
-
+find_package(Qt5Core REQUIRED)
 
 ###################################
 ## catkin specific configuration ##

--- a/ros/src/computing/planning/motion/packages/astar_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/astar_planner/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   vector_map
 )
 
+find_package(Qt5Core REQUIRED)
+
 ###################################
 ## catkin specific configuration ##
 ###################################

--- a/ros/src/computing/planning/motion/packages/dp_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/dp_planner/CMakeLists.txt
@@ -20,6 +20,8 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
+find_package(Qt5Core REQUIRED)
+
 ###################################
 ## catkin specific configuration ##
 ###################################

--- a/ros/src/computing/planning/motion/packages/lattice_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/lattice_planner/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   #dbw_mkz_msgs
 )
 
+find_package(Qt5Core REQUIRED)
+
 ################################################
 ## Find OpenMP in order to parallelize loops  ##
 ################################################

--- a/ros/src/computing/planning/motion/packages/op_simulator/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_simulator/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   autoware_msgs
 )
 
+find_package(Qt5Core REQUIRED)
+
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 

--- a/ros/src/computing/planning/motion/packages/op_simulator_perception/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_simulator_perception/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(catkin REQUIRED COMPONENTS
   autoware_msgs
 )
 
+find_package(Qt5Core REQUIRED)
+
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
+find_package(Qt5Core REQUIRED)
+
 ################################################
 ## Declare ROS messages, services and actions ##
 ################################################

--- a/ros/src/data/packages/map_file/CMakeLists.txt
+++ b/ros/src/data/packages/map_file/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   autoware_msgs
 )
 
+find_package(Qt5Core REQUIRED)
+
 find_package(PCL REQUIRED COMPONENTS io)
 # See: https://github.com/ros-perception/perception_pcl/blob/lunar-devel/pcl_ros/CMakeLists.txt#L10-L22
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")

--- a/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_pointcloud/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_pointcloud/CMakeLists.txt
@@ -15,6 +15,7 @@ set(${PROJECT_NAME}_CATKIN_DEPS
 find_package(catkin REQUIRED COMPONENTS
              ${${PROJECT_NAME}_CATKIN_DEPS} pcl_conversions)
 find_package(Boost COMPONENTS signals)
+find_package(Qt5Core REQUIRED)
 
 # Resolve system dependency on yaml-cpp, which apparently does not
 # provide a CMake find_package() module.

--- a/ros/src/sensing/filters/packages/points_downsampler/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/points_downsampler/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
+find_package(Qt5Core REQUIRED)
+
 add_message_files(
   FILES
   PointsDownsamplerInfo.msg

--- a/ros/src/socket/packages/oculus_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/oculus_socket/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs
 )
 
+find_package(Qt5Core REQUIRED)
+
 catkin_package(
 )
 

--- a/ros/src/system/gazebo/laser_scan_converter/CMakeLists.txt
+++ b/ros/src/system/gazebo/laser_scan_converter/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 
+find_package(Qt5Core REQUIRED)
 
 catkin_package()
 

--- a/ros/src/util/packages/data_preprocessor/CMakeLists.txt
+++ b/ros/src/util/packages/data_preprocessor/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
 )
 find_package(OpenCV REQUIRED)
+find_package(Qt5Core REQUIRED)
 
 catkin_package(
 #  INCLUDE_DIRS include

--- a/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
+++ b/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(PCL 1.7 REQUIRED)
+find_package(Qt5Core REQUIRED)
 
 generate_dynamic_reconfigure_options(cfg/kitti_player.cfg)
 


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Countermeasures Qt5Core Linking issue on Ubuntu 16, caused by a PCL Bug

## Related PRs
Solves Issue autowarefoundation/autoware_ai#964 

## Todos
- [ ] Check compilability

## Steps to Test or Reproduce
1. Pull branch
`git clone -b fix/pcl_ros_qt_dependency https://github.com/CPFL/Autoware.git`.
2. compile using the provided `./catkin_make_release` script in `ros` directory.

