### PR TITLE
[Feature] Filter Clustered Objects using VectorMap info.

### DIFF
--- a/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/CMakeLists.txt
@@ -19,6 +19,10 @@ find_package(catkin REQUIRED COMPONENTS
   vector_map
   vector_map_server
   op_ros_helpers
+  vector_map
+  grid_map_ros
+  grid_map_cv
+  grid_map_msgs
 )
 
 set(CMAKE_AUTOMOC ON)
@@ -28,6 +32,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
+find_package(OpenMP)
 
 execute_process(
   COMMAND rosversion -d
@@ -265,8 +270,14 @@ else()
 
 endif()
 
-add_dependencies(euclidean_cluster lidar_tracker_generate_messages_cpp vector_map_server_generate_messages_cpp)
+add_dependencies(euclidean_cluster lidar_tracker_generate_messages_cpp vector_map_server_generate_messages_cpp vector_map)
 
+if (OPENMP_FOUND)
+    set_target_properties(euclidean_cluster PROPERTIES
+        COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
+        LINK_FLAGS ${OpenMP_CXX_FLAGS}
+    )
+endif()
 
 #kl contour tracker
 add_executable(kf_contour_tracker nodes/kf_contour_tracker/kf_contour_tracker.cpp nodes/kf_contour_tracker/src/kf_contour_tracker_core.cpp)

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_cluster.config
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_cluster.config
@@ -1,0 +1,8 @@
+grid_map_topic: /grid_map_wayarea
+grid_map_visualizations:
+  - name: cluster_wayarea
+    type: occupancy_grid
+    params:
+     layer: wayarea
+     data_min: 0
+     data_max: 100

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
@@ -22,6 +22,10 @@
 
 	<arg name="use_vector_map" default="true" />
 	<arg name="vectormap_frame" default="map" />
+	<arg name="vectormap_grid_width" default="30" /><!--meters-->
+	<arg name="vectormap_grid_height" default="70" /><!--meters-->
+	<arg name="vectormap_grid_resolution" default="0.3" /><!--meters-->
+	<arg name="vectormap_grid_behind" default="20" /><!--meters-->
 
 	<arg name="output_frame" default="velodyne" />
 

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/launch/euclidean_clustering.launch
@@ -57,4 +57,8 @@
 		<remap from="/points_raw" to="/sync_drivers/points_raw" if="$(arg sync)" />
 	</node>
 
+	<node pkg="grid_map_visualization" type="grid_map_visualization" name="clustering_grid_map_visualization" output="screen">
+		<rosparam command="load" file="$(find lidar_tracker)/launch/euclidean_cluster.config" />
+	</node>
+
 </launch>

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
@@ -2,6 +2,8 @@
 #include <vector>
 #include <string>
 #include <sstream>
+#include <limits>
+#include <cmath>
 
 #include <ros/ros.h>
 
@@ -54,15 +56,14 @@
 #include <grid_map_msgs/GridMap.h>
 #include <grid_map_cv/grid_map_cv.hpp>
 
+#include <vector_map/vector_map.h>
+
 #include <jsk_recognition_msgs/BoundingBox.h>
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
 #include <jsk_rviz_plugins/Pictogram.h>
 #include <jsk_rviz_plugins/PictogramArray.h>
 
 #include <tf/tf.h>
-
-#include <limits>
-#include <cmath>
 
 #include <opencv/cv.h>
 #include <opencv/highgui.h>
@@ -745,7 +746,7 @@ void segmentByDistance(const pcl::PointCloud<pcl::PointXYZ>::Ptr in_cloud_ptr,
 				final_clusters[i]->SetValidity(point_in_grid);
 
 			}
-			/timer.stop();
+			//timer.stop();
 			//std::cout << "vectormap filtering took " << timer.getTimeMilli() << " ms to check " << final_clusters.size() << std::endl;
 		}
 	}

