### PR TITLE
[feature] launch avt camera driver from rtm

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/avt_camera.launch
+++ b/ros/src/util/packages/runtime_manager/scripts/avt_camera.launch
@@ -1,0 +1,112 @@
+<launch>
+    <arg name="guid" default=""/>
+    <arg name="ip" default=""/>
+    <arg name="camera_info_url" default=""/>
+    <arg name="frame_id" default="avt_camera"/>
+    <arg name="trig_timestamp_topic" default=""/>
+    <arg name="show_debug_prints" default="true"/>
+
+    <arg name="trigger_source" default="FixedRate"/>
+
+    <arg name="acquisition_mode" default="Continuous"/>
+    <arg name="acquisition_rate" default="20"/>
+
+    <arg name="pixel_format" default="BayerRG8"/>
+
+    <arg name="exposure" default="10000"/>
+    <arg name="gain" default="15"/>
+
+    <arg name="exposure_auto" default="Continuous"/>
+    <arg name="gain_auto" default="Continuous"/>
+    <arg name="whitebalance_auto" default="Continuous"/>
+
+    <arg name="exposure_auto_max" default="50000"/>
+    <arg name="gain_auto_max" default="50"/>
+
+    <arg name="binning_x" default="1"/>
+    <arg name="binning_y" default="1"/>
+    <arg name="decimation_x" default="1"/>
+    <arg name="decimation_y" default="1"/>
+    <arg name="x_offset" default="0"/>
+    <arg name="y_offset" default="0"/>
+
+    <arg name="width" default="1920"/>
+    <arg name="height" default="1440"/>
+
+    <arg name="stream_bytes_per_second" default="45000000"/>
+
+    <group ns="avt_camera">
+        <node name="image_proc" pkg="image_proc" type="image_proc"/>
+    </group>
+
+    <node name="avt_camera" pkg="avt_vimba_camera" type="mono_camera_node" output="screen">
+        <param name="guid" value="$(arg guid)"/>
+        <param name="ip" value="$(arg ip)"/>
+        <param name="camera_info_url" value="$(arg camera_info_url)"/>
+        <param name="frame_id" value="$(arg frame_id)"/>
+        <param name="trig_timestamp_topic" value="$(arg trig_timestamp_topic)"/>
+        <param name="show_debug_prints" value="$(arg show_debug_prints)"/>
+
+        <!-- Trigger mode:
+            1. Freerun
+            2. SyncIn1
+            3. SyncIn2
+            4. SyncIn3
+            5. SyncIn4
+            6. FixedRate
+            7. Software
+        -->
+        <param name="trigger_source" value="$(arg trigger_source)"/>
+
+        <!-- Acquisition mode:
+            1. Continuous
+            2. SingleFrame
+            3. MultiFrame
+            4. Recorder
+        -->
+        <param name="acquisition_mode" value="$(arg acquisition_mode)"/>
+
+        <!-- Acquisition rate in fps -->
+        <param name="acquisition_rate" value="$(arg acquisition_rate)"/>
+
+        <!-- Pixel format:
+            1. Mono8
+            2. Mono12
+            3. Mono12Packed
+            4. BayerRG8
+            5. BayerRG12Packed
+            6. BayerGR12
+            7. RGB8Packed
+            8. BGR8Packed
+        -->
+        <param name="pixel_format" value="$(arg pixel_format)"/>
+        <!-- Exposure in us -->
+        <param name="exposure" value="$(arg exposure)"/>
+        <!-- Gain in dB -->
+        <param name="gain" value="$(arg gain)"/>
+
+        <!-- Auto control
+            1. Off
+            2. Once
+            3. Continuous
+        -->
+        <param name="exposure_auto" value="$(arg exposure_auto)"/>
+        <param name="gain_auto" value="$(arg gain_auto)"/>
+        <param name="whitebalance_auto" value="$(arg whitebalance_auto)"/>
+
+        <param name="exposure_auto_max" value="$(arg exposure_auto_max)"/>
+        <param name="gain_auto_max" value="$(arg gain_auto_max)"/>
+
+        <param name="binning_x" value="$(arg binning_x)"/>
+        <param name="binning_y" value="$(arg binning_y)"/>
+        <param name="decimation_x" value="$(arg decimation_x)"/>
+        <param name="decimation_y" value="$(arg decimation_y)"/>
+        <param name="x_offset" value="$(arg x_offset)"/>
+        <param name="y_offset" value="$(arg y_offset)"/>
+        <param name="width" value="$(arg width)"/>
+        <param name="height" value="$(arg height)"/>
+
+        <param name="stream_bytes_per_second" value="$(arg stream_bytes_per_second)"/>
+    </node>
+
+</launch>

--- a/ros/src/util/packages/runtime_manager/scripts/avt_vimba.sh
+++ b/ros/src/util/packages/runtime_manager/scripts/avt_vimba.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source /etc/profile.d/VimbaGigETL_32bit.sh
+source /etc/profile.d/VimbaGigETL_64bit.sh
+roslaunch runtime_manager avt_camera.launch "$@"

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -42,22 +42,33 @@ subs :
         desc : USB Generic desc sample
         probe: 'lsusb -v | grep wTerminalType | grep "Camera Sensor" > /dev/null'
         run  : roslaunch runtime_manager uvc_camera.launch
