### PR TITLE
[feature] Grasshopper3 node modified to set the mode and pixel format

### DIFF
--- a/ros/src/sensing/drivers/camera/packages/baumer/README.md
+++ b/ros/src/sensing/drivers/camera/packages/baumer/README.md
@@ -1,7 +1,7 @@
 ## Baumer Package
 
 This package allows to obtain an image stream from Baumer cameras.
-It was testes successfully on a VLG22C.
+It was tested successfully on a VLG22C.
 
 ### Requirements
 

--- a/ros/src/sensing/drivers/camera/packages/baumer/nodes/vlg22/src/vlg22_main.cpp
+++ b/ros/src/sensing/drivers/camera/packages/baumer/nodes/vlg22/src/vlg22_main.cpp
@@ -260,20 +260,22 @@ void adjust_exposure(BGAPI::Camera* camera_pointer,
 
 	if (current_brightness < threshold_brightness)
 	{
-		ROS_INFO("increasing exposure");
-		exposure = prev_exposure + exposure_delta;
-		if (exposure >= VLG22_MAX_EXPOSURE)
-			exposure = VLG22_MAX_EXPOSURE;
-		baumer_change_exposure(camera_pointer, exposure);
+		if (exposure <= VLG22_MAX_EXPOSURE)
+		{
+			exposure = prev_exposure + exposure_delta;
+			ROS_INFO("Increasing exposure");
+			baumer_change_exposure(camera_pointer, exposure);
+		}
 	}
 
 	if (current_brightness == 1.0)
 	{
-		ROS_INFO("reducing exposure");
-		exposure = prev_exposure - exposure_delta;
-		if (exposure <= VLG22_MIN_EXPOSURE)
-			exposure = VLG22_MIN_EXPOSURE;
-		baumer_change_exposure(camera_pointer, exposure);
+		if (exposure >= VLG22_MIN_EXPOSURE)
+		{
+			exposure = prev_exposure - exposure_delta;
+			ROS_INFO("Reducing exposure");
+			baumer_change_exposure(camera_pointer, exposure);
+		}
 	}
 	prev_exposure = exposure;
 }

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/grasshopper3/grasshopper3.cpp
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/grasshopper3/grasshopper3.cpp
@@ -53,16 +53,16 @@
 
 static volatile int running = 1;
 
-static void signalHandler(int)
+static void signal_handler(int)
 {
 	running = 0;
 	ros::shutdown();
 }
 
