### PR TITLE
Fixed mirrored images on Ladybug camera

### DIFF
--- a/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/ladybug/ladybug.cpp
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/ladybug/ladybug.cpp
@@ -363,6 +363,7 @@ int main (int argc, char **argv)
 			cv::resize(image,image,cv::Size(size.width*image_scale/100, size.height*image_scale/100));
 			//
 			cv::transpose(image, image);
+			cv::flip(image, image, 1);
 
 			if (i==0)
 				image.copyTo(full_size);


### PR DESCRIPTION
## Status
*DEVELOPMENT*

## Description
This PR fixes issue reported on autowarefoundation/autoware_ai#1030 

## Todos
- [X] Tested on real camera on Ubuntu 14.04, Ubuntu 16.04

## Steps to Test or Reproduce

```
roslaunch autoware_pointgrey_drivers ladybug.launch
```
Verify image is shown correctly.