### PR TITLE
re added launch files for estima models

### DIFF
--- a/ros/src/util/packages/model_publisher/launch/estima_black.launch
+++ b/ros/src/util/packages/model_publisher/launch/estima_black.launch
@@ -1,0 +1,19 @@
+<!-- -->
+<launch>
+  <arg name="base_frame" default="/base_link"/>
+  <arg name="topic_name" default="vehicle_model"/>
+  <arg name="offset_x" default="1.2"/>
+  <arg name="offset_y" default="0.0"/>
+  <arg name="offset_z" default="0.0"/>
+  <arg name="offset_roll" default="0.0"/> <!-- degree -->
+  <arg name="offset_pitch" default="0.0"/> <!-- degree -->
+  <arg name="offset_yaw" default="0.0"/> <!-- degree -->
+  <arg name="model_path" default="./src/.config/model/estima_black.urdf" />
+  <arg name="gui" default="False" />
+
+  <param name="robot_description" textfile="$(arg model_path)" />
+  <param name="use_gui" value="$(arg gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
+</launch>

--- a/ros/src/util/packages/model_publisher/launch/estima_gray.launch
+++ b/ros/src/util/packages/model_publisher/launch/estima_gray.launch
@@ -1,0 +1,19 @@
+<!-- -->
+<launch>
+  <arg name="base_frame" default="/base_link"/>
+  <arg name="topic_name" default="vehicle_model"/>
+  <arg name="offset_x" default="1.2"/>
+  <arg name="offset_y" default="0.0"/>
+  <arg name="offset_z" default="0.0"/>
+  <arg name="offset_roll" default="0.0"/> <!-- degree -->
+  <arg name="offset_pitch" default="0.0"/> <!-- degree -->
+  <arg name="offset_yaw" default="0.0"/> <!-- degree -->
+  <arg name="model_path" default="./src/.config/model/estima_gray.urdf" />
+  <arg name="gui" default="False" />
+
+  <param name="robot_description" textfile="$(arg model_path)" />
+  <param name="use_gui" value="$(arg gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
+</launch>

--- a/ros/src/util/packages/model_publisher/launch/estima_white.launch
+++ b/ros/src/util/packages/model_publisher/launch/estima_white.launch
@@ -1,0 +1,19 @@
+<!-- -->
+<launch>
+  <arg name="base_frame" default="/base_link"/>
+  <arg name="topic_name" default="vehicle_model"/>
+  <arg name="offset_x" default="1.2"/>
+  <arg name="offset_y" default="0.0"/>
+  <arg name="offset_z" default="0.0"/>
+  <arg name="offset_roll" default="0.0"/> <!-- degree -->
+  <arg name="offset_pitch" default="0.0"/> <!-- degree -->
+  <arg name="offset_yaw" default="0.0"/> <!-- degree -->
+  <arg name="model_path" default="./src/.config/model/estima_white.urdf" />
+  <arg name="gui" default="False" />
+
+  <param name="robot_description" textfile="$(arg model_path)" />
+  <param name="use_gui" value="$(arg gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
+</launch>


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Adds the launch files to use the Estima models in RVIZ using the Robot Model

## Related PRs
#890 

```
roslaunch model_publisher estima_white.launch
roslaunch model_publisher estima_gray.launch
roslaunch model_publisher estima_black.launch
```
![image](https://user-images.githubusercontent.com/7009053/32868678-a539bf06-cab6-11e7-8455-87381c2678f8.png)