-void parseCameraInfo(const cv::Mat  &camMat,
-                       const cv::Mat  &disCoeff,
-                       const cv::Size &imgSize,
-                       sensor_msgs::CameraInfo &msg)
+void parse_camera_info(const cv::Mat& camMat,
+                       const cv::Mat& disCoeff,
+                       const cv::Size& imgSize,
+                       sensor_msgs::CameraInfo& msg)
 {
 	msg.header.frame_id = "camera";
 	//  msg.header.stamp    = ros::Time::now();
@@ -102,7 +102,7 @@ void parseCameraInfo(const cv::Mat  &camMat,
 }
 
 
-static void print_camera_info(FlyCapture2::CameraInfo* info)
+void print_camera_info(FlyCapture2::CameraInfo* info)
 {
 	std::cout << "\n*** CAMERA INFORMATION ***\n"
 		  << "\tSerial number       - " << info->serialNumber << "\n"
@@ -115,13 +115,41 @@ static void print_camera_info(FlyCapture2::CameraInfo* info)
 		  << std::endl;
 }
 
-static std::vector<FlyCapture2::Camera*>
-initializeCameras(FlyCapture2::BusManager *bus_manger, int camera_num)
+void print_image_settings(
+		const FlyCapture2::Format7ImageSettings& image_settings,
+		const unsigned int& packet_size,
+		const float& percentage
+	)
+{
+	std::cout << "Image settings: " << std::endl;
+	std::cout << "\tMode: " << image_settings.mode << std::endl;
+	std::cout << "\tPixel Format: 0x" << std::hex << image_settings.pixelFormat << std::dec << std::endl;
+	std::cout << "\tOffset X: " << image_settings.offsetX << std::endl;
+	std::cout << "\tOffset Y: " << image_settings.offsetY << std::endl;
+	std::cout << "\tWidth: " << image_settings.width << std::endl;
+	std::cout << "\tHeight: " << image_settings.height << std::endl;
+	std::cout << "Packet size: " << packet_size << " (" << percentage << "%)" << std::endl;
+}
+
+void print_format7_info(const FlyCapture2::Format7Info& info, bool supported)
+{
+	std::cout << "supported: " << supported << std::endl;
+	std::cout << "mode: " << info.mode << std::endl;
+	std::cout << "maxWidth: " << info.maxWidth << std::endl;
+	std::cout << "maxHeight: " << info.maxHeight << std::endl;
+	std::cout << "packetSize: " << info.packetSize << std::endl;
+	std::cout << "percentage: " << info.percentage << std::endl;
+	std::cout << "pixelFormatBitField: " << info.pixelFormatBitField << std::endl;
+}
+
+void initialize_cameras(std::vector<FlyCapture2::Camera *> &cameras,
+                        FlyCapture2::BusManager *bus_manger,
+                        int camera_num,
+                        FlyCapture2::Mode desired_mode,
+                        FlyCapture2::PixelFormat desired_pixel_format)
 {
 	// Connect to all detected cameras and attempt to set them to
 	// a common video mode and frame rate
-
-	std::vector<FlyCapture2::Camera*> cameras;
 	for (int i = 0; i < camera_num; i++)
 	{
 		FlyCapture2::Camera *camera = new FlyCapture2::Camera();
@@ -149,7 +177,7 @@ initializeCameras(FlyCapture2::BusManager *bus_manger, int camera_num)
 			std::exit(-1);
 		}
 
-		image_info.timestamp.onOff = true;
+		image_info.timestamp.onOff = false;
 		error = camera->SetEmbeddedImageInfo(&image_info);
 		if (error != FlyCapture2::PGRERROR_OK)
 		{
@@ -166,14 +194,92 @@ initializeCameras(FlyCapture2::BusManager *bus_manger, int camera_num)
 			std::exit(-1);
 		}
 
+		//obtain working settings
+		FlyCapture2::VideoMode default_video_mode;
+		FlyCapture2::FrameRate default_frame_rate;
+
+		error = camera->GetVideoModeAndFrameRate(&default_video_mode, &default_frame_rate);
+		if (error != FlyCapture2::PGRERROR_OK)
+		{
+			error.PrintErrorTrace();
+			std::exit(-1);
+		}
+
+		//try to set Format7, according to the desired mode and pixel format.
+		FlyCapture2::Format7ImageSettings image_settings;
+		bool supported = false;
+		unsigned int packet_size;
+		float percentage;
+
+		FlyCapture2::Format7Info format7_info;
+		format7_info.mode = desired_mode;
+
+		error = camera->GetFormat7Info(&format7_info, &supported);
+		if (error != FlyCapture2::PGRERROR_OK)
+		{
+			error.PrintErrorTrace();
+			std::exit(-1);
+		}
+
+		print_format7_info(format7_info, supported);
+
+		if (supported)
+		{
+			error = camera->GetFormat7Configuration(&image_settings, &packet_size, &percentage);
+			if (error != FlyCapture2::PGRERROR_OK)
+			{
+				error.PrintErrorTrace();
+				std::exit(-1);
+			}
+
+			image_settings.mode = desired_mode;
+			image_settings.pixelFormat = desired_pixel_format;
+			image_settings.offsetX = 0;
+			image_settings.offsetY = 0;
+			image_settings.width = format7_info.maxWidth;
+			image_settings.height = format7_info.maxHeight;
+
+			FlyCapture2::Format7PacketInfo packet_info;
+			bool valid_settings = false;
+			error = camera->ValidateFormat7Settings(&image_settings, &valid_settings, &packet_info);
+			if (error != FlyCapture2::PGRERROR_OK)
+			{
+				error.PrintErrorTrace();
+				std::exit(-1);
+			}
+			packet_size = packet_info.recommendedBytesPerPacket;
+			error = camera->SetFormat7Configuration(&image_settings, packet_size);
+			if (error != FlyCapture2::PGRERROR_OK)
+			{
+				error.PrintErrorTrace();
+				std::exit(-1);
+			}
+
+			error = camera->GetFormat7Configuration(&image_settings, &packet_size, &percentage);
+			if (error != FlyCapture2::PGRERROR_OK)
+			{
+				error.PrintErrorTrace();
+				std::exit(-1);
+			}
+
+			print_image_settings(image_settings, packet_size, percentage);
+		}
+		else
+		{
+			ROS_ERROR("Selected Mode not supported, using last working mode.");
+		}
+
 		print_camera_info(&camera_info);
 		cameras.push_back(camera);
 	}
-
-	return cameras;
 }
 
