### PR TITLE
Feature/pacmod apex as timer publisher

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
@@ -8,6 +8,7 @@ if(EXISTS "${AS_MSG_PATH}")
 find_package(
   catkin REQUIRED COMPONENTS
   roscpp
+  message_filters
   std_msgs
   geometry_msgs
   module_comm_msgs

--- a/ros/src/actuation/vehicles/packages/as/launch/as_interface.launch
+++ b/ros/src/actuation/vehicles/packages/as/launch/as_interface.launch
@@ -7,9 +7,9 @@
 	<arg name="use_curvature_cmd" default="true"/>
 
 	<node pkg="as" type="as_interface" name="as_interface" output="log">
-		<param name="acceleration_limit" value="$(arg acceleration_limit)"/>
-		<param name="deceleration_limit" value="$(arg deceleration_limit)"/>
-		<param name="max_curvature_rate" value="$(arg max_curvature_rate)"/>
+		<param name="acceleration_limit" value="$(arg acceleration_limit)" />
+		<param name="deceleration_limit" value="$(arg deceleration_limit)" />
+		<param name="max_curvature_rate" value="$(arg max_curvature_rate)" />
 		<param name="use_curvature_cmd" value="$(arg use_curvature_cmd)" />
 	</node>
 

--- a/ros/src/actuation/vehicles/packages/as/launch/as_interface.launch
+++ b/ros/src/actuation/vehicles/packages/as/launch/as_interface.launch
@@ -4,13 +4,13 @@
 	<arg name="acceleration_limit" default="3.0"/>
 	<arg name="deceleration_limit" default="6.0"/>
 	<arg name="max_curvature_rate" default="0.75"/>
-	<arg name="useCurvatureCmd" default="true"/>
+	<arg name="use_curvature_cmd" default="true"/>
 
 	<node pkg="as" type="as_interface" name="as_interface" output="log">
 		<param name="acceleration_limit" value="$(arg acceleration_limit)"/>
 		<param name="deceleration_limit" value="$(arg deceleration_limit)"/>
 		<param name="max_curvature_rate" value="$(arg max_curvature_rate)"/>
-		<param name="useCurvatureCmd" value="$(arg useCurvatureCmd)" />
+		<param name="use_curvature_cmd" value="$(arg use_curvature_cmd)" />
 	</node>
 
 </launch>

--- a/ros/src/actuation/vehicles/packages/as/launch/as_interface.launch
+++ b/ros/src/actuation/vehicles/packages/as/launch/as_interface.launch
@@ -5,12 +5,16 @@
 	<arg name="deceleration_limit" default="6.0"/>
 	<arg name="max_curvature_rate" default="0.75"/>
 	<arg name="use_curvature_cmd" default="true"/>
+	<arg name="use_timer_publisher" default="false"/>
+	<arg name="publish_frequency" default="10.0"/>
 
 	<node pkg="as" type="as_interface" name="as_interface" output="log">
 		<param name="acceleration_limit" value="$(arg acceleration_limit)" />
 		<param name="deceleration_limit" value="$(arg deceleration_limit)" />
 		<param name="max_curvature_rate" value="$(arg max_curvature_rate)" />
 		<param name="use_curvature_cmd" value="$(arg use_curvature_cmd)" />
+		<param name="use_timer_publisher" value="$(arg use_timer_publisher)" />
+		<param name="publish_frequency" value="$(arg publish_frequency)" />
 	</node>
 
 </launch>

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
@@ -153,10 +153,10 @@ void PacmodInterface::publishToPacmod()
   turn_signal_pub_.publish(turn_signal);
   gear_pub_.publish(gear_comm);
 
-  std::cout << "mode: " << speed_mode.mode << std::endl;
-  std::cout << "speed: " << speed_mode.speed << std::endl;
-  std::cout << "steer: " << steer_mode.curvature << std::endl;
-  std::cout << "gear: " << gear_comm.command.gear << std::endl;
+  ROS_INFO_STREAM("mode: " << speed_mode.mode << ", "
+                           << "speed: " << speed_mode.speed << ", "
+                           << "steer: " << steer_mode.curvature << ", "
+                           << "gear: " << (int)gear_comm.command.gear);
 }
 
 }  // pacmod

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
@@ -44,6 +44,7 @@
 
 #include <dbw_mkz_msgs/SteeringReport.h>
 #include <autoware_msgs/CurvatureCommandStamped.h>
