### PR TITLE
NDT support CUDA 9.0 #1009

### DIFF
--- a/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/include/fast_pcl/ndt_gpu/common.h
+++ b/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/include/fast_pcl/ndt_gpu/common.h
@@ -15,3 +15,9 @@
 
 #define SHARED_MEM_SIZE 3072
 #endif
+
+//  This is the temploary patch for CUDA9 build problem 
+#if ( __CUDACC_VER_MAJOR__ >=9 )
+#undef  __CUDACC_VER__
+#define __CUDACC_VER__ 90000 
+#endif


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
https://github.com/CPFL/Autoware/issues/1009
Build Error with Cuda9 autowarefoundation/autoware_ai#4

## Related PRs
Non

## Todos
- [x] Tests
- [ ] Documentation

Tested with both cuda9 and cuda8

## Steps to Test or Reproduce
Outline the steps to test 


```
ros$ ./catkin_make_release

[100%] Linking CXX executable /home/tandoh/Autoware-Andoh104/ros/devel/lib/points_preprocessor/ray_ground_filter
[100%] Built target ray_ground_filter
ros$ ./run
```


No build error and run