### PR TITLE
Explicit check for GREEN traffic light in decision maker

### DIFF
--- a/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
+++ b/ros/src/computing/perception/detection/packages/road_wizard/nodes/feat_proj/feat_proj.cpp
@@ -310,8 +310,8 @@ void read_signaldata(const char *filename, std::vector<Signal>&ret)
 {
   int max_id;
   Tbl tbl = read_csv(filename, &max_id);
-  size_t i, n = tbl.size();\
-  std::cout << "n: " << n << "\n";
+  size_t i, n = tbl.size();
+
   for (i=0; i<n; i++) {
     Signal signal;
     int id = std::stoi(tbl[i][0]);
@@ -418,8 +418,6 @@ void echoSignals2(ros::Publisher &pub, bool useOpenGLCoord = false) {
 	}
 	signalsInFrame.header.stamp = ros::Time::now();
 	pub.publish(signalsInFrame);
-
-	std::cout << "There are " << signalsInFrame.Signals.size() << " signals in range" << std::endl;
 }
 
 

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
@@ -111,11 +111,11 @@ void DecisionMakerNode::callbackFromConfig(const autoware_msgs::ConfigDecisionMa
 }
 
 void DecisionMakerNode::callbackFromLightColor(const ros::MessageEvent<autoware_msgs::traffic_light const> &event)
-{    
+{
   const autoware_msgs::traffic_light *light = event.getMessage().get();
 //  const ros::M_string &header = event.getConnectionHeader();
 //  std::string topic = header.at("topic"); 
-  
+
   if(!isManualLight){// && topic.find("manage") == std::string::npos){
 	  current_traffic_light_ = light->traffic_light;
 	  if (current_traffic_light_ == state_machine::E_RED || current_traffic_light_ == state_machine::E_YELLOW)
@@ -123,11 +123,15 @@ void DecisionMakerNode::callbackFromLightColor(const ros::MessageEvent<autoware_
 		  ctx->setCurrentState(state_machine::DRIVE_BEHAVIOR_TRAFFICLIGHT_RED_STATE);
 		  ctx->disableCurrentState(state_machine::DRIVE_BEHAVIOR_TRAFFICLIGHT_GREEN_STATE);
 	  }
-	  else
+	  else if (current_traffic_light_ == state_machine::E_GREEN)
 	  {
 		  ctx->setCurrentState(state_machine::DRIVE_BEHAVIOR_TRAFFICLIGHT_GREEN_STATE);
 		  ctx->disableCurrentState(state_machine::DRIVE_BEHAVIOR_TRAFFICLIGHT_RED_STATE);
 	  }
+         else // fall back else
+         {
+                 // this will not update the state, which means the previous state will be continued
+         }
   }
 }
 

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -2439,6 +2439,24 @@ params :
         dash         : ''
         delim        : ':='
         only_enable  : True
+    - name      : network_definition_file
+      desc      : network_definition json file
+      label     : network_definition json file
+      kind      : path
+      path_type : multi
+      v         : /tmp/network_definition.json
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name      : pretrained_model_file
+      desc      : pretrained_model params file
+      label     : pretrained_model params file
+      kind      : path
+      path_type : multi
+      v         : /tmp/network_definition.params
+      cmd_param :
+        dash        : ''
+        delim       : ':='
 
   - name : region_tlr_ssd
     vars :


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
- Added explicit "GREEN" traffic light check in decision maker
- "UNKNOWN" signal keeps the previous state in decision maker
- added dialogue boxes to load traffic detection models in runtime manager

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce
When the traffic light changes from "RED" --> "UNKNOWN", the car should not move, but stay in the red light state.