### PR TITLE
Suppress compile error

### DIFF
--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_decision.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_decision.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <numeric>
 
 #include <geometry_msgs/PoseStamped.h>
 #include <jsk_rviz_plugins/OverlayText.h>


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
I encounterd compile error like following:
```
Autoware/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_decision.cpp:86:28: error: ‘accumulate’ is not a member of ‘std’
```
And this can be avoided by this modification.

## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce
run
```
catkin_make_release
```
under `Autoware/ros/`.
The compile error should be suppressed.