### PR TITLE
[Bugfix] The NDT executable file was divided into two

### DIFF
--- a/ros/src/computing/perception/localization/packages/ndt_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/CMakeLists.txt
@@ -67,16 +67,32 @@ endif()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-IF(PCL_VERSION VERSION_LESS "1.7.2")
 SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
-ELSE(PCL_VERSION VERSION_LESS "1.7.2")
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -DUSE_FAST_PCL ${CMAKE_CXX_FLAGS}")
-ENDIF(PCL_VERSION VERSION_LESS "1.7.2")
 
 add_executable(ndt_matching nodes/ndt_matching/ndt_matching.cpp)
 add_executable(ndt_mapping nodes/ndt_mapping/ndt_mapping.cpp)
+target_link_libraries(ndt_matching ${catkin_LIBRARIES})
+target_link_libraries(ndt_mapping ${catkin_LIBRARIES})
+add_dependencies(ndt_matching autoware_msgs_generate_messages_cpp)
+add_dependencies(ndt_mapping autoware_msgs_generate_messages_cpp)
+
+IF(NOT (PCL_VERSION VERSION_LESS "1.7.2"))
+add_executable(ndt_matching_omp nodes/ndt_matching/ndt_matching.cpp)
+add_executable(ndt_mapping_omp nodes/ndt_mapping/ndt_mapping.cpp)
+target_link_libraries(ndt_matching_omp ${catkin_LIBRARIES})
+target_link_libraries(ndt_mapping_omp ${catkin_LIBRARIES})
+add_dependencies(ndt_matching_omp autoware_msgs_generate_messages_cpp)
+add_dependencies(ndt_mapping_omp autoware_msgs_generate_messages_cpp)
+
+set_target_properties(ndt_matching_omp  PROPERTIES COMPILE_DEFINITIONS "USE_FAST_PCL")
+set_target_properties(ndt_mapping_omp   PROPERTIES COMPILE_DEFINITIONS "USE_FAST_PCL")
+ENDIF(NOT (PCL_VERSION VERSION_LESS "1.7.2"))
+
 add_executable(lazy_ndt_mapping nodes/lazy_ndt_mapping/lazy_ndt_mapping.cpp)
 add_executable(queue_counter nodes/queue_counter/queue_counter.cpp)
+target_link_libraries(lazy_ndt_mapping ${catkin_LIBRARIES})
+target_link_libraries(queue_counter ${catkin_LIBRARIES})
+add_dependencies(lazy_ndt_mapping autoware_msgs_generate_messages_cpp)
 
 if ("${ROS_VERSION}" MATCHES "(indigo|jade)")
 #add_executable(ndt_matching_tku nodes/ndt_matching_tku/ndt_matching_tku.cpp nodes/ndt_matching_tku/newton.cpp nodes/ndt_matching_tku/algebra.cpp)
@@ -84,21 +100,9 @@ add_executable(ndt_matching_tku nodes/ndt_matching_tku/ndt_matching_tku.cpp)
 add_executable(ndt_mapping_tku nodes/ndt_mapping_tku/ndt_mapping_tku.cpp)
 add_executable(mapping nodes/ndt_mapping_tku/mapping.cpp)
 add_executable(tf_mapping nodes/tf_mapping/tf_mapping.cpp)
-endif()
 
-target_link_libraries(ndt_matching ${catkin_LIBRARIES})
-target_link_libraries(ndt_mapping ${catkin_LIBRARIES})
-target_link_libraries(lazy_ndt_mapping ${catkin_LIBRARIES})
-target_link_libraries(queue_counter ${catkin_LIBRARIES})
-
-if ("${ROS_VERSION}" MATCHES "(indigo|jade)")
 target_link_libraries(ndt_matching_tku ndt_tku ${catkin_LIBRARIES})
 target_link_libraries(ndt_mapping_tku ndt_tku ${catkin_LIBRARIES})
 target_link_libraries(mapping ndt_tku ${catkin_LIBRARIES})
 target_link_libraries(tf_mapping ${catkin_LIBRARIES})
 endif()