--- a/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
+++ b/ros/src/computing/perception/detection/packages/lidar_tracker/nodes/euclidean_cluster/euclidean_cluster.cpp
@@ -141,6 +141,11 @@ static double _max_boundingbox_side;
 static double _remove_points_upto;
 static double _cluster_merge_threshold;
 
+static double _vectormap_grid_width;
+static double _vectormap_grid_height;
+static double _vectormap_grid_resolution;
+static double _vectormap_grid_behind;
+
 std::vector<std::vector<geometry_msgs::Point>> _way_area_points;
 
 static bool _use_gpu;
@@ -1199,12 +1204,16 @@ int main (int argc, char** argv)
 	private_nh.param("keep_lane_right_distance", _keep_lane_right_distance, 5.0);	ROS_INFO("keep_lane_right_distance: %f", _keep_lane_right_distance);
 	private_nh.param("clustering_thresholds", _clustering_thresholds);
 	private_nh.param("clustering_distances", _clustering_distances);
-	private_nh.param("max_boundingbox_side", _max_boundingbox_side, 10.0);				ROS_INFO("max_boundingbox_side: %f", _max_boundingbox_side);
-	private_nh.param("cluster_merge_threshold", _cluster_merge_threshold, 1.5);			ROS_INFO("cluster_merge_threshold: %f", _cluster_merge_threshold);
-	private_nh.param<std::string>("output_frame", _output_frame, "velodyne");			ROS_INFO("output_frame: %s", _output_frame.c_str());
+	private_nh.param("max_boundingbox_side", _max_boundingbox_side, 10.0);		ROS_INFO("max_boundingbox_side: %f", _max_boundingbox_side);
+	private_nh.param("cluster_merge_threshold", _cluster_merge_threshold, 1.5);	ROS_INFO("cluster_merge_threshold: %f", _cluster_merge_threshold);
+	private_nh.param<std::string>("output_frame", _output_frame, "velodyne");	ROS_INFO("output_frame: %s", _output_frame.c_str());
 
-	private_nh.param("use_vector_map", _use_vector_map, false);							ROS_INFO("use_vector_map: %d", _use_vector_map);
-	private_nh.param<std::string>("vectormap_frame", _vectormap_frame, "map");			ROS_INFO("vectormap_frame: %s", _vectormap_frame.c_str());
+	private_nh.param("use_vector_map", _use_vector_map, false);					ROS_INFO("use_vector_map: %d", _use_vector_map);
+	private_nh.param<std::string>("vectormap_frame", _vectormap_frame, "map");	ROS_INFO("vectormap_frame: %s", _vectormap_frame.c_str());
+	private_nh.param("vectormap_grid_width", _vectormap_grid_width, 30.0);	    ROS_INFO("vectormap_grid_width: %f", _vectormap_grid_width);
+	private_nh.param("vectormap_grid_height", _vectormap_grid_height, 70.0);	ROS_INFO("vectormap_grid_height: %f", _vectormap_grid_height);
+	private_nh.param("vectormap_grid_resolution", _vectormap_grid_resolution, 0.3);	ROS_INFO("vectormap_grid_resolution: %f", _vectormap_grid_resolution);
+	private_nh.param("vectormap_grid_behind", _vectormap_grid_behind, 20.0);	ROS_INFO("vectormap_grid_resolution: %f", _vectormap_grid_behind);
 
 	private_nh.param("remove_points_upto", _remove_points_upto, 0.0);		ROS_INFO("remove_points_upto: %f", _remove_points_upto);
 
@@ -1239,8 +1248,8 @@ int main (int argc, char** argv)
 
 	grid_map::GridMap gridmap({"wayarea"});
 	_wayarea_gridmap = &gridmap;