+#include <autoware_msgs/lamp_cmd.h>
 
 namespace pacmod
 {
@@ -73,6 +74,7 @@ private:
   ros::Subscriber control_mode_sub_;
   ros::Subscriber speed_sub_;
   ros::Subscriber curvature_cmd_sub_;
+  ros::Subscriber lamp_cmd_sub_;
 
   // timer
   ros::Timer pacmod_timer_;
@@ -93,6 +95,7 @@ private:
   double speed_ = 0.0;
   double curvature_ = 0.0;
   std_msgs::Header header_;
+  autoware_msgs::lamp_cmd lamp_cmd_;
 
   // callbacks
   void callbackFromCurvatureCmd(const autoware_msgs::CurvatureCommandStampedConstPtr& msg);
@@ -100,6 +103,7 @@ private:
   void callbackFromControlMode(const std_msgs::BoolConstPtr& msg);
   void callbackFromSteeringReport(const dbw_mkz_msgs::SteeringReportConstPtr& msg);
   void callbackPacmodTimer(const ros::TimerEvent& event);
+  void callbackFromLampCmd(const autoware_msgs::lamp_cmdConstPtr& msg);
 
   // publisher
   void publishToPacmod();

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
@@ -38,6 +38,7 @@
 #include <geometry_msgs/TwistStamped.h>
 #include <module_comm_msgs/SteerMode.h>
 #include <module_comm_msgs/SpeedMode.h>
+#include <module_comm_msgs/VelocityAccel.h>
 #include <platform_comm_msgs/TurnSignalCommand.h>
 #include <platform_comm_msgs/GearCommand.h>
 #include <platform_comm_msgs/Gear.h>
@@ -67,7 +68,7 @@ private:
   ros::Publisher turn_signal_pub_;
   ros::Publisher gear_pub_;
 
-  ros::Publisher current_twist_pub_;
+  ros::Publisher velocity_pub_;
 
   // subscriber
   ros::Subscriber twist_cmd_sub_;
@@ -101,7 +102,7 @@ private:
   void callbackFromCurvatureCmd(const autoware_msgs::CurvatureCommandStampedConstPtr& msg);
   void callbackFromTwistCmd(const geometry_msgs::TwistStampedConstPtr& msg);
   void callbackFromControlMode(const std_msgs::BoolConstPtr& msg);
-  void callbackFromSteeringReport(const dbw_mkz_msgs::SteeringReportConstPtr& msg);
+  void callbackFromVelocityAccel(const module_comm_msgs::VelocityAccelConstPtr& msg);
   void callbackPacmodTimer(const ros::TimerEvent& event);
   void callbackFromLampCmd(const autoware_msgs::lamp_cmdConstPtr& msg);
 

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
@@ -77,16 +77,16 @@ private:
   double acceleration_limit_;
   double deceleration_limit_;
   double max_curvature_rate_;
-  bool   use_curvature_cmd_;
+  bool use_curvature_cmd_;
 
   // variables
   bool control_mode_;
 
   // callbacks
-  void callbackFromCurvatureCmd(const autoware_msgs::CurvatureCommandStamped &msg);
-  void callbackFromTwistCmd(const geometry_msgs::TwistStampedConstPtr &msg);
-  void callbackFromControlMode(const std_msgs::BoolConstPtr &msg);
-  void callbackFromSteeringReport(const dbw_mkz_msgs::SteeringReportConstPtr &msg);
+  void callbackFromCurvatureCmd(const autoware_msgs::CurvatureCommandStamped& msg);
+  void callbackFromTwistCmd(const geometry_msgs::TwistStampedConstPtr& msg);
+  void callbackFromControlMode(const std_msgs::BoolConstPtr& msg);
+  void callbackFromSteeringReport(const dbw_mkz_msgs::SteeringReportConstPtr& msg);
 
   // initializer
   void initForROS();

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
@@ -74,11 +74,16 @@ private:
   ros::Subscriber speed_sub_;
   ros::Subscriber curvature_cmd_sub_;
 
+  // timer
+  ros::Timer pacmod_timer_;
+
   // ros param
   double acceleration_limit_;
   double deceleration_limit_;
   double max_curvature_rate_;
   bool use_curvature_cmd_;
+  bool use_timer_publisher_;
+  double publish_frequency_;
 
   // constants
   static constexpr double minimum_linear_x_ = 1e-6;
@@ -94,7 +99,8 @@ private:
   void callbackFromTwistCmd(const geometry_msgs::TwistStampedConstPtr& msg);
   void callbackFromControlMode(const std_msgs::BoolConstPtr& msg);
   void callbackFromSteeringReport(const dbw_mkz_msgs::SteeringReportConstPtr& msg);
-  
+  void callbackPacmodTimer(const ros::TimerEvent& event);
+
   // publisher
   void publishToPacmod();
 

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
@@ -34,6 +34,7 @@
 // ROS includes
 #include <ros/ros.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Header.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <module_comm_msgs/SteerMode.h>
 #include <module_comm_msgs/SpeedMode.h>
@@ -79,14 +80,23 @@ private:
   double max_curvature_rate_;
   bool use_curvature_cmd_;
 
+  // constants
+  static constexpr double minimum_linear_x_ = 1e-6;
+
   // variables
-  bool control_mode_;
+  bool control_mode_ = false;
+  double speed_ = 0.0;
+  double curvature_ = 0.0;
+  std_msgs::Header header_;
 
   // callbacks
-  void callbackFromCurvatureCmd(const autoware_msgs::CurvatureCommandStamped& msg);
+  void callbackFromCurvatureCmd(const autoware_msgs::CurvatureCommandStampedConstPtr& msg);
   void callbackFromTwistCmd(const geometry_msgs::TwistStampedConstPtr& msg);
   void callbackFromControlMode(const std_msgs::BoolConstPtr& msg);
   void callbackFromSteeringReport(const dbw_mkz_msgs::SteeringReportConstPtr& msg);
+  
+  // publisher
+  void publishToPacmod();
 
   // initializer
   void initForROS();

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface_node.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface_node.cpp
@@ -33,7 +33,7 @@
 
 #include "as_interface.h"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ros::init(argc, argv, "as_interface");
   pacmod::PacmodInterface pacmod_interface;

--- a/ros/src/computing/perception/localization/packages/deadreckoner/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(deadreckoner)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+  nav_msgs
+  geometry_msgs
+)
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES deadreckoner
+#  CATKIN_DEPENDS other_catkin_pkg
+#  DEPENDS system_lib
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(deadreckoner
+  nodes/deadreckoner_node.cpp
+  nodes/deadreckoner.cpp
+)
+
+target_link_libraries(deadreckoner
+  ${catkin_LIBRARIES}
+)

