### PR TITLE
[update] Hokuyo 2D driver update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See also [branching_model](https://github.com/CPFL/Autoware/blob/master/docs/en/
 
 ```
 % sudo apt-get install ros-indigo-desktop-full ros-indigo-nmea-msgs ros-indigo-nmea-navsat-driver ros-indigo-sound-play ros-indigo-jsk-visualization ros-indigo-grid-map ros-indigo-gps-common
-% sudo apt-get install ros-indigo-controller-manager ros-indigo-ros-control ros-indigo-ros-controllers ros-indigo-gazebo-ros-control ros-indigo-sicktoolbox ros-indigo-sicktoolbox-wrapper ros-indigo-joystick-drivers ros-indigo-novatel-span-driver
+% sudo apt-get install ros-indigo-controller-manager ros-indigo-ros-control ros-indigo-ros-controllers ros-indigo-gazebo-ros-control ros-indigo-sicktoolbox ros-indigo-sicktoolbox-wrapper ros-indigo-joystick-drivers ros-indigo-novatel-span-driver ros-indigo-urg-node
 % sudo apt-get install libnlopt-dev freeglut3-dev qtbase5-dev libqt5opengl5-dev libssh2-1-dev libarmadillo-dev libpcap-dev gksu libgl1-mesa-dev libglew-dev software-properties-common libyaml-cpp-dev python-flask python-requests
 % sudo add-apt-repository ppa:mosquitto-dev/mosquitto-ppa
 % sudo apt-get install libmosquitto-dev
@@ -67,7 +67,7 @@ See also [branching_model](https://github.com/CPFL/Autoware/blob/master/docs/en/
 ### Install dependencies for Ubuntu 16.04 kinetic
 ```
 % sudo apt-get install ros-kinetic-desktop-full ros-kinetic-nmea-msgs ros-kinetic-nmea-navsat-driver ros-kinetic-sound-play ros-kinetic-jsk-visualization ros-kinetic-grid-map ros-kinetic-gps-common
-% sudo apt-get install ros-kinetic-controller-manager ros-kinetic-ros-control ros-kinetic-ros-controllers ros-kinetic-gazebo-ros-control ros-kinetic-joystick-drivers
+% sudo apt-get install ros-kinetic-controller-manager ros-kinetic-ros-control ros-kinetic-ros-controllers ros-kinetic-gazebo-ros-control ros-kinetic-joystick-drivers ros-kinetic-urg-node
 % sudo apt-get install libnlopt-dev freeglut3-dev qtbase5-dev libqt5opengl5-dev libssh2-1-dev libarmadillo-dev libpcap-dev gksu libgl1-mesa-dev libglew-dev python-wxgtk3.0 software-properties-common libmosquitto-dev libyaml-cpp-dev python-flask python-requests
 ```
 

--- a/ros/src/sensing/drivers/lidar/packages/hokuyo/scripts/hokuyo_3d.launch
+++ b/ros/src/sensing/drivers/lidar/packages/hokuyo/scripts/hokuyo_3d.launch
@@ -1,9 +1,12 @@
 <launch>
-  <arg name="ip" default="192.168.1.10"/>
+  <arg name="ip" default="192.168.0.10"/>
   <arg name="topic_name" default="points_raw"/>
+  <arg name="interlace" default="4"/>
 
   <node name="hokuyo_3d" pkg="hokuyo" type="hokuyo_3d" output="log">
-	<param name="ip" value="$(arg ip)"/>
-	<remap from="hokuyo_cloud2" to="$(arg topic_name)"/>
+    <param name="ip" value="$(arg ip)"/>
+    <param name="interlace" value="$(arg interlace)"/>
+    <remap from="hokuyo_cloud2" to="$(arg topic_name)"/>
+    <remap from="/hokuyo_3d/hokuyo_cloud2" to="$(arg topic_name)"/>
   </node>
 </launch>

--- a/ros/src/sensing/drivers/lidar/packages/hokuyo/scripts/top_urg.launch
+++ b/ros/src/sensing/drivers/lidar/packages/hokuyo/scripts/top_urg.launch
@@ -1,5 +1,30 @@
 <launch>
-  <param name="hokuyo_node/calibrate_time" type="bool" value="false" />
-  <param name="hokuyo_node/port" type="str" value="/dev/ttyACM0" />
-  <node name="hokuyo_node" pkg="hokuyo_node" type="hokuyo_node" />
+
+<!--  When using an IP-connected LIDAR, populate the "ip_address" parameter with the address of the LIDAR.
+      Otherwise, leave it blank. If supported by your LIDAR, you may enable the publish_intensity
+      and/or publish_multiecho options. -->
+
+
+    <arg name="ip_address" default="" />
+    <arg name="serial_port" default="/dev/ttyACM0" />
+    <arg name="serial_baud" default="115200" />
+    <arg name="frame_id" default="laser" />
+    <arg name="calibrate_time" default="true" />
+    <arg name="publish_intensity" default="false" />
+    <arg name="publish_multiecho" default="false" />
+    <arg name="angle_min" default="-1.5707963" />
+    <arg name="angle_max" default="1.5707963" />
+
+    <node name="urg_node" pkg="urg_node" type="urg_node" output="screen">
+        <param name="ip_address" value="$(arg ip_address)"/>
+        <param name="serial_port" value="$(arg serial_port)"/>
+        <param name="serial_baud" value="$(arg serial_baud)"/>
+        <param name="frame_id" value="$(arg frame_id)"/>
+        <param name="calibrate_time" value="$(arg calibrate_time)"/>
+        <param name="publish_intensity" value="$(arg publish_intensity)"/>
+        <param name="publish_multiecho" value="$(arg publish_multiecho)"/>
+        <param name="angle_min" value="$(arg angle_min)"/>
+        <param name="angle_max" value="$(arg angle_max)"/>
+    </node>
+
 </launch>

--- a/ros/src/sensing/drivers/lidar/packages/hokuyo/scripts/top_urg.launch
+++ b/ros/src/sensing/drivers/lidar/packages/hokuyo/scripts/top_urg.launch
@@ -4,6 +4,8 @@
       Otherwise, leave it blank. If supported by your LIDAR, you may enable the publish_intensity
       and/or publish_multiecho options. -->
 
+<!-- Note: when using a USB interface device please make sure the ip_address parameter is empty,
+    otherwise the driver will choose instead the Ethernet interface. -->
 
     <arg name="ip_address" default="" />
     <arg name="serial_port" default="/dev/ttyACM0" />

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/ReadMe_calibration_test.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/ReadMe_calibration_test.txt
@@ -35,7 +35,7 @@ ReadMe.png参照
 		dt: f
 		data: [0.014429, -0.032025, 0.003003, -0.001721]  #camera_calibrationにて求めた行列
 ---param.yaml-end--------------------------------------------------------------------------------------
-2:hokuyo_node、uvc_camera、calibration_of_camera_and_lrfを実行
+2:urg_node、uvc_camera、calibration_of_camera_and_lrfを実行
 	2.1:LRFウィンドウ、カメラ画像ウィンドウが表示される
 3:カメラ、LRFでチェッカーボードを認識し、CALIBRATE(CLICK)をクリックする
 	3.1:LRFにて認識されるとLRFウィンドウにLRF OKと表示されます。

--- a/ros/src/util/packages/data_preprocessor/scripts/top_urg.launch
+++ b/ros/src/util/packages/data_preprocessor/scripts/top_urg.launch
@@ -1,5 +1,30 @@
 <launch>
-  <param name="hokuyo_node/calibrate_time" type="bool" value="false" />
-  <param name="hokuyo_node/port" type="str" value="/dev/ttyACM0" />
-  <node name="hokuyo_node" pkg="hokuyo_node" type="hokuyo_node" />
+
+<!--  When using an IP-connected LIDAR, populate the "ip_address" parameter with the address of the LIDAR.
+      Otherwise, leave it blank. If supported by your LIDAR, you may enable the publish_intensity
+      and/or publish_multiecho options. -->
+
+
+    <arg name="ip_address" default="" />
+    <arg name="serial_port" default="/dev/ttyACM0" />
+    <arg name="serial_baud" default="115200" />
+    <arg name="frame_id" default="laser" />
+    <arg name="calibrate_time" default="true" />
+    <arg name="publish_intensity" default="false" />
+    <arg name="publish_multiecho" default="false" />
+    <arg name="angle_min" default="-1.5707963" />
+    <arg name="angle_max" default="1.5707963" />
+
+    <node name="urg_node" pkg="urg_node" type="urg_node" output="screen">
+        <param name="ip_address" value="$(arg ip_address)"/>
+        <param name="serial_port" value="$(arg serial_port)"/>
+        <param name="serial_baud" value="$(arg serial_baud)"/>
+        <param name="frame_id" value="$(arg frame_id)"/>
+        <param name="calibrate_time" value="$(arg calibrate_time)"/>
+        <param name="publish_intensity" value="$(arg publish_intensity)"/>
+        <param name="publish_multiecho" value="$(arg publish_multiecho)"/>
+        <param name="angle_min" value="$(arg angle_min)"/>
+        <param name="angle_max" value="$(arg angle_max)"/>
+    </node>
+
 </launch>

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -177,7 +177,6 @@ subs :
             flags : [ center_v ]
       - name : Hokuyo 2D URG
         desc : urg_node supports SCIP 2.2 or earlier compliant laser range-finders.
-        probe: 'lsusb -d 15d1: > /dev/null'
         run  : roslaunch hokuyo top_urg.launch
         param: hokuyo_urg
 

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -179,15 +179,20 @@ subs :
         desc : urg_node supports SCIP 2.2 or earlier compliant laser range-finders.
         probe: 'lsusb -d 15d1: > /dev/null'
         run  : roslaunch hokuyo top_urg.launch
+        param: hokuyo_urg
+
       - name : Hokuyo 3D-URG
         desc : Hokuyo 3D-URG desc sample
         probe:
         run  : roslaunch hokuyo hokuyo_3d.launch
+        param: hokuyo_3d
+
       - name : Sick LMS511
         desc : Initializes the Sick LMS511 driver
         probe:
         run  : roslaunch sick_driver lms511.launch
         param: sick_lms511
+
       - name : IBEO 8L Single
         desc : IBEO 8L Single desc sample
         probe:
@@ -936,6 +941,103 @@ params :
       label : output_point_topic
       kind  : str
       v     : /points_transformed
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+
+  - name  : hokuyo_urg
+    vars  :
+    - name  : ip_address
+      desc  : IP address if the LiDAR has ethernet interface
+      label : ip_address
+      kind  : str
+      v     : ''
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : serial_port
+      desc  : Serial Port of the LiDAR
+      label : serial_port
+      kind  : str
+      v     : /dev/ttyACM0
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : frame_id
+      desc  : Coordinate frame to publish the scan
+      label : frame_id
+      kind  : str
+      v     : laser
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : calibrate_time
+      desc  : calibrate_time
+      label : calibrate_time
+      kind      : checkbox
+      v         : True
+      cmd_param :
+        dash      : ''
+        delim     : ':='
+    - name  : publish_intensity
+      desc  : Publish intensity value
+      label : publish_intensity
+      kind      : checkbox
+      v         : False
+      cmd_param :
+        dash      : ''
+        delim     : ':='
+    - name  : publish_multiecho
+      desc  : publish multiecho
+      label : publish_multiecho
+      kind      : checkbox
+      v         : False
+      cmd_param :
+        dash      : ''
+        delim     : ':='
+    - name  : angle_min
+      desc  : Minimum angle of the scan
+      label : angle_min
+      min   : -1.57
+      max   : 0
+      v     : -1.57
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : angle_max
+      desc  : Maximum angle of the scan
+      label : angle_max
+      min   : 0
+      max   : 1.57
+      v     : 1.57
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+
+  - name  : hokuyo_3d
+    vars  :
+    - name  : ip
+      desc  : IP address of the LiDAR
+      label : ip
+      kind  : str
+      v     : 192.168.0.10
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : topic_name
+      desc  : Topic name to publish the cloud
+      label : topic_name
+      kind  : str
+      v     : /points_raw
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : interlace
+      desc  : Interlacing value
+      label : interlace
+      min   : 1
+      max   : 10
+      v     : 4
       cmd_param :
         dash        : ''
         delim       : ':='

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -175,8 +175,8 @@ subs :
           calibration :
             prop  : 0
             flags : [ center_v ]
-      - name : Hokuyo TOP-URG
-        desc : Hokuyo TOP-URG desc sample
+      - name : Hokuyo 2D URG
+        desc : urg_node supports SCIP 2.2 or earlier compliant laser range-finders.
         probe: 'lsusb -d 15d1: > /dev/null'
         run  : roslaunch hokuyo top_urg.launch
       - name : Hokuyo 3D-URG


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
This PR solves autowarefoundation/autoware_ai#57 updating the required package to the recent `urg_node` for Hokuyo LiDARs.
Also adds UI configuration for both 2D and 3D drivers.

## Todos
- [x] Tests
- [X] Documentation


## Steps to Test
1. Clone this branch
1. Compile `./catkin_make_release`
1. Launch RTM
1. Connect LiDAR either by serial or ethernet port
1. Launch Hokuyo 2D or Hokuyo 3D from Sensing Tab
1. Launch rviz 
1. Display LaserScan or PointCloud topic

