### PR TITLE
[fix] waypoint velocity error and sick cmake warning

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_velocity_visualizer/waypoint_velocity_visualizer.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_velocity_visualizer/waypoint_velocity_visualizer.cpp
@@ -193,7 +193,11 @@ void WaypointVelocityVisualizer::deleteMarkers()
 {
   velocity_marker_array_.markers.clear();
   visualization_msgs::Marker marker;
+#ifndef ROS_KINETIC
+  marker.action = visualization_msgs::Marker::DELETE;
+#else
   marker.action = visualization_msgs::Marker::DELETEALL;
+#endif
   velocity_marker_array_.markers.push_back(marker);
   velocity_marker_pub_.publish(velocity_marker_array_);
 }

--- a/ros/src/sensing/drivers/lidar/packages/sick/package.xml
+++ b/ros/src/sensing/drivers/lidar/packages/sick/package.xml
@@ -10,7 +10,8 @@
 
   <url type="website">https://github.com/pangfumin/lms511_laser</url>
 
-  <build_depend>catkin</build_depend>
+  <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
 


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
This PR fixes autowarefoundation/autoware_ai#44 and autowarefoundation/autoware_ai#45 introduced by autowarefoundation/autoware#1043 and autowarefoundation/autoware#1054 respectively.

## Related PRs
autowarefoundation/autoware#1043 New Velocity Visualizer using undefined `DELETEALL` in visualization_msgs::Marker on Indigo.
autowarefoundation/autoware#1054 Using incorrectly `build_depend` instead of `buildtool_depend`

## Todos
- [X] Tests
  - [X] Ubuntu 14.04
  - [x] Ubuntu 16.04

## Steps to Test or Reproduce
1. Checkout this branch
2. Compile normally using catkin_make, both issues should  be resolved.