--- a/ros/src/computing/perception/localization/packages/deadreckoner/launch/deadreckoner.launch
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/launch/deadreckoner.launch
@@ -1,0 +1,12 @@
+<!-- -->
+<launch>
+
+  <arg name="current_twist" default="current_twist" />
+  <arg name="current_odom" default="odom_pose" />
+
+  <node pkg="deadreckoner" type="deadreckoner" name="deadreckoner" output="screen">
+    <remap from="current_twist" to="$(arg current_twist)" />
+    <remap from="current_odom" to="$(arg current_odom)" />
+  </node>
+
+</launch>

--- a/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.cpp
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2017, Nagoya University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Autoware nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "deadreckoner.h"
+
+DeadRecokner::DeadRecokner() : nh_(), private_nh_("~")
+{
+  twist_sub_ = nh_.subscribe("current_twist", 10, &DeadRecokner::callbackFromCurrentTwist, this);
+  odom_pub_ = nh_.advertise<nav_msgs::Odometry>("current_odom", 10);
+}
+
+DeadRecokner::~DeadRecokner()
+{
+}
+
+void DeadRecokner::callbackFromCurrentTwist(const geometry_msgs::TwistStampedConstPtr& msg)
+{
+  // TODO: calurate odom.pose.pose by accumulating
+  nav_msgs::Odometry odom;
+  odom.header = msg->header;
+  odom.twist.twist = msg->twist;
+  odom_pub_ .publish(odom);
+}