+
       - name : IEEE1394
         desc : IEEE1394 desc sample
         probe:
         run  :
+
       - name : Baumer VLG-22
         desc : Baumer VLG-22 desc sample
         probe:
         run  : roslaunch vlg22c_cam baumer.launch
+
       - name : IDS UI-3060CP
         desc : IDS UI-3060CP (Requires official ueye package)
         probe:
         run  : roslaunch ueye nodelets.launch
+
       - name : Sekonix 3322/3323 GMSLCamera
-        desc : gmsl camera. run on PX2 only
+        desc : gmsl camera. runs only on PX2
         probe:
         run  : roslaunch autoware_driveworks_interface gmsl_interface
+
+      - name : AVT Vimba Mako
+        desc : Allied Vision Technologies Mako Camera. Requires the installation of avt_vimba_camera package and Vimba SDK.
+        run  : do_shell_exec "$(rospack find runtime_manager)/scripts/avt_vimba.sh"
+        param: avt_params
+        gui  :
+          flags: [ SIGTERM, kill_children ]
 
   - name : GNSS
     desc : GNSS desc sample
@@ -431,29 +442,125 @@ params :
         delim       : ':='
         only_enable : True
 
-#  - name  : points_image
-#    vars  :
-#    - name      : file
-#      kind      : path
-#      v         : ''
-#      cmd_param :
-#        delim : ''
-
-#  - name  : scan_image
-#    vars  :
-#    - name      : file
-#      kind      : path
-#      v         : ''
-#      rosparam  : /scan2image/camera_yaml
-
-#  - name  : virtual_scan_image
-#    vars  :
-#    - name      : file
-#      kind      : path
-#      v         : ''
-#      cmd_param :
-#        dash : ''
-#        delim: ':='
+  - name  : avt_params
+    vars  :
+    - name  : guid
+      label : guid
+      desc  : Camera serial number to connect to. Choose either this or IP Address
+      kind  : str
+      v     : '50-'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : ip
+      label : ip
+      desc  : IP address of the camera to connect to.
+      kind  : str
+      v     : ''
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : camera_info_url
+      label : camera_info_url
+      desc  : Path to the calibration file.
+      kind  : path
+      v     : ''
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : show_debug_prints
+      label : show_debug_prints
+      desc  : Print debug messages to the terminal. True or False.
+      kind  : str
+      v     : 'true'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : acquisition_mode
+      label : acquisition_mode
+      desc  : Default Continuous
+      kind  : str
+      v     : 'Continuous'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : acquisition_rate
+      label : acquisition_rate
+      desc  : Frames per second. Default 20
+      min   : 1
+      max   : 100
+      v     : 20
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : pixel_format
+      label : pixel_format
+      desc  : Please check launch file for all availables format. Default BayerRG8
+      kind  : str
+      v     : 'BayerRG8'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : exposure
+      label : exposure
+      desc  : Exposure time in us. Default 10000
+      min   : 100
+      max   : 500000
+      v     : 10000
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : gain
+      label : gain
+      desc  : Gain in db. Default 15
+      min   : 0
+      max   : 100
+      v     : 15
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : exposure_auto
+      label : exposure_auto
+      desc  : Exposure mode. Continuous, Once, Off.
+      kind  : str
+      v     : 'Continuous'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : gain_auto
+      label : gain_auto
+      desc  : Automatic gain mode. Continuous, Once, Off.
+      kind  : str
+      v     : 'Continuous'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : whitebalance_auto
+      label : whitebalance_auto
+      desc  : White balance mode. Continuous, Once, Off.
+      kind  : str
+      v     : 'Continuous'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : gain_auto_max
+      label : gain_auto_max
+      desc  : Automatic maximum gain in db. Default 32
+      min   : 0
+      max   : 100
+      v     : 32
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : exposure_auto_max
+      label : exposure_auto_max
+      desc  : Auto exposure maximum value in us. Default 50000
+      min   : 100
+      max   : 500000
+      v     : 50000
+      cmd_param :
+        dash        : ''
+        delim       : ':='
 
   - name  : voxel_grid_filter
     topic : /config/voxel_grid_filter


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Support for AVT cameras using the Vimba SDK.
autowarefoundation/autoware_ai#99 

## Steps to Test or Reproduce
1. Install Vimba SDK https://www.alliedvision.com/en/products/software.html
1. Install ROS driver http://wiki.ros.org/avt_vimba_camera
1. Pull this branch
1. Compile
1. Launch from RTM -> Sensing tab -> AVT Vimba Mako, configuring IP or Serial Number
or
1. Launch from sourced terminal `roslaunch runtime_manager avt_camera.launch guid:=SERIALNUMBER`

The image should be streamed to `/avt_camera/image_raw`

![image](https://user-images.githubusercontent.com/7009053/37605022-aa68881a-2bd5-11e8-931b-fc6bdc61fcd9.png)
