### PR TITLE
Support for multi cameras in obj_reproj node

### DIFF
--- a/ros/src/computing/perception/detection/packages/cv_tracker/launch/reprojection.launch
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/launch/reprojection.launch
@@ -8,7 +8,7 @@
     <group ns="obj_car">
 
       <arg name="projection_matrix_src_car" default="/projection_matrix"/>
-      <arg name="camera_info_src_car" default="/camera/camera_info"/>
+      <arg name="camera_info_src_car" default="/camera_info"/>
 
       <node pkg="cv_tracker" name="reprojection" type="obj_reproj">
         <param name="projection_matrix_topic" value="$(arg camera_id)$(arg projection_matrix_src_car)"/>
@@ -24,7 +24,7 @@
     <group ns="obj_person">
 
       <arg name="projection_matrix_src_pedestrian" default="/projection_matrix"/>
-      <arg name="camera_info_src_pedestrian" default="/camera/camera_info"/>
+      <arg name="camera_info_src_pedestrian" default="/camera_info"/>
 
       <node pkg="cv_tracker" name="reprojection" type="obj_reproj">
         <param name="projection_matrix_topic" value="$(arg camera_id)$(arg projection_matrix_src_pedestrian)"/>

--- a/ros/src/computing/perception/detection/packages/cv_tracker/nodes/obj_reproj/obj_reproj.cpp
+++ b/ros/src/computing/perception/detection/packages/cv_tracker/nodes/obj_reproj/obj_reproj.cpp
@@ -387,11 +387,11 @@ int main(int argc, char **argv){
   std::string projectionMat_topic_name;
   private_nh.param<std::string>("projection_matrix_topic", projectionMat_topic_name, "/projection_matrix");
   std::string camera_info_topic_name;
-  private_nh.param<std::string>("camera_info_topic", camera_info_topic_name, "/camera/camera_info");
+  private_nh.param<std::string>("camera_info_topic", camera_info_topic_name, "/camera_info");
 
   //get camera ID
   camera_id_str = camera_info_topic_name;
-  camera_id_str.erase(camera_id_str.find("/camera/camera_info"));
+  camera_id_str.erase(camera_id_str.find("/camera_info"));
   if (camera_id_str == "/") {
     camera_id_str = "camera";
   }


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fixes topic subscription for multiple cameras, reported on autowarefoundation/autoware_ai#1021
(Additional notes: obj_reproj does not work in current develop autowarefoundation/autoware_ai#1067)


## Related PRs
autowarefoundation/autoware#886
autowarefoundation/autoware#930

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce

1. Publish PCD Map, Vector Map, Map and base_link TF, Camera-Velodyne TF, Camera intrinsics

1. Run NDT Localization

1. Run euclidean_cluster

1. Run ssd_unc, range_fusion, klt_track and "obj_reproj"

/obj_car/obj_label_marker and /obj_car/obj_label are published.