### PR TITLE
[hotfix] lidar_tracker package

### DIFF
--- a/ros/src/computing/perception/detection/packages/lidar_tracker/launch/kf_lidar_track.launch
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/launch/kf_lidar_track.launch
@@ -1,6 +1,18 @@
 <!-- Launch file for Kalman Filter Tracker -->
 <launch>
+	<arg name="distance_matching_threshold" default="1.5" />
+	<arg name="tracker_merging_threshold" default="1.0" />
+	<arg name="pose_estimation" default="false" />
+	<arg name="keep_alive" default="2" />
+	<arg name="maximum_track_id" default="200" />
+	
 	<!-- rosrun lidar_tracker kf_track -->
-	<node pkg="lidar_tracker" type="kf_lidar_track" name="kf_lidar_track" />
+	<node pkg="lidar_tracker" type="kf_lidar_track" name="kf_lidar_track">
+		<param name="distance_matching_threshold" value="$(arg distance_matching_threshold)" />
+		<param name="tracker_merging_threshold" value="$(arg tracker_merging_threshold)" />
+		<param name="pose_estimation" value="$(arg pose_estimation)" />
+		<param name="keep_alive" value="$(arg keep_alive)" />
+		<param name="maximum_track_id" value="$(arg maximum_track_id)" />
+	</node>
 
 </launch>

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/kf_lidar_track/includes/KfLidarTracker.h
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/kf_lidar_track/includes/KfLidarTracker.h
@@ -102,6 +102,7 @@ class KfLidarTracker
 	size_t maximum_allowed_skipped_frames_;
 	size_t maximum_trace_length_;
 	size_t next_track_id_;
+	size_t maximum_track_id_;
 
 	bool pose_estimation_;
 	void CheckTrackerMerge(size_t in_tracker_id, std::vector<CTrack>& in_trackers, std::vector<bool>& in_out_visited_trackers, std::vector<size_t>& out_merge_indices, double in_merge_threshold);
@@ -109,7 +110,14 @@ class KfLidarTracker
 	void MergeTrackers(std::vector<CTrack>& in_trackers, std::vector<CTrack>& out_trackers, std::vector<size_t> in_merge_indices, const size_t& current_index, std::vector<bool>& in_out_merged_trackers);
 	void CreatePolygonFromPoints(const geometry_msgs::Polygon& in_points, boost_polygon& out_polygon);
 public:
-	KfLidarTracker(float in_time_delta, float accel_noise_mag, float dist_thres = 3, float tracker_merging_threshold=2, size_t maximum_allowed_skipped_frames = 10, size_t max_trace_length = 10, bool in_pose_estimation = false);
+	KfLidarTracker(float in_time_delta,
+					float accel_noise_mag,
+					float dist_thres = 3,
+					float tracker_merging_threshold=2,
+					size_t maximum_allowed_skipped_frames = 10,
+					size_t max_trace_length = 10,
+					bool in_pose_estimation = false,
+					size_t maximum_track_id = 200);
 	~KfLidarTracker(void);
 
 	enum DistType

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/kf_lidar_track/kf_lidar_track.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/kf_lidar_track/kf_lidar_track.cpp
@@ -5,6 +5,8 @@
  *      Author: ne0
  */
 
+#include <vector>
+
 #include "ros/ros.h"
 
 #include <pcl_ros/transforms.h>
@@ -23,8 +25,6 @@
 #include <jsk_rviz_plugins/Pictogram.h>
 #include <jsk_rviz_plugins/PictogramArray.h>
 #include <jsk_recognition_msgs/PolygonArray.h>
-
-#include <vector>
 
 #include "KfLidarTracker.h"
 
@@ -46,6 +46,7 @@ private:
 
 	bool pose_estimation_;
 	int keep_alive_;
+	int maximum_track_id_;
 
 	boost::shared_ptr<KfLidarTracker> tracker_ptr;
 
@@ -65,10 +66,16 @@ KfLidarTrackNode::KfLidarTrackNode() :
 	pub_jsk_hulls_ = node_handle_.advertise<jsk_recognition_msgs::PolygonArray>("/cluster_hulls_tracked",1);
 	pub_jsk_pictograms_ = node_handle_.advertise<jsk_rviz_plugins::PictogramArray>("/cluster_ids_tracked",1);
 