-static int getNumCameras(FlyCapture2::BusManager *bus_manager)
+/*!
+ * Get the number of cameras connected to the system
+ * @param bus_manager Valid pointer to the BusManager
+ * @return The number of detected cameras
+ */
+unsigned int get_num_cameras(FlyCapture2::BusManager* bus_manager)
 {
 	unsigned int cameras;
 	FlyCapture2::Error error = bus_manager->GetNumOfCameras(&cameras);
@@ -190,11 +296,14 @@ static int getNumCameras(FlyCapture2::BusManager *bus_manager)
 		std::cerr << "Error: This program requires at least 1 camera." << std::endl;
 		std::exit(-1);
 	}
-
-	return static_cast<int>(cameras);
+	return cameras;
 }
 
-static void startCapture(std::vector<FlyCapture2::Camera*>& cameras)
+/*!
+ * Initialize the capture on all the cameras
+ * @param cameras An array of valid pointers to the camera objects
+ */
+void start_capture(std::vector<FlyCapture2::Camera *>& cameras)
 {
 	for (auto *camera : cameras)
 	{
@@ -205,11 +314,14 @@ static void startCapture(std::vector<FlyCapture2::Camera*>& cameras)
 			return;
 		}
 	}
-
-	return;
 }
 
-void getMatricesFromFile(ros::NodeHandle nh, sensor_msgs::CameraInfo &camerainfo_msg)
+/*!
+ * Reads and parses the Autoware calibration file format
+ * @param nh ros node handle
+ * @param camerainfo_msg CameraInfo message to fill
+ */
+void getMatricesFromFile(const ros::NodeHandle& nh, sensor_msgs::CameraInfo &camerainfo_msg)
 {
 	//////////////////CAMERA INFO/////////////////////////////////////////
 	cv::Mat  cameraExtrinsicMat;
@@ -241,7 +353,42 @@ void getMatricesFromFile(ros::NodeHandle nh, sensor_msgs::CameraInfo &camerainfo
 		fs["DistCoeff"] >> distCoeff;
 		fs["ImageSize"] >> imageSize;
 	}
-	parseCameraInfo(cameraMat, distCoeff, imageSize, camerainfo_msg);
+	parse_camera_info(cameraMat, distCoeff, imageSize, camerainfo_msg);
+}
+
+/*!
+ * Reads the params from the console
+ * @param private_nh[in] Private Ros node handle
+ * @param fps[out] Read value from the console
+ * @param mode[out] Read value from the console
+ * @param format[out] Read value from the console
+ */
+void ros_get_params(const ros::NodeHandle& private_nh, int& fps, int& mode, std::string& format)
+{
+	if (private_nh.getParam("fps", fps))
+	{
+		ROS_INFO("fps set to %d", fps);
+	} else {
+		fps = 20;
+		ROS_INFO("No param received, defaulting fps to %d", fps);
+	}
+
+	if (private_nh.getParam("mode", mode))
+	{
+		ROS_INFO("mode set to %d", mode);
+	} else {
+		mode = 0;
+		ROS_INFO("No param received, defaulting mode to %d", mode);
+	}
+
+	if (private_nh.getParam("format", format))
+	{
+		ROS_INFO("format set to %s", format.c_str());
+	} else {
+		format = "raw";
+		ROS_INFO("No param received, defaulting format to %s", format.c_str());
+	}
+
 }
 
 int main(int argc, char **argv)
