### PR TITLE
Avoid returning zero by ros time now

### DIFF
--- a/ros/src/data/packages/vector_map/lib/vector_map/vector_map.cpp
+++ b/ros/src/data/packages/vector_map/lib/vector_map/vector_map.cpp
@@ -734,6 +734,13 @@ void VectorMap::subscribe(ros::NodeHandle& nh, category_t category)
 
 void VectorMap::subscribe(ros::NodeHandle& nh, category_t category, const ros::Duration& timeout)
 {
+  // wait for clock
+  ros::Rate wait_rate(10);
+  while (ros::ok() && ros::Time::now().isZero())
+  {
+    wait_rate.sleep();
+  }
+
   registerSubscriber(nh, category);
   ros::Rate rate(1);
   ros::Time end = ros::Time::now() + timeout;


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
when /use_sim_time is true, ros::Time::now() returns zero and non-blocking subscriber doesn't work in simulation.

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
use vector map library