### PR TITLE
add checkbox for IDS UI-3060CP

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -58,6 +58,10 @@ subs :
         desc : Baumer VLG-22 desc sample
         probe:
         run  : roslaunch vlg22c_cam baumer.launch
+      - name : IDS UI-3060CP
+        desc : IDS UI-3060CP
+        probe:
+        run  : roslaunch ueye nodelets.launch
 
   - name : GNSS
     desc : GNSS desc sample

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -59,7 +59,7 @@ subs :
         probe:
         run  : roslaunch vlg22c_cam baumer.launch
       - name : IDS UI-3060CP
-        desc : IDS UI-3060CP
+        desc : IDS UI-3060CP (Requires official ueye package)
         probe:
         run  : roslaunch ueye nodelets.launch
 


### PR DESCRIPTION
## Status
DEVELOPMENT

## Description
Adds support to ueye from IDS Imaging cameras using the ueye ros package (http://wiki.ros.org/ueye) in Runtime Manager in the sensing tab. autowarefoundation/autoware_ai#46 

Added checkbox for IDS UI-3060CP camera.

### Pre requisites to use the checkbox
- Install the IDS SDK in advance from [here](https://en.ids-imaging.com/download-ueye-lin64.html).

**The SDK only supports Linux kernel version higher than 3.4 so the camera node works on Ubuntu 16.04 + ROS Kinetic without the need of a kernel upgrade**

For more details, visit the author's website in http://wiki.ros.org/ueye

## Todos
- [x] Tests
- [x] Documentation

## Steps to Test or Reproduce
1. Download and install the SDK from [here](https://en.ids-imaging.com/download-ueye-lin64.html).
1. Install the ROS package for the IDS camera
$ sudo apt-get install ros-kinetic-ueye`
1. Start camera service (only have to do it once.)
`$ sudo /etc/init.d/ueyeusbdrc start`
1. Check camera operation (if necessary)
`$ idscameramanager` 
1. Assign unique ids to each camera (if necessary)
`$ sudo ueyesetid'
1. Launch the ROS node
    - From Runtime Manager: Clicking the checkbox next to `IDS UI-3060CP`
    - From Terminal: `$ roslaunch ueye nodelets.launch`
