### PR TITLE
iodevice error fix for xsens imu driver on kinetic

### DIFF
--- a/ros/src/sensing/drivers/imu/packages/xsens/src/xsens_driver/src/mtdevice.py
+++ b/ros/src/sensing/drivers/imu/packages/xsens/src/xsens_driver/src/mtdevice.py
@@ -19,8 +19,10 @@ class MTDevice(object):
 	def __init__(self, port, baudrate=115200, timeout=0.1, autoconf=True,
 			config_mode=False):
 		"""Open device."""
-		self.device = serial.Serial(port, baudrate, timeout=timeout,
-				writeTimeout=timeout)
+#		self.device = serial.Serial(port, baudrate, timeout=timeout,
+#				writeTimeout=timeout)
+                self.device = serial.Serial(port, baudrate, timeout=timeout,
+                                           writeTimeout=timeout, rtscts=True, dsrdtr=True)
 		self.device.flushInput()	# flush to make sure the port is ready TODO
 		self.device.flushOutput()	# flush to make sure the port is ready TODO
 		## timeout for communication


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description

This PR fixes the xsens iodevice error. https://github.com/CPFL/Autoware/issues/940

## Related PRs
List related PRs against other branches:

## Steps to Test or Reproduce
On develop: 


  1. Check out autoware
  1. Go to `Autoware/ros/src/sensing/drivers/imu/packages/xsens/src/xsens_driver/src`
  1. Run: `./mtdevice.py`. You should see an error similar to below:

```
Traceback (most recent call last):
  File "./mtdevice.py", line 1024, in <module>
    main()
  File "./mtdevice.py", line 979, in main
    mt = MTDevice(device, baudrate)
  File "./mtdevice.py", line 23, in __init__
    writeTimeout=timeout)
  File "/usr/lib/python2.7/dist-packages/serial/serialutil.py", line 180, in __init__
    self.open()
  File "/usr/lib/python2.7/dist-packages/serial/serialposix.py", line 311, in open
    self._update_dtr_state()
  File "/usr/lib/python2.7/dist-packages/serial/serialposix.py", line 605, in _update_dtr_state
    fcntl.ioctl(self.fd, TIOCMBIS, TIOCM_DTR_str)
IOError: [Errno 22] Invalid argument

```

To test fix: check out this branch and follow the same instructions. No error should be thrown, instead verbose output should be printed.

@amc-nu @dejanpan FYI