-
-add_dependencies(ndt_matching autoware_msgs_generate_messages_cpp)
-add_dependencies(ndt_mapping autoware_msgs_generate_messages_cpp)
-add_dependencies(lazy_ndt_mapping autoware_msgs_generate_messages_cpp)
-

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_mapping.launch
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_mapping.launch
@@ -9,13 +9,21 @@
   <arg name="imu_topic" default="/imu_raw" />
 
   <!-- rosrun ndt_localizer ndt_mapping  -->
-  <node pkg="ndt_localizer" type="queue_counter" name="queue_counter" output="log" />
-  <node pkg="ndt_localizer" type="ndt_mapping" name="ndt_mapping" output="log">
+  <node pkg="ndt_localizer" type="queue_counter" name="queue_counter" output="log"/>
+  <node pkg="ndt_localizer" type="ndt_mapping" name="ndt_mapping" output="log" unless="$(arg use_openmp)">
     <param name="use_openmp" value="$(arg use_openmp)" />
     <param name="use_imu" value="$(arg use_imu)" />
     <param name="use_odom" value="$(arg use_odom)" />
     <param name="imu_upside_down" value="$(arg imu_upside_down)" />
     <param name="imu_topic" value="$(arg imu_topic)" />
   </node>
-  
+
+  <node pkg="ndt_localizer" type="ndt_mapping_omp" name="ndt_mapping_omp" output="log" if="$(arg use_openmp)">
+    <param name="use_openmp" value="$(arg use_openmp)" />
+    <param name="use_imu" value="$(arg use_imu)" />
+    <param name="use_odom" value="$(arg use_odom)" />
+    <param name="imu_upside_down" value="$(arg imu_upside_down)" />
+    <param name="imu_topic" value="$(arg imu_topic)" />
+  </node>
+
 </launch>

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_matching.launch
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_matching.launch
@@ -13,19 +13,31 @@
   <arg name="use_local_transform" default="false" />
   <arg name="sync" default="false" />
   <arg name="imu_topic" default="/imu_raw" />
-  
-  <node pkg="ndt_localizer" type="ndt_matching" name="ndt_matching" output="log">
+
+  <node pkg="ndt_localizer" type="ndt_matching" name="ndt_matching" output="log" unless="$(arg use_openmp)">
     <param name="use_gnss" value="$(arg use_gnss)" />
     <param name="use_imu" value="$(arg use_imu)" />
     <param name="use_odom" value="$(arg use_odom)" />
     <param name="imu_upside_down" value="$(arg imu_upside_down)" />
     <param name="queue_size" value="$(arg queue_size)" />
     <param name="offset" value="$(arg offset)" />
-    <param name="use_openmp" value="$(arg use_openmp)" />
     <param name="get_height" value="$(arg get_height)" />
     <param name="use_local_transform" value="$(arg use_local_transform)" />
     <param name="imu_topic" value="$(arg imu_topic)" />
     <remap from="/points_raw" to="/sync_drivers/points_raw" if="$(arg sync)" />
   </node>
-  
+
+  <node pkg="ndt_localizer" type="ndt_matching_omp" name="ndt_matching_omp" output="log" if="$(arg use_openmp)">
+    <param name="use_gnss" value="$(arg use_gnss)" />
+    <param name="use_imu" value="$(arg use_imu)" />
+    <param name="use_odom" value="$(arg use_odom)" />
+    <param name="imu_upside_down" value="$(arg imu_upside_down)" />
+    <param name="queue_size" value="$(arg queue_size)" />
+    <param name="offset" value="$(arg offset)" />
+    <param name="get_height" value="$(arg get_height)" />
+    <param name="use_local_transform" value="$(arg use_local_transform)" />
+    <param name="imu_topic" value="$(arg imu_topic)" />
+    <remap from="/points_raw" to="/sync_drivers/points_raw" if="$(arg sync)" />
+  </node>
+
 </launch>


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
The NDT executable file was divided into two, original PCL and fast PCL. autowarefoundation/autoware_ai#1029 
If you do NOT use OpenMP, use the original PCL(pcl/registration/ndt.h),
and If you use OpenMP, use fast PCL(fast_pcl/registration/ndt.h).

The two execution files are separated by ON / OFF of "USE OpenMP" of the app tab.


## Todos
- [x ] Tests
- [ ] Documentation


## Steps to Test or Reproduce
You can switch between these two executable files by "USE OpenMP" checkbox of the ndt_matching (or mapping ) app tab.
