### PR TITLE
Docker access to USB and Ethernet devices, support to PTGrey camera

### DIFF
--- a/docker/Dockerfile.indigo
+++ b/docker/Dockerfile.indigo
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
         software-properties-common \
         wget curl git cmake cmake-curses-gui
 
-# Intall ROS
+# Install ROS
 RUN wget http://packages.ros.org/ros.key -O - | apt-key add -
 RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-get update && apt-get install -y \
@@ -31,7 +31,7 @@ RUN apt-get install -y \
         libgoogle-perftools-dev \
         libeigen3-dev
 
-# Intall some basic GUI and sound libs
+# Install some basic GUI and sound libs
 RUN apt-get install -y \
         xz-utils file locales dbus-x11 pulseaudio dmz-cursor-theme \
         fonts-dejavu fonts-liberation hicolor-icon-theme \
@@ -40,7 +40,7 @@ RUN apt-get install -y \
         libgl1-mesa-glx libgl1-mesa-dri \
         && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX
 
-# Intall some basic GUI tools
+# Install some basic GUI tools
 RUN apt-get install -y \
         cmake-qt-gui \
         gnome-terminal
@@ -64,6 +64,34 @@ RUN echo "source /opt/ros/indigo/setup.bash" >> /home/$USERNAME/.bashrc && \
         echo "export QT_X11_NO_MITSHM=1" >> /home/$USERNAME/.bashrc && \
         # cd to home on login
         echo "cd" >> /home/$USERNAME/.bashrc
+
+############
+##PT GREY FlyCaptureSDK
+############
+#download driver
+RUN wget http://ertl.jp/~amonrroy/flycapture2-2.6.3.4-amd64-pkg.tgz && \
+    tar -xvzf flycapture2-2.6.3.4-amd64-pkg.tgz
+##install dependencies
+RUN apt-get install -y libraw1394-11 libgtk2.0-0 libgtkmm-2.4-dev libglademm-2.4-dev libgtkglextmm-x11-1.2-dev libusb-1.0-0
+
+RUN cd flycapture2-2.6.3.4-amd64 && \
+    dpkg -i libflycapture-2* && \
+    dpkg -i libflycapturegui-2* && \
+    dpkg -i libflycapture-c-2* && \
+    dpkg -i libflycapturegui-c-2* && \
+    dpkg -i libmultisync-2* && \
+    dpkg -i flycap-2* && \
+    dpkg -i flycapture-doc-2* && \
+    dpkg -i updatorgui*
+
+#setup camera usb permissions
+ENV PGUDEVFILE /etc/udev/rules.d/40-pgr.rules
+RUN groupadd -f pgrimaging && \
+    usermod -a -G pgrimaging $USERNAME && \
+    echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"1e10\", MODE=\"0666\", GROUP=\"pgrimaging\" " >> PGUDEVFILE && \
+/etc/init.d/udev restart
+
+## End PT GREY
 
 # Change user
 USER autoware

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,11 @@
 # Autoware Docker
-Assuming the NVIDIA drivers and Docker and nvidia-docker are properly installed(see [Docker installation](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/) [nvidia-docker installation](https://github.com/NVIDIA/nvidia-docker) ).
+Assuming the NVIDIA drivers and Docker and nvidia-docker are properly
+installed.
+
+[Docker installation](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/)
+
+
+[nvidia-docker installation](https://github.com/NVIDIA/nvidia-docker)
 
 ## How to build
 ```

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,4 +30,6 @@ nvidia-docker run \
     --env="XAUTHORITY=${XAUTH}" \
     --env="DISPLAY=${DISPLAY}" \
     -u autoware \
+    --privileged -v /dev/bus/usb:/dev/bus/usb \
+    --net=host \
     autoware-$1


### PR DESCRIPTION
## Status
*DEVELOPMENT*

## Description
Solves Issue autowarefoundation/autoware_ai#1014 

## Related PRs
autowarefoundation/autoware#873 

## Todos
- [X] Support for Indigo
  - [X] ROSBAG playback
  - [X] NDT Matching
  - [X] Grasshopper 3 camera driver
  - [X] Velodyne PointCloud driver
  - [X] Mounting USB drives
  - [ ] SSD Object detector
  - [ ] YOLO2 Object detector
  - [ ] Test IMU
  - [ ] Compare performance between native Autoware and docker
- [ ] Support for Kinetic

## Steps to Test or Reproduce
1. Build indigo image  (Detailed instructions on `Autoware/docker/README.md`)
1. Run docker indigo
1. Execute Runtime Manager
1. Launch Camera and Velodyne drivers
1. Open RVIZ and add corresponding topics
![image](https://user-images.githubusercontent.com/7009053/32949211-599513a4-cbe5-11e7-84b3-806a0a65738b.png)

