### PR TITLE
Runtime Manager, modify update_func()

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -1016,12 +1016,11 @@ class MyFrame(rtmgr.MyFrame):
 		return ( d.get('pdic'), d.get('gdic'), d.get('param') )
 
 	def update_func(self, pdic, gdic, prm):
-		pdic_empty = (pdic == {})
 		for var in prm.get('vars', []):
 			name = var.get('name')
 			gdic_v = gdic.get(name, {})
 			func = gdic_v.get('func')
-			if func is None and not pdic_empty:
+			if func is None and name in pdic:
 				continue
 			v = var.get('v')
 			if func is not None:


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Correct processing when parameter is not set when Runtime Manager node is started

When Runtime Manager starts the node,
When the parameter is not set,
Fix processing to complement the default value.

Conventionally, among a plurality of parameters given to a node,
Only when all are not set up, we supplemented all default values.

Among the plurality of parameters to be given to the node,
Even if only a part of it is not set,
It complemented the default value.

With this change,
When adding a parameter to a node,
Even if the old param.yaml remains,
Default values will be set for new parameters added.

英文が不適当かもしれませんので、以下、日本語で失礼します。

Runtime Managerのノード起動時にパラメータが未設定の場合の処理の修正

Runtime Managerがノードを起動する際に、
パラメータが未設定の場合に、
デフォルト値を補完する処理を修正しました。

従来では、ノードに与える複数のパラメータのうち、
全てが未設定な場合のみ、全てにデフォルト値を補完していました。

ノードに与える複数のパラメータのうち、
一部だけが未設定な場合でも、該当パラメータに
デフォルト値を補完するようにしました。

この変更により、
ノードにパラメータの追加を行なった時に、
古いparam.yamlが残っている場合でも、
追加した新しいパラメータにデフォルト値が設定されるようになります。

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [x] Tests
- [x] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
roslaunch pkg_A executable_A
```
The car should move.