### PR TITLE
[bugfix]use qt5_wrap_ui instead of autouic

### DIFF
--- a/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
+#set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -205,13 +205,15 @@ if(EXISTS "/usr/local/cuda")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
 
+  qt5_wrap_ui(vscan_lidar_track_ui_mainwindow nodes/vscan_lidar_track/mainwindow.ui)
+
   add_executable(vscan_lidar_track
     nodes/vscan_lidar_track/main.cpp
     nodes/vscan_lidar_track/mainwindow.cpp
     nodes/vscan_lidar_track/mainwindow.h
-    nodes/vscan_lidar_track/mainwindow.ui
     nodes/vscan_lidar_track/rbsspfvehicletracker.cpp
     nodes/vscan_lidar_track/rbsspfvehicletracker.h
+    ${vscan_lidar_track_ui_mainwindow}
     )
 
   set_target_properties(vscan_lidar_track

--- a/ros/src/computing/perception/detection/packages/road_wizard/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/road_wizard/CMakeLists.txt
@@ -120,13 +120,15 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+qt5_wrap_ui(tlr_tuner_ui_mainwindow nodes/tlr_tuner/mainwindow.ui)
+
 add_executable(tlr_tuner
   nodes/tlr_tuner/tlr_tuner.cpp
   nodes/tlr_tuner/mainwindow.cpp
   nodes/tlr_tuner/mainwindow.h
-  nodes/tlr_tuner/mainwindow.ui
   nodes/tlr_tuner/tunerBody.cpp
   nodes/tlr_tuner/tunerBody.h
+  ${tlr_tuner_ui_mainwindow}
   )
 
 set_target_properties(tlr_tuner

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
+#set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -108,11 +108,15 @@ target_link_libraries(calibration_test
 endif()
 ## 3D
 if ("${ROS_VERSION}" MATCHES "(indigo|jade|kinetic)")
+
+qt5_wrap_ui(calibration_toolkit_ui_mainwindow nodes/calibration_toolkit/mainwindow.ui)
+
+
 add_executable(calibration_toolkit
   nodes/calibration_toolkit/main.cpp
   nodes/calibration_toolkit/mainwindow.cpp
   nodes/calibration_toolkit/mainwindow.h
-  nodes/calibration_toolkit/mainwindow.ui
+  ${calibration_toolkit_ui_mainwindow}
 )
 
 set_target_properties(calibration_toolkit

--- a/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
+#set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -61,12 +61,14 @@ add_library(points_image
 )
 add_dependencies(points_image autoware_msgs_generate_messages_cpp)
 
+qt5_wrap_ui(points2vscan_ui_mainwindow nodes/points2vscan/mainwindow.ui)
+
 # points2vscan
 add_executable(points2vscan
   nodes/points2vscan/main.cpp
   nodes/points2vscan/mainwindow.cpp
   nodes/points2vscan/mainwindow.h
-  nodes/points2vscan/mainwindow.ui
+  ${points2vscan_ui_mainwindow}
 )
 
 set_target_properties(points2vscan


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
use qt5_wrap_ui instead of autouic.
Because autouic requires version 3.0.2 of CMake, so it did not work on ubuntu 14.04.

Probably I think autowarefoundation/autoware_ai#1056 will be solved.

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
I dont have ubuntu 14.04 PC.
So please compile and check.
(I tested it on ubuntu 16.04)
