### PR TITLE
Fix crash on NDT mapping gpu

### DIFF
--- a/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/NormalDistributionsTransform.cu
+++ b/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/NormalDistributionsTransform.cu
@@ -1626,7 +1626,6 @@ __global__ void gpuSum(T *input, int size, int half_size)
 
 double GNormalDistributionsTransform::getFitnessScore(double max_range)
 {
-	printf("TESTTTTTTTTTTTTTTTTTTT");
 	double fitness_score = 0.0;
 
 	float *trans_x, *trans_y, *trans_z;

--- a/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/NormalDistributionsTransform.cu
+++ b/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/NormalDistributionsTransform.cu
@@ -529,7 +529,7 @@ __global__ void computeHessianListS0(float *trans_x, float *trans_y, float *tran
 													double *icov00, double *icov01, double *icov02,
 													double *icov10, double *icov11, double *icov12,
 													double *icov20, double *icov21, double *icov22,
-													double *point_gradients0, double *point_gradients1, double *point_gradients2,
+													double *point_gradients,
 													double *tmp_hessian,
 													int valid_voxel_num)
 {
@@ -538,12 +538,12 @@ __global__ void computeHessianListS0(float *trans_x, float *trans_y, float *tran
 	int col = blockIdx.y;
 
 	if (col < 6) {
-		double *tmp_pg0 = point_gradients0 + col * valid_points_num;
-		double *tmp_pg1 = point_gradients1 + 6 * valid_points_num;
-		double *tmp_pg2 = point_gradients2 + 6 * valid_points_num;
+		double *tmp_pg0 = point_gradients + col * valid_points_num;
+		double *tmp_pg1 = tmp_pg0 + 6 * valid_points_num;
+		double *tmp_pg2 = tmp_pg1 + 6 * valid_points_num;
 		double *tmp_h = tmp_hessian + col * valid_voxel_num;
 
-		for (int i = id; i < valid_points_num && col < 6; i += stride) {
+		for (int i = id; i < valid_points_num; i += stride) {
 			int pid = valid_points[i];
 			double d_x = static_cast<double>(trans_x[pid]);
 			double d_y = static_cast<double>(trans_y[pid]);
@@ -876,7 +876,7 @@ double GNormalDistributionsTransform::computeDerivatives(Eigen::Matrix<double, 6
 												inverse_covariance, inverse_covariance + voxel_num, inverse_covariance + 2 * voxel_num,
 												inverse_covariance + 3 * voxel_num, inverse_covariance + 4 * voxel_num, inverse_covariance + 5 * voxel_num,
 												inverse_covariance + 6 * voxel_num, inverse_covariance + 7 * voxel_num, inverse_covariance + 8 * voxel_num,
-												point_gradients, point_gradients + 6 * valid_points_num, point_gradients + 12 * valid_points_num,
+												point_gradients,
 												tmp_hessian, valid_voxel_num);
 		checkCudaErrors(cudaGetLastError());
 		grid.z = 6;
@@ -1495,7 +1495,7 @@ void GNormalDistributionsTransform::computeHessian(Eigen::Matrix<double, 6, 6> &
 												inverse_covariance, inverse_covariance + voxel_num, inverse_covariance + 2 * voxel_num,
 												inverse_covariance + 3 * voxel_num, inverse_covariance + 4 * voxel_num, inverse_covariance + 5 * voxel_num,
 												inverse_covariance + 6 * voxel_num, inverse_covariance + 7 * voxel_num, inverse_covariance + 8 * voxel_num,
-												point_gradients, point_gradients + 6 * valid_points_num, point_gradients + 12 * valid_points_num,
+												point_gradients,
 												tmp_hessian, valid_voxel_num);
 	checkCudaErrors(cudaGetLastError());
 

--- a/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/NormalDistributionsTransform.cu
+++ b/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/NormalDistributionsTransform.cu
@@ -140,30 +140,6 @@ void GNormalDistributionsTransform::setInputTarget(pcl::PointCloud<pcl::PointXYZ
 	}
 }
 
-void GNormalDistributionsTransform::setInputTarget(pcl::PointXYZI *input, int size)
-{
-	// Copy input map data from the host memory to the GPU memory
-	GRegistration::setInputTarget(input, size);
-
-	// Build the voxel grid
-	if (target_points_number_ != 0) {
-		voxel_grid_.setLeafSize(resolution_, resolution_, resolution_);
-		voxel_grid_.setInput(target_x_, target_y_, target_z_, target_points_number_);
-	}
-}
-
-void GNormalDistributionsTransform::setInputTarget(pcl::PointXYZ *input, int size)
-{
-	// Copy input map data from the host memory to the GPU memory
-	GRegistration::setInputTarget(input, size);
-
-	// Build the voxel grid
-	if (target_points_number_ != 0) {
-		voxel_grid_.setLeafSize(resolution_, resolution_, resolution_);
-		voxel_grid_.setInput(target_x_, target_y_, target_z_, target_points_number_);
-	}
-}
-
 void GNormalDistributionsTransform::computeTransformation(const Eigen::Matrix<float, 4, 4> &guess)
 {
 

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_mapping.launch
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_mapping.launch
@@ -10,8 +10,8 @@
   <arg name="imu_topic" default="/imu_raw" />
 
   <!-- rosrun ndt_localizer ndt_mapping  -->
-  <node pkg="ndt_localizer" type="queue_counter" name="queue_counter" output="log"/>
-  <node pkg="ndt_localizer" type="ndt_mapping" name="ndt_mapping" output="log" unless="$(arg use_openmp)">
+  <node pkg="ndt_localizer" type="queue_counter" name="queue_counter" output="screen"/>
+  <node pkg="ndt_localizer" type="ndt_mapping" name="ndt_mapping" output="screen" unless="$(arg use_openmp)">
     <param name="use_gpu" value="$(arg use_gpu)" />
     <param name="use_fast_pcl" value="$(arg use_fast_pcl)" />
     <param name="use_openmp" value="$(arg use_openmp)" />
@@ -21,7 +21,7 @@
     <param name="imu_topic" value="$(arg imu_topic)" />
   </node>
 
-  <node pkg="ndt_localizer" type="ndt_mapping_omp" name="ndt_mapping_omp" output="log" if="$(arg use_openmp)">
+  <node pkg="ndt_localizer" type="ndt_mapping_omp" name="ndt_mapping_omp" output="screen" if="$(arg use_openmp)">
     <param name="use_gpu" value="$(arg use_gpu)" />
     <param name="use_fast_pcl" value="$(arg use_fast_pcl)" />
     <param name="use_openmp" value="$(arg use_openmp)" />

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_mapping/ndt_mapping.cpp
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_mapping/ndt_mapping.cpp
@@ -892,7 +892,7 @@ int main(int argc, char** argv)
   std::cout << "use_imu: " << _use_imu << std::endl;
   std::cout << "use_gpu: " << _use_gpu << std::endl;
   std::cout << "use_openmp: " << _use_openmp << std::endl;
-  std::cout << "use_fast_pcl: " << _use_openmp << std::endl;
+  std::cout << "use_fast_pcl: " << _use_fast_pcl << std::endl;
   std::cout << "imu_upside_down: " << _imu_upside_down << std::endl;
   std::cout << "use_odom: " << _use_odom << std::endl;
   std::cout << "imu_topic: " << _imu_topic << std::endl;


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fix the illegal gpu memory access error in ndt_mapping gpu, which causes ndt_mapping crash as reported in autowarefoundation/autoware_ai#1082 

## Related PRs
List related PRs against other branches:
autowarefoundation/autoware#878 

## Todos
- [X] Tests
- [X] Documentation


## Steps to Test or Reproduce
1. Check Use Fast PCL and Use GPU from the app button next to ndt_mapping in the computing tab of runtime manager
1. launch ndt_mapping
1. Play rosbag including points_raw topic