### PR TITLE
[fix] Added missing Qt5Core dependency for PCL in autoware_calibration package

### DIFF
--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
@@ -49,7 +49,6 @@ target_link_libraries(autoware_camera_lidar_calibration_node
     ${OpenCV_LIBRARIES}
     ${catkin_LIBRARIES}
     ${PCL_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
 )
 add_dependencies(autoware_camera_lidar_calibration_node ${catkin_EXPORTED_TARGETS})
 

--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
     geometry_msgs
     tf
 )
-
+find_package(Qt5Core REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(PCL)
 
@@ -49,6 +49,7 @@ target_link_libraries(autoware_camera_lidar_calibration_node
     ${OpenCV_LIBRARIES}
     ${catkin_LIBRARIES}
     ${PCL_LIBRARIES}
+    ${Qt5Core_LIBRARIES}
 )
 add_dependencies(autoware_camera_lidar_calibration_node ${catkin_EXPORTED_TARGETS})
 


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fixes error reported in autowarefoundation/autoware_ai#85 as initially mentioned in autowarefoundation/autoware#774 

## Todos
- [X] Tests

## Steps to Test or Reproduce
1. pull this branch
1. compile using ./catkin_make_release

Should be no error