### PR TITLE
Disable cudaHostRegister on arm64 systems.

### DIFF
--- a/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/include/fast_pcl/ndt_gpu/Registration.h
+++ b/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/include/fast_pcl/ndt_gpu/Registration.h
@@ -9,7 +9,6 @@
 #include "common.h"
 #include <eigen3/Eigen/Dense>
 #include <eigen3/Eigen/Geometry>
-#include <velodyne_pointcloud/point_types.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 

--- a/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/Registration.cu
+++ b/ros/src/computing/perception/localization/lib/fast_pcl/ndt_gpu/src/Registration.cu
@@ -170,7 +170,9 @@ void GRegistration::setInputSource(pcl::PointCloud<pcl::PointXYZI>::Ptr input)
 		pcl::PointXYZI *host_tmp = input->points.data();
 
 		// Pin the host buffer for accelerating the memory copy
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostRegister(host_tmp, sizeof(pcl::PointXYZI) * points_number_, cudaHostRegisterDefault));
+#endif
 
 		checkCudaErrors(cudaMemcpy(tmp, host_tmp, sizeof(pcl::PointXYZI) * points_number_, cudaMemcpyHostToDevice));
 
@@ -228,7 +230,9 @@ void GRegistration::setInputSource(pcl::PointCloud<pcl::PointXYZI>::Ptr input)
 		checkCudaErrors(cudaFree(tmp));
 
 		// Unpin host buffer
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostUnregister(host_tmp));
+#endif
 	}
 }
 
@@ -245,7 +249,9 @@ void GRegistration::setInputSource(pcl::PointCloud<pcl::PointXYZ>::Ptr input)
 		pcl::PointXYZ *host_tmp = input->points.data();
 
 		// Pin the host buffer for accelerating the memory copy
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostRegister(host_tmp, sizeof(pcl::PointXYZ) * points_number_, cudaHostRegisterDefault));
+#endif
 
 		checkCudaErrors(cudaMemcpy(tmp, host_tmp, sizeof(pcl::PointXYZ) * points_number_, cudaMemcpyHostToDevice));
 
@@ -299,7 +305,9 @@ void GRegistration::setInputSource(pcl::PointCloud<pcl::PointXYZ>::Ptr input)
 		checkCudaErrors(cudaMemcpy(trans_z_, z_, sizeof(float) * points_number_, cudaMemcpyDeviceToDevice));
 
 		checkCudaErrors(cudaFree(tmp));
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostUnregister(host_tmp));
+#endif
 	}
 }
 
@@ -317,7 +325,9 @@ void GRegistration::setInputTarget(pcl::PointCloud<pcl::PointXYZI>::Ptr input)
 
 		pcl::PointXYZI *host_tmp = input->points.data();
 
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostRegister(host_tmp, sizeof(pcl::PointXYZI) * target_points_number_, cudaHostRegisterDefault));
+#endif
 
 		checkCudaErrors(cudaMemcpy(tmp, host_tmp, sizeof(pcl::PointXYZI) * target_points_number_, cudaMemcpyHostToDevice));
 
@@ -347,7 +357,9 @@ void GRegistration::setInputTarget(pcl::PointCloud<pcl::PointXYZI>::Ptr input)
 		checkCudaErrors(cudaGetLastError());
 		checkCudaErrors(cudaDeviceSynchronize());
 
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostUnregister(host_tmp));
+#endif
 		checkCudaErrors(cudaFree(tmp));
 	}
 }
@@ -363,7 +375,9 @@ void GRegistration::setInputTarget(pcl::PointCloud<pcl::PointXYZ>::Ptr input)
 
 		pcl::PointXYZ *host_tmp = input->points.data();
 
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostRegister(host_tmp, sizeof(pcl::PointXYZ) * target_points_number_, cudaHostRegisterDefault));
+#endif
 
 		checkCudaErrors(cudaMemcpy(tmp, host_tmp, sizeof(pcl::PointXYZ) * target_points_number_, cudaMemcpyHostToDevice));
 
@@ -394,7 +408,9 @@ void GRegistration::setInputTarget(pcl::PointCloud<pcl::PointXYZ>::Ptr input)
 		checkCudaErrors(cudaDeviceSynchronize());
 
 		checkCudaErrors(cudaFree(tmp));
+#ifndef __aarch64__
 		checkCudaErrors(cudaHostUnregister(host_tmp));
+#endif
 	}
 }
 


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Disable cudaHostRegister() function on arm64 systems to avoid "operation not supported" error described in autowarefoundation/autoware_ai#75 . Need to be tested on drivePx2.

## Related PRs

## Todos
- [x] Tests


## Steps to Test or Reproduce
1. Select "pcl_anh_gpu" from the app button of ndt_mapping.

2. launch ndt_mapping.