--- a/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.h
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2017, Nagoya University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Autoware nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"geometry
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef DEADRECKONER_H
+#define DEADRECKONER_H
+
+#include <ros/ros.h>
+#include <nav_msgs/Odometry.h>
+#include <geometry_msgs/TwistStamped.h>
+
+class DeadRecokner
+{
+public:
+  DeadRecokner();
+  ~DeadRecokner();
+private:
+  ros::NodeHandle nh_, private_nh_;
+  ros::Subscriber twist_sub_;
+  ros::Publisher odom_pub_;
+  
+  void callbackFromCurrentTwist(const geometry_msgs::TwistStampedConstPtr& msg);
+};
+#endif  // DEADRECKONER_H

--- a/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner_node.cpp
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner_node.cpp
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2017, Nagoya University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Autoware nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <ros/ros.h>
+
+#include "deadreckoner.h"
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "deadreckoner");
+  DeadRecokner node;
+  ros::spin();
+  return 0;
+}

--- a/ros/src/computing/perception/localization/packages/deadreckoner/package.xml
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package>
+  <name>deadreckoner</name>
+  <version>0.0.0</version>
+  <description>The deadreckoner package</description>
+
+  <maintainer email="aohsato@gmail.com">Akihito Ohsato</maintainer>
+
+  <license>TODO</license>
+
+  <author email="aohsato@gmail.com">Akihito Ohsato</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+  </export>
+
+</package>

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_matching.launch
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/launch/ndt_matching.launch
@@ -3,9 +3,9 @@
 
   <arg name="use_gnss" default="1" />
   <arg name="use_imu" default="false" />
-  <arg name="use_odom" default="false" />
+  <arg name="use_odom" default="true" />
   <arg name="imu_upside_down" default="false" />
-  <arg name="queue_size" default="10" />
+  <arg name="queue_size" default="1" />
   <arg name="offset" default="linear" />
   <arg name="use_openmp" default="false" />
   <arg name="get_height" default="false" />

--- a/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_matching/ndt_matching.cpp
+++ b/ros/src/computing/perception/localization/packages/ndt_localizer/nodes/ndt_matching/ndt_matching.cpp
@@ -1111,8 +1111,8 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     estimated_vel_mps.data = current_velocity;
     estimated_vel_kmph.data = current_velocity * 3.6;
 
-    estimated_vel_mps_pub.publish(estimated_vel_mps);
-    estimated_vel_kmph_pub.publish(estimated_vel_kmph);
+    //estimated_vel_mps_pub.publish(estimated_vel_mps);
+    //estimated_vel_kmph_pub.publish(estimated_vel_kmph);
 
     // Set values for publishing pose
     predict_q.setRPY(predict_pose.roll, predict_pose.pitch, predict_pose.yaw);
@@ -1154,7 +1154,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     predict_pose_imu_msg.pose.orientation.y = predict_q_imu.y();
     predict_pose_imu_msg.pose.orientation.z = predict_q_imu.z();
     predict_pose_imu_msg.pose.orientation.w = predict_q_imu.w();
-    predict_pose_imu_pub.publish(predict_pose_imu_msg);
+    //predict_pose_imu_pub.publish(predict_pose_imu_msg);
 
     tf::Quaternion predict_q_odom;
     predict_q_odom.setRPY(predict_pose_odom.roll, predict_pose_odom.pitch, predict_pose_odom.yaw);
@@ -1167,7 +1167,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     predict_pose_odom_msg.pose.orientation.y = predict_q_odom.y();
     predict_pose_odom_msg.pose.orientation.z = predict_q_odom.z();
     predict_pose_odom_msg.pose.orientation.w = predict_q_odom.w();
