### PR TITLE
Bug/as interface pacmod

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
@@ -152,7 +152,14 @@ void PacmodInterface::publishToPacmod()
   platform_comm_msgs::TurnSignalCommand turn_signal;
   turn_signal.header.stamp = ros::Time::now();
   turn_signal.mode = speed_mode.mode;
-  if (lamp_cmd_.l == 1)
+
+  // if both lamps are enabled
+  if (lamp_cmd_.l == 1 && lamp_cmd_.r == 1)
+  {
+    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::LEFT;
+    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::RIGHT;
+  }
+  else if (lamp_cmd_.l == 1)
   {
     turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::LEFT;
   }


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fixes the problem of setting the hazard lights through pacmod.

## Related PRs
merge after merging #1146 

## Steps to Test or Reproduce
should be able to enable both the blinker lights by send command on `lamp_cmd`