### PR TITLE
[CI] Add Travis CI conf for ROS Kinetic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_failure: always
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic"   PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: USE_DEB=true  ROS_DISTRO="kinetic"   PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - .ci_config/travis.sh


### PR DESCRIPTION
You may or may not have been using CI (Continuous Integration) somewhere internally, but AFAICT on your public repo there's no trait for that, so goes this PR. CI is IMHO a way to go to avoid many problems including buildfarm hassles like https://github.com/ros/rosdistro/pull/16449 ;)!

[ROS offers a few different ways](http://wiki.ros.org/CIs) to simplify setting up CI. In this PR, I'm suggesting [industrial_ci](http://wiki.ros.org/industrial_ci) (admittedly I'm one of the authors&maintainers). It's a set of scripts for CI on ROS. The simple config file in this PR enables CI to run on Travis CI for this repo, including [ROS pre-release test](http://wiki.ros.org/bloom/Tutorials/PrereleaseTest) that is recommended for packages released on ROS buildfarm.
Contrary to its name, it works for any ROS packages as well, not limited to "industrial" pkgs.

If this looks good, can any admin enable Travis for this repo at https://travis-ci.org/profile/CPFL?

----

If you're curious how the CI result looks, I've run CI jobs on my fork against current HEAD https://github.com/130s/Autoware/pull/1 and [here's CI result](https://travis-ci.org/130s/Autoware/jobs/305981587). Looks like all CI jobs failed due to various issues.

How to interpret the CI result per each PR on your repo may be a little tricky for now, as I found a WIP ticket https://github.com/CPFL/Autoware/issues/766 where more packages are getting ready to be released so that CI might not pass unless all in-progress work gets done.

----

It's totally up to the maintainers to use which CI tool, how to configure the detail, how to utilize the CI result etc. Just fyi that we as in [industrial_ci](http://wiki.ros.org/industrial_ci) maintainers have been very active in responding to questions and enhancement requests over a few years.