-    predict_pose_odom_pub.publish(predict_pose_odom_msg);
+    //predict_pose_odom_pub.publish(predict_pose_odom_msg);
 
     tf::Quaternion predict_q_imu_odom;
     predict_q_imu_odom.setRPY(predict_pose_imu_odom.roll, predict_pose_imu_odom.pitch, predict_pose_imu_odom.yaw);
@@ -1180,7 +1180,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     predict_pose_imu_odom_msg.pose.orientation.y = predict_q_imu_odom.y();
     predict_pose_imu_odom_msg.pose.orientation.z = predict_q_imu_odom.z();
     predict_pose_imu_odom_msg.pose.orientation.w = predict_q_imu_odom.w();
-    predict_pose_imu_odom_pub.publish(predict_pose_imu_odom_msg);
+    //predict_pose_imu_odom_pub.publish(predict_pose_imu_odom_msg);
 
     ndt_q.setRPY(ndt_pose.roll, ndt_pose.pitch, ndt_pose.yaw);
     if (_use_local_transform == true)
@@ -1252,7 +1252,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
       localizer_pose_msg.pose.orientation.w = localizer_q.w();
     }
 
-    predict_pose_pub.publish(predict_pose_msg);
+    //predict_pose_pub.publish(predict_pose_msg);
     ndt_pose_pub.publish(ndt_pose_msg);
     // current_pose is published by vel_pose_mux
     //    current_pose_pub.publish(current_pose_msg);
@@ -1286,12 +1286,12 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     estimate_twist_msg.twist.angular.y = 0.0;
     estimate_twist_msg.twist.angular.z = angular_velocity;
 
-    estimate_twist_pub.publish(estimate_twist_msg);
+    //estimate_twist_pub.publish(estimate_twist_msg);
 
     geometry_msgs::Vector3Stamped estimate_vel_msg;
     estimate_vel_msg.header.stamp = current_scan_time;
     estimate_vel_msg.vector.x = current_velocity;
-    estimated_vel_pub.publish(estimate_vel_msg);
+    //estimated_vel_pub.publish(estimate_vel_msg);
 
     // Set values for /ndt_stat
     ndt_stat_msg.header.stamp = current_scan_time;
@@ -1302,11 +1302,11 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     ndt_stat_msg.acceleration = current_accel;
     ndt_stat_msg.use_predict_pose = 0;
 
-    ndt_stat_pub.publish(ndt_stat_msg);
+    //ndt_stat_pub.publish(ndt_stat_msg);
     /* Compute NDT_Reliability */
     ndt_reliability.data = Wa * (exe_time / 100.0) * 100.0 + Wb * (iteration / 10.0) * 100.0 +
                            Wc * ((2.0 - trans_probability) / 2.0) * 100.0;
-    ndt_reliability_pub.publish(ndt_reliability);
+    //ndt_reliability_pub.publish(ndt_reliability);
 
     // Write log
     if (!ofs)
@@ -1316,39 +1316,39 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     }
     static ros::Time start_time = input->header.stamp;
 
