### PR TITLE
[Bugfix] feat_proj does not considered the possibility that the ID of the ADAS map does not start with 1

### DIFF
--- a/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
+++ b/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
@@ -309,9 +309,9 @@ void echoSignals2(ros::Publisher &pub, bool useOpenGLCoord = false)
 		}
 	}
 
-	for (unsigned int i = 1; i <= vmap.signals.size(); i++)
+	for (const auto& signal_map : vmap.signals)
 	{
-		Signal signal = vmap.signals[i];
+		const Signal signal = signal_map.second;
 		int pid = vmap.vectors[signal.vid].pid;
 
 		Point3 signalcenter = vmap.getPoint(pid);


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
reported in autowarefoundation/autoware_ai#1081 

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
Please test feat_proj with the ID of the ADAS map that does not begin with 1.
(If necessary, I send such a map)
