### PR TITLE
launch file missing parameter setting.

### DIFF
--- a/ros/src/computing/planning/motion/packages/astar_planner/launch/velocity_set.launch
+++ b/ros/src/computing/planning/motion/packages/astar_planner/launch/velocity_set.launch
@@ -6,7 +6,7 @@
   <arg name="decelerate_vel_min" default="1.3" />
   <arg name="remove_points_upto" default="2.3" />
   <arg name="enable_multiple_crosswalk_detection" default="true" />
-  <arg name="enablePlannerDynamicSwitch" default="true" />
+  <arg name="enablePlannerDynamicSwitch" default="false" />
 
   <node pkg="astar_planner" type="velocity_set" name="velocity_set" output="log">
     <param name="use_crosswalk_detection" value="$(arg use_crosswalk_detection)" />

--- a/ros/src/computing/planning/motion/packages/astar_planner/launch/velocity_set.launch
+++ b/ros/src/computing/planning/motion/packages/astar_planner/launch/velocity_set.launch
@@ -6,6 +6,7 @@
   <arg name="decelerate_vel_min" default="1.3" />
   <arg name="remove_points_upto" default="2.3" />
   <arg name="enable_multiple_crosswalk_detection" default="true" />
+  <arg name="enablePlannerDynamicSwitch" default="true" />
 
   <node pkg="astar_planner" type="velocity_set" name="velocity_set" output="log">
     <param name="use_crosswalk_detection" value="$(arg use_crosswalk_detection)" />


### PR DESCRIPTION
missing parameter setting, when launch motion plan, report error :enablePlannerDynamicSwitch arg to be set.
see :  https://github.com/CPFL/Autoware/issues/871

## Status
**PRODUCTION / DEVELOPMENT**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
roslaunch pkg_A executable_A
```
The car should move.