-    ofs << input->header.seq << "," << scan_points_num << "," << step_size << "," << trans_eps << "," << std::fixed
-        << std::setprecision(5) << current_pose.x << "," << std::fixed << std::setprecision(5) << current_pose.y << ","
-        << std::fixed << std::setprecision(5) << current_pose.z << "," << current_pose.roll << "," << current_pose.pitch
-        << "," << current_pose.yaw << "," << predict_pose.x << "," << predict_pose.y << "," << predict_pose.z << ","
-        << predict_pose.roll << "," << predict_pose.pitch << "," << predict_pose.yaw << ","
-        << current_pose.x - predict_pose.x << "," << current_pose.y - predict_pose.y << ","
-        << current_pose.z - predict_pose.z << "," << current_pose.roll - predict_pose.roll << ","
-        << current_pose.pitch - predict_pose.pitch << "," << current_pose.yaw - predict_pose.yaw << ","
-        << predict_pose_error << "," << iteration << "," << fitness_score << "," << trans_probability << ","
-        << ndt_reliability.data << "," << current_velocity << "," << current_velocity_smooth << "," << current_accel
-        << "," << angular_velocity << "," << time_ndt_matching.data << "," << align_time << "," << getFitnessScore_time
-        << std::endl;
+    // ofs << input->header.seq << "," << scan_points_num << "," << step_size << "," << trans_eps << "," << std::fixed
+    //     << std::setprecision(5) << current_pose.x << "," << std::fixed << std::setprecision(5) << current_pose.y << ","
+    //     << std::fixed << std::setprecision(5) << current_pose.z << "," << current_pose.roll << "," << current_pose.pitch
+    //     << "," << current_pose.yaw << "," << predict_pose.x << "," << predict_pose.y << "," << predict_pose.z << ","
+    //     << predict_pose.roll << "," << predict_pose.pitch << "," << predict_pose.yaw << ","
+    //     << current_pose.x - predict_pose.x << "," << current_pose.y - predict_pose.y << ","
+    //     << current_pose.z - predict_pose.z << "," << current_pose.roll - predict_pose.roll << ","
+    //     << current_pose.pitch - predict_pose.pitch << "," << current_pose.yaw - predict_pose.yaw << ","
+    //     << predict_pose_error << "," << iteration << "," << fitness_score << "," << trans_probability << ","
+    //     << ndt_reliability.data << "," << current_velocity << "," << current_velocity_smooth << "," << current_accel
+    //     << "," << angular_velocity << "," << time_ndt_matching.data << "," << align_time << "," << getFitnessScore_time
+    //     << std::endl;
 
-    std::cout << "-----------------------------------------------------------------" << std::endl;
-    std::cout << "Sequence: " << input->header.seq << std::endl;
-    std::cout << "Timestamp: " << input->header.stamp << std::endl;
-    std::cout << "Frame ID: " << input->header.frame_id << std::endl;
-    //		std::cout << "Number of Scan Points: " << scan_ptr->size() << " points." << std::endl;
-    std::cout << "Number of Filtered Scan Points: " << scan_points_num << " points." << std::endl;
-    std::cout << "NDT has converged: " << has_converged << std::endl;
-    std::cout << "Fitness Score: " << fitness_score << std::endl;
-    std::cout << "Transformation Probability: " << trans_probability << std::endl;
-    std::cout << "Execution Time: " << exe_time << " ms." << std::endl;
-    std::cout << "Number of Iterations: " << iteration << std::endl;
-    std::cout << "NDT Reliability: " << ndt_reliability.data << std::endl;
-    std::cout << "(x,y,z,roll,pitch,yaw): " << std::endl;
-    std::cout << "(" << current_pose.x << ", " << current_pose.y << ", " << current_pose.z << ", " << current_pose.roll
-              << ", " << current_pose.pitch << ", " << current_pose.yaw << ")" << std::endl;
-    std::cout << "Transformation Matrix: " << std::endl;
-    std::cout << t << std::endl;
-    std::cout << "Align time: " << align_time << std::endl;
-    std::cout << "Get fitness score time: " << getFitnessScore_time << std::endl;
-    std::cout << "-----------------------------------------------------------------" << std::endl;
+    // std::cout << "-----------------------------------------------------------------" << std::endl;
+    // std::cout << "Sequence: " << input->header.seq << std::endl;
+    // std::cout << "Timestamp: " << input->header.stamp << std::endl;
+    // std::cout << "Frame ID: " << input->header.frame_id << std::endl;
+    // //		std::cout << "Number of Scan Points: " << scan_ptr->size() << " points." << std::endl;
+    // std::cout << "Number of Filtered Scan Points: " << scan_points_num << " points." << std::endl;
+    // std::cout << "NDT has converged: " << has_converged << std::endl;
+    // std::cout << "Fitness Score: " << fitness_score << std::endl;
+    // std::cout << "Transformation Probability: " << trans_probability << std::endl;
+    // std::cout << "Execution Time: " << exe_time << " ms." << std::endl;
+    // std::cout << "Number of Iterations: " << iteration << std::endl;
+    // std::cout << "NDT Reliability: " << ndt_reliability.data << std::endl;
+    // std::cout << "(x,y,z,roll,pitch,yaw): " << std::endl;
+    // std::cout << "(" << current_pose.x << ", " << current_pose.y << ", " << current_pose.z << ", " << current_pose.roll
+    //           << ", " << current_pose.pitch << ", " << current_pose.yaw << ")" << std::endl;
+    // std::cout << "Transformation Matrix: " << std::endl;
+    // std::cout << t << std::endl;
+    // std::cout << "Align time: " << align_time << std::endl;
+    // std::cout << "Get fitness score time: " << getFitnessScore_time << std::endl;
+    // std::cout << "-----------------------------------------------------------------" << std::endl;
 
     // Update offset
     if (_offset == "linear")

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.cpp
@@ -48,6 +48,7 @@ PurePursuitNode::PurePursuitNode()
   , const_velocity_(5.0)
   , lookahead_distance_ratio_(2.0)
   , minimum_lookahead_distance_(6.0)
