### PR TITLE
Update README.md

### DIFF
--- a/ros/src/computing/perception/detection/packages/cv_tracker/nodes/ssd/README.md
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/nodes/ssd/README.md
@@ -5,6 +5,8 @@
 2. Clone SSD Caffe fork ( It's better to do it in your home dir, if you haven't. CMake files will be looking for it there)
 ```
 % git clone https://github.com/weiliu89/caffe.git ssdcaffe
+% cd ssdcaffe
+% git checkout 5365d0dccacd18e65f10e840eab28eb65ce0cda7
 ```
 
 3. Follow the authors' instruction to complete the requisites to compile.


### PR DESCRIPTION
Added instructions on how to compile compatible version of SSD with Autoware

## Status
**PRODUCTION **

## Description
Added corresponding repository hash to which Autoware is compatible with SSD.
Newer versions changed the API, thus breaking compatibility.

branch | PR
------ | ------
https://github.com/CPFL/Autoware/tree/hotfix/ssd_compatibility_instructions


## Todos
- [X] Tests
- [X] Documentation

## Steps to Test or Reproduce
SSD's Autoware node README includes extra instructions

Launch SSD node from UI pointing it to the corresponding models.