-	node_handle_.param("distance_matching_threshold", distance_matching_threshold_, 1.5);	ROS_INFO("distance_matching_threshold: %f", distance_matching_threshold_);// distance threshold to match objects between scans
-	node_handle_.param("tracker_merging_threshold", tracker_merging_threshold_, 1.0);	ROS_INFO("tracker_merging_threshold: %f", tracker_merging_threshold_);// distance threshold to match objects between scans
-	node_handle_.param("pose_estimation", pose_estimation_, false);	ROS_INFO("pose_estimation: %d", pose_estimation_);// whether or not to estimate pose
-	node_handle_.param("keep_alive", keep_alive_, 2);	ROS_INFO("keep_alive: %d", keep_alive_);// frames to keep an object
+	node_handle_.param("distance_matching_threshold", distance_matching_threshold_, 1.5);
+	ROS_INFO("distance_matching_threshold: %f", distance_matching_threshold_);// distance threshold to match objects between scans
+	node_handle_.param("tracker_merging_threshold", tracker_merging_threshold_, 1.0);
+	ROS_INFO("tracker_merging_threshold: %f", tracker_merging_threshold_);// distance threshold to match objects between scans
+	node_handle_.param("pose_estimation", pose_estimation_, false);
+	ROS_INFO("pose_estimation: %d", pose_estimation_);// whether or not to estimate pose
+	node_handle_.param("keep_alive", keep_alive_, 2);
+	ROS_INFO("keep_alive: %d", keep_alive_);// frames to keep an object
+	node_handle_.param("maximum_track_id", maximum_track_id_, 200);
+	ROS_INFO("maximum_track_id: %d", maximum_track_id_);// frames to keep an object
 
 
 
@@ -77,7 +84,8 @@ KfLidarTrackNode::KfLidarTrackNode() :
 							distance_matching_threshold_, 			//matching distance threshold
 							tracker_merging_threshold_, //tracker merging threshold
 							keep_alive_, 				//life span
-							keep_alive_));			//trace length
+							keep_alive_,
+							maximum_track_id_));			//trace length
 }
 
 KfLidarTrackNode::~KfLidarTrackNode()

--- a/ros/src/sensing/filters/packages/points_preprocessor/launch/ground_filter.launch
+++ b/ros/src/sensing/filters/packages/points_preprocessor/launch/ground_filter.launch
@@ -10,11 +10,11 @@
         <arg name="min_point" default="3" />
         <arg name="clipping_thres" default="-0.5" />
         <arg name="gap_thres" default="0.5" />
-        <arg name="no_ground_point_topic" default="/points_no_ground />
+        <arg name="no_ground_point_topic" default="/points_no_ground" />
         <arg name="ground_point_topic" default="/points_ground" />
 
         <!-- rosrun lidar_tracker ground_filter -->
-        <node pkg="points_preprocessor" type="ground_filter" name="ground_filter">
+        <node pkg="points_preprocessor" type="ground_filter" name="ground_filter" output="log">
                 <param name="point_topic" value="$(arg point_topic)" />
                 <param name="remove_floor" value="$(arg remove_floor)" />
                 <param name="sensor_model" value="$(arg sensor_model)" />

--- a/ros/src/sensing/filters/packages/points_preprocessor/nodes/ground_filter/ground_filter.cpp
+++ b/ros/src/sensing/filters/packages/points_preprocessor/nodes/ground_filter/ground_filter.cpp
@@ -205,7 +205,7 @@ void GroundFilter::FilterGround(const pcl::PointCloud<velodyne_pointcloud::Point
 				}
 				else
 				{//this should never execute due to Sensor specs
-					ROS_ERROR("GroundFilter: Division by Zero avoided on pair_angle");
+					ROS_WARN("GroundFilter: Division by Zero avoided on pair_angle");
 					pair_angle = 0;
 				}
 				if (


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
This PR fixes issues autowarefoundation/autoware_ai#969 and autowarefoundation/autoware_ai#969 

## Todos
- [x] Tests

## Steps to Test or Reproduce
### Ground Filter fix
```
roslaunch points_preprocessor ground_filter.launch
```
The `ground_filter` node should start, instead of cause crash.

### Lidar tracker Id fix
```
roslaunch lidar_tracker kf_lidar_track.launch
```
Please refer to autowarefoundation/autoware_ai#969 for further explanation.