### PR TITLE
[fix] feat_proj node multi cam support

### DIFF
--- a/ros/src/computing/perception/detection/packages/road_wizard/launch/feat_proj.launch
+++ b/ros/src/computing/perception/detection/packages/road_wizard/launch/feat_proj.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="camera_id" default="/"/>
-  <arg name="camera_info_src" default="/camera/camera_info"/>
+  <arg name="camera_info_src" default="/camera_info"/>
   <arg name="use_path_info" default="false"/>
 
   <node pkg="road_wizard" type="feat_proj" name="feature_projection">

--- a/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
+++ b/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
@@ -353,11 +353,11 @@ int main (int argc, char *argv[])
   ros::NodeHandle rosnode;
   ros::NodeHandle private_nh("~");
   std::string cameraInfo_topic_name;
-  private_nh.param<std::string>("camera_info_topic", cameraInfo_topic_name, "/camera/camera_info");
+  private_nh.param<std::string>("camera_info_topic", cameraInfo_topic_name, "/camera_info");
 
   /* get camera ID */
   camera_id_str = cameraInfo_topic_name;
-  camera_id_str.erase(camera_id_str.find("/camera/camera_info"));
+  camera_id_str.erase(camera_id_str.find("/camera_info"));
   if (camera_id_str == "/") {
     camera_id_str = "camera";
   }


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fixes topic subscription for multiple cameras, reported on autowarefoundation/autoware_ai#1021

## Related PRs
autowarefoundation/autoware#886 

## Todos
- [X] Tests
  - [X] Ubuntu 14.04
  - [X] Ubuntu 16.04

## Steps to Test or Reproduce
- Follow steps reported on autowarefoundation/autoware_ai#1045 
- Launch node from RTM or
```
roslaunch road_wizard feat_proj.launch
roslaunch road_wizard traffic_light_recognition  (both ML and DL based nodes)
```
- Traffic light should be shown in the image published by `traffic_light_recognition` node in the topic `/traffic_light_recognition` and with the help of the Rviz plugin *Traffic light recognition*