### PR TITLE
perfect the code.

### DIFF
--- a/ros/src/computing/perception/localization/packages/autoware_connector/nodes/can_info_translator/can_info_translator_core.cpp
+++ b/ros/src/computing/perception/localization/packages/autoware_connector/nodes/can_info_translator/can_info_translator_core.cpp
@@ -91,8 +91,7 @@ void VelPoseConnectNode::publishVelocity(const autoware_msgs::CanInfoConstPtr &m
   tw.twist.linear.x = kmph2mps(msg->speed);  // km/h -> m/s
 
   // angular velocity
-  if (v_info_.is_stored)
-    tw.twist.angular.z = v_info_.convertSteeringAngleToAngularVelocity(kmph2mps(msg->speed), msg->angle);
+  tw.twist.angular.z = v_info_.convertSteeringAngleToAngularVelocity(kmph2mps(msg->speed), msg->angle);
 
   pub1_.publish(tw);
 }


### PR DESCRIPTION
if v_info_.is_stored == false,  tw.twist.angular.z is rubbish value or previous value, it is abnormal, and in convertSteeringAngleToAngularVelocity( ) function, it already assert v_info_.is_stored is true, duplicate assert.

## Status
**PRODUCTION / DEVELOPMENT**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
roslaunch pkg_A executable_A
```
The car should move.