+  , curvature_shift_(0.0)
 {
   initForROS();
 
@@ -104,6 +105,8 @@ void PurePursuitNode::run()
 
     double kappa = 0;
     bool can_get_curvature = pp_.canGetCurvature(&kappa);
+    kappa += curvature_shift_;  // tuning for each vehicle
+
     publishTwistStamped(can_get_curvature, kappa);
     publishControlCommandStamped(can_get_curvature, kappa);
     publishCurvatureCommandStamped(can_get_curvature, kappa);
@@ -184,6 +187,7 @@ void PurePursuitNode::callbackFromConfig(const autoware_msgs::ConfigWaypointFoll
   const_velocity_ = config->velocity;
   lookahead_distance_ratio_ = config->lookahead_ratio;
   minimum_lookahead_distance_ = config->minimum_lookahead_distance;
+  curvature_shift_ = config->curvature_shift;
   is_config_set_ = true;
 }
 

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.h
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.h
@@ -97,6 +97,7 @@ private:
   double const_velocity_;            // km/h
   double lookahead_distance_ratio_;
   double minimum_lookahead_distance_;  // the next waypoint must be outside of this threshold.
+  double curvature_shift_;  // radian/meter
 
   // callbacks
   void callbackFromConfig(const autoware_msgs::ConfigWaypointFollowerConstPtr &config);

--- a/ros/src/msgs/autoware_msgs/msg/ConfigWaypointFollower.msg
+++ b/ros/src/msgs/autoware_msgs/msg/ConfigWaypointFollower.msg
@@ -6,3 +6,4 @@ float32 lookahead_ratio
 float32 minimum_lookahead_distance
 float32 displacement_threshold
 float32 relative_angle_threshold
+float32 curvature_shift

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -1645,6 +1645,12 @@ params :
       min   : 0
       max   : 90
       v     : 0
+    - name  : curvature_shift
+      desc  : curvature_shift desc sample
+      label : curvature_shift
+      min   : -0.1
+      max   : 0.1
+      v     : 0
     - name    : is_linear_interpolation
       desc    : linear_interpolate_mode desc sample
       label   : 'Linear Interpolation'


### PR DESCRIPTION
## Status
** DEVELOPMENT**

## Description
This change enables publishing at a constant cycle regardless of the update of input topics.
For example, even when the update of the self-position estimate is delayed, the control command to the row-level controller is updated at the specified cycle.

## Steps to Test or Reproduce
1. Launch this node with `use_timer_publisher` option.

```
$ roslaunch as as_interface.launch use_timer_publisher:=true
```

1. Check topics

```
$ rostopic hz /as/arbitrated_speed_commands
subscribed to [/as/arbitrated_speed_commands]
average rate: 10.001
	min: 0.096s max: 0.105s std dev: 0.00234s window: 10
average rate: 10.007
	min: 0.096s max: 0.105s std dev: 0.00231s window: 20
average rate: 10.005
	min: 0.096s max: 0.105s std dev: 0.00225s window: 30
```