-	_wayarea_gridmap->setGeometry(grid_map::Length(90, 30), 0.2);
-	_wayarea_gridmap->setPosition(grid_map::Position(20,0));
+	_wayarea_gridmap->setGeometry(grid_map::Length(_vectormap_grid_height, _vectormap_grid_width), _vectormap_grid_resolution);
+	_wayarea_gridmap->setPosition(grid_map::Position(_vectormap_grid_behind,0));
 
 	if (way_areas.empty())
 	{

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -1052,16 +1052,16 @@ params :
         dash        : ''
         delim       : ':='
     - name    : clip_min_height
-      desc    : clip_min_height desc sample
+      desc    : Remove points below this value. Introduced value must match the input data frame coordinate system.
       label   : 'clip_min_height (~sensor height)'
       min       : -5
       max       : 5
-      v       : -1.3
+      v       : -5
       cmd_param :
         dash        : ''
         delim       : ':='
     - name    : clip_max_height
-      desc    : clip_max_height desc sample
+      desc    : Remove points above this value. Introduced value must match the input data frame coordinate system.
       label   : 'clip_max_height (above sensor)'
       min       : 0
       max       : 5
@@ -1070,18 +1070,57 @@ params :
         dash        : ''
         delim       : ':='
     - name    : use_vector_map
-      desc    : use_vector_map desc sample
+      desc    : If checked, Localization and ADAS MAp with WAYAREA info should be published. Objects outside the road will be filtered.
       label   : 'use_vector_map'
       kind    : checkbox
-      v       : True
+      v       : false
       cmd_param :
         dash        : ''
         delim       : ':='
     - name    : vectormap_frame
-      desc    : vectormap_frame desc sample
+      desc    : Frame of the VectorMap according to TF. default. map
       label   : 'vectormap_frame'
       kind    : str
       v       : map
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name    : vectormap_grid_width
+      desc    : Width Distance in Meters to create a filtering grid to the sides. Default. 30
+      label   : 'vectormap_grid_width'
+      min       : 10.0
+      max       : 100.0
+      v       : 30.0
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name    : vectormap_grid_height
+      desc    : Height Distance in Meters to create a filtering grid to the front. Default. 70
+      label   : 'vectormap_grid_height'
+      min       : 10.0
+      max       : 100.0
+      v       : 70.0
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name    : vectormap_grid_resolution
+      desc    : One Grid square is equivalent to this value in meters. Smaller Value provide better resolution at the cost of memory (Default. 0.3)
+      label   : 'vectormap_grid_resolution'
+      min       : 0.1
+      max       : 1.0
+      v       : 0.3
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name    : vectormap_grid_behind
+      desc    : Allows to perform filtering behind the vehicle. Moves the grid to filter objects behind the current position (Default. 20.0)
+      label   : 'vectormap_grid_behind'
+      min       : 0.0
+      max       : 50.0
+      v       : 20.0
+      cmd_param :
+        dash        : ''
+        delim       : ':='
     - name    : remove_points_upto
       desc    : remove_points_upto desc sample
       label   : 'remove_points_upto (ignore points up to this distance)'


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
This PR solves issue autowarefoundation/autoware_ai#1071 with the help of the `wayarea` data contained in the VectorMap.

## Todos
- [X] Tests
- [X] Documentation


## Steps to Test or Reproduce
Pre-requisites:
* PCD Map
* Vector (ADAS) MAP with `wayarea` data available
* NDT Localization working

1. Press the [app] next to Euclidean Cluster in the Computing Tab
1. Select the correct point cloud topic for input
1. Enable *use_vector_map* checkbox.
1. Select the appropriate `frame` of the vector map (normally `map`).
1. The GridMap params can be used as the defaults ones. (See the tooltips for extra details)
1. Launch the node enabling the `euclidean_cluster` checkbox
![image](https://user-images.githubusercontent.com/7009053/34071109-9d57c664-e2b4-11e7-9aa9-c2ff60aa2b1d.png)
1. In Rviz add a Visualization *Map* in the **rviz** section
1. In the topic select: `/clustering_grid_map_visualization/cluster_wayarea`
1. The drivable area should now be visible in rviz as shown below
![image](https://user-images.githubusercontent.com/7009053/34071154-67e73e64-e2b5-11e7-9d5b-1efd395fa6de.png)
1. The `CloudClusters` published by `euclidean_cluster` will be filtered by this **white** area. Objects which its centroid falls outside this region will not be included in the output Array.

