### PR TITLE
Fix not to use NDT (fast_pcl) to leak memory

### DIFF
--- a/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_matching.launch
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_matching.launch
@@ -10,7 +10,7 @@
   <arg name="use_openmp" default="false" />
   <arg name="get_height" default="false" />
   <arg name="use_local_transform" default="false" />
-  <arg name="use_fast_pcl" default="true" />
+  <arg name="use_fast_pcl" default="false" />
   <arg name="use_gpu" default="false" />
   <arg name="sync" default="false" />
   <arg name="imu_topic" default="/imu_raw" />
@@ -24,6 +24,7 @@
     <param name="offset" value="$(arg offset)" />
     <param name="get_height" value="$(arg get_height)" />
     <param name="use_local_transform" value="$(arg use_local_transform)" />
+    <param name="use_fast_pcl" value="$(arg use_fast_pcl)" />
     <param name="use_gpu" value="$(arg use_gpu)" />
     <param name="use_openmp" value="$(arg use_openmp)" />
     <param name="imu_topic" value="$(arg imu_topic)" />

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_matching/ndt_matching.cpp
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_matching/ndt_matching.cpp
@@ -225,7 +225,7 @@ static std_msgs::Float32 ndt_reliability;
 static bool _use_gpu = false;
 static bool _use_openmp = false;
 
-static bool _use_fast_pcl = true;
+static bool _use_fast_pcl = false;
 
 static bool _get_height = false;
 static bool _use_local_transform = false;
@@ -514,6 +514,7 @@ static void map_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
       new_ndt.setResolution(ndt_res);
       new_ndt.setStepSize(step_size);
       new_ndt.setTransformationEpsilon(trans_eps);
+
       #ifdef USE_FAST_PCL
         new_ndt.omp_align(*output_cloud, Eigen::Matrix4f::Identity());
       #else


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fix not to use NDT (fast_pcl) to leak memory.

Memory leak NDT will correct as soon as it finds the cause.


## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
test ndt_matching
