### PR TITLE
Added support for PointGrey USB Cameras from inside docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,6 +85,33 @@ RUN echo "source /opt/ros/indigo/setup.bash" >> /home/$USERNAME/.bashrc && \
         echo "export QT_X11_NO_MITSHM=1" >> /home/$USERNAME/.bashrc && \
         # cd to home on login
         echo "cd" >> /home/$USERNAME/.bashrc 
+        
+############
+##PT GREY FlyCaptureSDK
+############
+#download driver
+RUN wget http://ertl.jp/~amonrroy/flycapture2-2.6.3.4-amd64-pkg.tgz && \
+    tar -xvzf flycapture2-2.6.3.4-amd64-pkg.tgz
+##install dependencies
+RUN apt-get install -y libraw1394-11 libgtk2.0-0 libgtkmm-2.4-dev libglademm-2.4-dev libgtkglextmm-x11-1.2-dev libusb-1.0-0
+
+RUN cd flycapture2-2.6.3.4-amd64 && \
+    dpkg -i libflycapture-2* && \
+    dpkg -i libflycapturegui-2* && \
+    dpkg -i libflycapture-c-2* && \
+    dpkg -i libflycapturegui-c-2* && \
+    dpkg -i libmultisync-2* && \
+    dpkg -i flycap-2* && \
+    dpkg -i flycapture-doc-2* && \
+    dpkg -i updatorgui*
+
+#setup camera usb permissions
+ENV PGUDEVFILE /etc/udev/rules.d/40-pgr.rules
+RUN groupadd -f pgrimaging && \
+    usermod -a -G pgrimaging $USERNAME && \
+    echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"1e10\", MODE=\"0666\", GROUP=\"pgrimaging\" " >> PGUDEVFILE && \
+    /etc/init.d/udev restart
+
 
 # Change user
 USER autoware

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,5 +9,6 @@ nvidia-docker run \
         --volume=$XAUTH:$XAUTH:rw \
         --env="XAUTHORITY=${XAUTH}" \
         --env="DISPLAY=${DISPLAY}" \
+        --privileged -v /dev/bus/usb:/dev/bus/usb \
         -u autoware \
         autoware-image


### PR DESCRIPTION
## Status
*DEVELOPMENT*

## Description
These changes:
* Allow to build a Docker image with privileged access to the host's USB devices.
* Adds the setup script to enable the compilation of the pointgrey grasshopper node.

Adds the feature as described in autowarefoundation/autoware_ai#1014 

## Todos
- [ ] Tests

## Steps to Test or Reproduce
1. Clone the repo
2. Go to the `docker` directory
3. Run `sudo sh build.sh`
4. Execute `sudo sh run.sh`
5. Once in the docker terminal, launch Autoware `cd Autoware/ros && ./run`
6. Click `PointGrey Grasshopper 3` from sensing tab
7. Launch `Image Viewer` from computing tab

![image](https://user-images.githubusercontent.com/7009053/32432228-1653c9e2-c31a-11e7-930a-f17bc1faa095.png)

Tested on:
* Ubuntu 14.04.5
* ROS Indigo 1.11.21