### PR TITLE
[feature] Add timeout to the grasshopper camera node.

### DIFF
--- a/ros/src/sensing/drivers/camera/packages/pointgrey/README.md
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/README.md
@@ -23,6 +23,7 @@ Sensing Tab -> Cameras -> PointGrey Grasshopper3
 |`fps`|*integer* |Defines the frames per second at which to attempt image stream acquisition.|
 |`mode`|*integer*|Camera Mode - please check your camera for valid modes (0,1,2,...,31). |
 |`format`|*string*|Pixel Format, which can be either `raw` or `rgb`. `raw` will publish the default bayer format according to your camera sensor. Both modes have 8 bits per pixel per channel.|
+|`timeout`|*integer*|Timeout in miliseconds. Default 1000 ms.|
 |`CalibrationFile`|*string*|Path to an Autoware-compatible calibration file to be published in the `camera_info` topic related to this camera.|
 
 ## Ladybug

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/scripts/grasshopper3.launch
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/scripts/grasshopper3.launch
@@ -5,11 +5,13 @@
 	<arg name="CalibrationFile" default=""/>        <!--Path to Autoware calibration format file-->
 	<arg name="mode" default="0"/>                  <!--Valid Camera Mode -->
 	<arg name="format" default="raw"/>              <!--Pixel Format to acquire the image "raw" or "rgb"-->
+	<arg name="timeout" default="1000"/>            <!--Timeout in mili seconds-->
 
 	<node pkg="autoware_pointgrey_drivers" type="grasshopper3_camera" name="grasshopper" output="screen">
 		<param name="fps" value="$(arg fps)"/>
 		<param name="calibrationfile" value="$(arg CalibrationFile)"/>
 		<param name="mode" value="$(arg mode)"/>
 		<param name="format" value="$(arg format)"/>
+		<param name="timeout" value="$(arg timeout)"/>
 	</node>
 </launch>

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -399,6 +399,15 @@ params :
       cmd_param :
         dash        : ''
         delim       : ':='
+    - name  : timeout
+      label : timeout
+      desc  : Miliseconds to wait before dropping the frame. Default 1000 ms
+      min   : 10
+      max   : 2000
+      v     : 1000
+      cmd_param :
+        dash        : ''
+        delim       : ':='
 
   - name  : ladybug_params
     vars  :


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Solves autowarefoundation/autoware_ai#90 

If the node cannot read a frame from the camera during the specified time. The frame will be dropped and the node will continue, instead of waiting indefinitely.

## Todos
- [X] Tests
- [X] Documentation

## Steps to Test or Reproduce
1. Pull this branch
1. Compile
1. Run from either the terminal or RTM as specified in README.md