@@ -249,24 +396,37 @@ int main(int argc, char **argv)
 	////////////////POINT GREY CAMERA /////////////////////////////
 	FlyCapture2::BusManager busMgr;
 
-	int camera_num = getNumCameras(&busMgr);
-	std::vector<FlyCapture2::Camera*> cameras = initializeCameras(&busMgr, camera_num);
-
 	////ROS STUFF////
 	ros::init(argc, argv, "grasshopper3");
 	ros::NodeHandle n;
 	ros::NodeHandle private_nh("~");
 
-	signal(SIGTERM, signalHandler);//detect closing
+	signal(SIGTERM, signal_handler);//detect closing
 
-	double fps;
-	if (private_nh.getParam("fps", fps))
+	int fps, camera_mode;
+	std::string pixel_format;
+
+	ros_get_params(private_nh, fps, camera_mode, pixel_format);
+
+	//
+	FlyCapture2::Mode desired_mode;
+	FlyCapture2::PixelFormat desired_pixel_format;
+
+	desired_mode = (FlyCapture2::Mode)camera_mode;
+
+	if(pixel_format == "rgb")
 	{
-		ROS_INFO("fps set to %.2f", fps);
-	} else {
-		fps = 15.0;
-		ROS_INFO("No param received, defaulting to %.2f", fps);
+		desired_pixel_format = FlyCapture2::PIXEL_FORMAT_RGB8;
 	}
+	else
+	{
+		desired_pixel_format = FlyCapture2::PIXEL_FORMAT_RAW8;
+	}
+
+	//init cameras
+	int camera_num = get_num_cameras(&busMgr);
+	std::vector<FlyCapture2::Camera*> cameras;
+	initialize_cameras(cameras, &busMgr, camera_num, desired_mode, desired_pixel_format);
 
 	///////calibration data
 	sensor_msgs::CameraInfo camerainfo_msg;
@@ -287,7 +447,7 @@ int main(int argc, char **argv)
 		ROS_INFO("Publishing.. %s", topic.c_str());
 	}
 
-	startCapture(cameras);
+	start_capture(cameras);
 
 	std::cout << "Capturing by " << camera_num << " cameras..." << std::endl;
 
@@ -340,8 +500,6 @@ int main(int argc, char **argv)
 			size_t image_size = image.GetDataSize();
 			msg.data.resize(image_size);
 			memcpy(msg.data.data(), image.GetData(), image_size);
-
-
 
 			pub[i].publish(msg);
 			i++;

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/scripts/grasshopper3.launch
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/scripts/grasshopper3.launch
@@ -1,11 +1,15 @@
 <launch>
 
 	<!-- declare arguments with default values -->
-	<arg name="FPS" default="15"/>
-	<arg name="CalibrationFile" default=""/>
+	<arg name="fps" default="20"/>                  <!--frame per second to try to acquire the image -->
+	<arg name="CalibrationFile" default=""/>        <!--Path to Autoware calibration format file-->
+	<arg name="mode" default="0"/>                  <!--Valid Camera Mode -->
+	<arg name="format" default="raw"/>              <!--Pixel Format to acquire the image "raw" or "rgb"-->
 
 	<node pkg="autoware_pointgrey_drivers" type="grasshopper3_camera" name="grasshopper" output="screen">
