### PR TITLE
Use correct callback function

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/nodes/pacmod_interface/pacmod_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/pacmod_interface/pacmod_interface.cpp
@@ -55,7 +55,7 @@ void PacmodInterface::initForROS()
   // setup subscriber
   twist_cmd_sub_    = nh_.subscribe("twist_cmd", 10, &PacmodInterface::callbackFromTwistCmd, this);
   control_mode_sub_ = nh_.subscribe("/as/control_mode", 10, &PacmodInterface::callbackFromControlMode, this);
-  speed_sub_        = nh_.subscribe("/vehicle/steering_report", 10, &PacmodInterface::callbackFromTwistCmd, this);
+  speed_sub_        = nh_.subscribe("/vehicle/steering_report", 10, &PacmodInterface::callbackFromSteeringReport, this);
 
   // setup publisher
   steer_mode_pub_    = nh_.advertise<module_comm_msgs::SteerMode>("/as/arbitrated_steering_commands", 10);


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
The name of callback function was wrong, so I fixed it.

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce

```
roslaunch as pacmod_interface.launch
```