### PR TITLE
[fix] Image src incorrectly set in the config file of runtime manager of ssd node

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -3090,16 +3090,16 @@ params :
       cmd_param :
         dash      : ''
         delim     : ':='
-    - name      : image_raw_topic_str
-      desc      : image_raw_topic_str desc sample
-      label     : image_raw_topic_str
+    - name      : image_src
+      desc      : Image Topic to be fed to the network for detection
+      label     : image_src
       kind      : str
       v         : /image_raw
       cmd_param :
         dash      : ''
         delim     : ':='
     - name     : network_definition_file
-      desc     : network_definition_file sample
+      desc     : Prototxt file which defines the network
       label    : 'network_file (ssd)'
       kind     : path
       v        : ~/ssdcaffe/models/VGGNet/VOC0712Plus/SSD_300x300/deploy.prototxt
@@ -3107,7 +3107,7 @@ params :
         dash     : ''
         delim    : ':='
     - name     : pretrained_model_file
-      desc     : pretrained_model_file sample
+      desc     : Trained Caffe model
       label    : 'pattern_file (ssd)'
       kind     : path
       v        : ~/ssdcaffe/models/VGGNet/VOC0712Plus/SSD_300x300/VGG_VOC0712Plus_SSD_300x300_iter_240000.caffemodel


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
This PR fixes the ssd node defaulting to `image_raw` regardless of the source topic being set in runtime manager. Described in autowarefoundation/autoware_ai#1051 

## Related PRs
This error was initially generated by autowarefoundation/autoware#623 

## Todos
- [X] Tests
- [X] Documentation


## Steps to Test or Reproduce
1. Click on `ssd_unc` node [app] button
2. Change the `image_src` text to something different than image_raw
3. Launch the node, clicking on the `ssd_unc` checkbox

SSD node now will correctly be fed from the specified topic, instead of defaulting to `image_raw`

![image](https://user-images.githubusercontent.com/7009053/33470565-4183f01a-d6ac-11e7-93f1-1e401aa96a99.png)