-		<param name="fps" value="$(arg FPS)"/>
+		<param name="fps" value="$(arg fps)"/>
 		<param name="calibrationfile" value="$(arg CalibrationFile)"/>
+		<param name="mode" value="$(arg mode)"/>
+		<param name="format" value="$(arg format)"/>
 	</node>
 </launch>

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -25,27 +25,19 @@ subs :
         desc : PointGrey Grasshoper 3 (USB1) desc sample
         probe: 'lsusb -d 1e10: > /dev/null'
         run  : roslaunch autoware_pointgrey_drivers grasshopper3.launch
-        param: calibration_path_grasshopper3
-        gui  :
-          CalibrationFile :
-            prop  : 1
-            flags : [ center_v ]
+        param: grasshopper3_params
+
       - name : PointGrey Generic
         desc : PointGrey Generic desc sample
         probe:
         run  : roslaunch pointgrey_camera_driver camera.launch
+
       - name : PointGrey LadyBug 5
         desc : PointGrey LadyBug 5 desc sample
         probe:
         run  : roslaunch autoware_pointgrey_drivers ladybug.launch
-        param: calibration_path_ladybug
-        gui  :
-          CalibrationFile :
-            prop  : 1
-            flags : [ center_v ]
-          Scale :
-            prop  : 1
-            flags : [ center_v ]
+        param: ladybug_params
+
       - name : USB Generic
         desc : USB Generic desc sample
         probe: 'lsusb -v | grep wTerminalType | grep "Camera Sensor" > /dev/null'
@@ -358,27 +350,65 @@ params :
         delim: ':='
         must : True
 
-  - name  : calibration_path_grasshopper3
+  - name  : grasshopper3_params
     vars  :
     - name  : CalibrationFile
-      desc  : CalibrationFile desc sample
+      label : CalibrationFile
+      desc  : Path to Autoware format calibration file
       kind  : path
       v     : ''
       cmd_param :
         dash        : ''
         delim       : ':='
         only_enable : True
-  - name  : calibration_path_ladybug
+    - name  : mode
+      label : mode
+      desc  : Camera mode (0,1,2,3,....). Default 0
+      min   : 0
+      max   : 32
+      v     : 0
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : format
+      label : format
+      desc  : Pixel format ("raw" or "rgb")
+      kind  : str
+      v     : 'raw'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : fps
+      label : fps
+      desc  : Frames per second to try to acquire. Default 20
+      min   : 1
+      max   : 24
+      v     : 20
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+
+  - name  : ladybug_params
     vars  :
+    - name  : SCALE
+      label : SCALE
+      desc  : scale, resize downsample ratio (0.1 - 1.0) Default 0.2
+      min   : 0.1
+      max   : 1.0
+      v     : 0.2
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        only_enable : True
     - name  : CalibrationFile
-      desc  : CalibrationFile desc sample
+      label : CalibrationFile
+      desc  : Path to Autoware format calibration file
       kind  : path
       v     : ''
       cmd_param :
         dash        : ''
         delim       : ':='
         only_enable : True
-        must        : True
 
 #  - name  : points_image
 #    vars  :


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Solves autowarefoundation/autoware_ai#64. Allows to set the desired camera mode and pixel format 

## Todos
- [X] Tests
- [X] Documentation

## Steps to Test or Reproduce
1. Pull this branch
1. Compile using `./catkin_make_release`
1. Install PointGrey SDK FlyCap
1. Make sure your camera works using FlyCap2 app before using this node
1. Launch the node either from a sourced terminal or RTM according to the README file in the package.
i.e. `roslaunch autoware_pointgrey_drivers grasshopper3.launch mode:=1 format:=rgb`
or
`roslaunch autoware_pointgrey_drivers grasshopper3.launch mode:=0 format:=raw`
1. Open rviz
1. Add `image_raw topic`

The camera image should be shown.