### PR TITLE
Fix/pacmod stopline

### DIFF
--- a/ros/src/computing/planning/decision/packages/decision_maker/launch/decision_maker.launch
+++ b/ros/src/computing/planning/decision/packages/decision_maker/launch/decision_maker.launch
@@ -1,7 +1,7 @@
 <!-- -->
 <launch>
 
-	<node pkg="decision_maker" type="decision_maker_node" name="decision_maker_node" output="log">
+	<node pkg="decision_maker" type="decision_maker_node" name="decision_maker_node" output="screen">
 	</node>
 	
 </launch>

--- a/ros/src/computing/planning/decision/packages/decision_maker/launch/decision_maker.launch
+++ b/ros/src/computing/planning/decision/packages/decision_maker/launch/decision_maker.launch
@@ -1,7 +1,7 @@
 <!-- -->
 <launch>
 
-	<node pkg="decision_maker" type="decision_maker_node" name="decision_maker_node" output="screen">
+	<node pkg="decision_maker" type="decision_maker_node" name="decision_maker_node" output="log">
 	</node>
 	
 </launch>

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
@@ -402,7 +402,7 @@ void DecisionMakerNode::callbackFromFinalWaypoint(const autoware_msgs::lane &msg
     for (size_t i=param_stopline_target_waypoint_-offset; i<param_stopline_target_waypoint_+offset ; i++) {
       if (current_finalwaypoints_.waypoints.at(i).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOPLINE) {
         ctx->setCurrentState(state_machine::DRIVE_ACC_STOPLINE_STATE);
-        CurrentStoplineTarget_ = current_finalwaypoints_.waypoints.at(param_stopline_target_waypoint_);
+        CurrentStoplineTarget_ = current_finalwaypoints_.waypoints.at(i);
         closest_stopline_waypoint_ = CurrentStoplineTarget_.gid;
         break;
       }

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
@@ -399,17 +399,18 @@ void DecisionMakerNode::callbackFromFinalWaypoint(const autoware_msgs::lane &msg
   if(current_finalwaypoints_.waypoints.size() > param_stopline_target_waypoint_+offset && param_stopline_target_waypoint_-offset > 0){
     // check if there is a stopline state in [param_stopline_target_waypoint_-offset, param_stopline_target_waypoint_+offset]
     for (size_t i=param_stopline_target_waypoint_-offset; i<param_stopline_target_waypoint_+offset ; i++) {
-        if (current_finalwaypoints_.waypoints.at(i).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOPLINE) {
-            ctx->setCurrentState(state_machine::DRIVE_ACC_STOPLINE_STATE);
-            CurrentStoplineTarget_ = current_finalwaypoints_.waypoints.at(param_stopline_target_waypoint_);
-            closest_stopline_waypoint_ = CurrentStoplineTarget_.gid;
-            break;
-        }
+      if (current_finalwaypoints_.waypoints.at(i).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOPLINE) {
+        ctx->setCurrentState(state_machine::DRIVE_ACC_STOPLINE_STATE);
+        CurrentStoplineTarget_ = current_finalwaypoints_.waypoints.at(param_stopline_target_waypoint_);
+        closest_stopline_waypoint_ = CurrentStoplineTarget_.gid;
+        break;
       }
+    }
     // check if there is a stopline state in [param_stopline_target_waypoint_-offset, param_stopline_target_waypoint_+offset]
     for (size_t i=param_stopline_target_waypoint_-offset; i<param_stopline_target_waypoint_+offset ; i++) {
       if (current_finalwaypoints_.waypoints.at(i).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOP) {
         ctx->setCurrentState(state_machine::DRIVE_ACC_STOP_STATE);
+        break;
       }
     }
   }

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
@@ -255,6 +255,7 @@ void DecisionMakerNode::setWaypointState(autoware_msgs::LaneArray& lane_array)
   }
 
     // add the steering state to the points at the end turn (with out intersection) explicitly
+    int last_turn_offset_wp = 20; // no.of waypoints extra to hold the steering state for the turn at the last
     for (auto &lane : lane_array.lanes){
 
         // check if the waypoints in the end have a turn
@@ -262,11 +263,11 @@ void DecisionMakerNode::setWaypointState(autoware_msgs::LaneArray& lane_array)
         auto last_wp = lane.waypoints[size -1];
 
         // if there are enough waypoints for turn in the end
-        if (size > 20 + str_wp_ahead_of_curvature_) {
+        if (size > last_turn_offset_wp + str_wp_ahead_of_curvature_) {
             int steering_state;
 
             // reference 20th waypoint from end
-            auto ref_wp = lane.waypoints[size - 1 -20];
+            auto ref_wp = lane.waypoints[size - 1 -last_turn_offset_wp];
 
             // get the yaw diff for the points in the end
             int diff = ((int)std::floor(calcPosesAngleDiff(ref_wp.pose.pose, last_wp.pose.pose)));
@@ -282,7 +283,7 @@ void DecisionMakerNode::setWaypointState(autoware_msgs::LaneArray& lane_array)
             // if there is a turn
             if (steering_state == autoware_msgs::WaypointState::STR_LEFT || steering_state == autoware_msgs::WaypointState::STR_RIGHT)
             {
-                for (size_t i=size-1; (i > 0 && (size-i) < (str_wp_ahead_of_curvature_+20)); i--)
+                for (size_t i=size-1; (i > 0 && (size-i) < (str_wp_ahead_of_curvature_+last_turn_offset_wp)); i--)
                 {
                     // update the state
                     lane.waypoints[i].wpstate.steering_state = steering_state;

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
@@ -282,11 +282,10 @@ void DecisionMakerNode::setWaypointState(autoware_msgs::LaneArray& lane_array)
             // if there is a turn
             if (steering_state == autoware_msgs::WaypointState::STR_LEFT || steering_state == autoware_msgs::WaypointState::STR_RIGHT)
             {
-                for (size_t i=size; (i > 0 && (size-i) < (str_wp_ahead_of_curvature_+20)); i--)
+                for (size_t i=size-1; (i > 0 && (size-i) < (str_wp_ahead_of_curvature_+20)); i--)
                 {
                     // update the state
                     lane.waypoints[i].wpstate.steering_state = steering_state;
-                    std::cerr << i << " ";
                 }
 
             }

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_callback.cpp
@@ -395,25 +395,18 @@ void DecisionMakerNode::callbackFromFinalWaypoint(const autoware_msgs::lane &msg
   // cached
   current_finalwaypoints_ = msg;
 
-  static size_t previous_idx = 0;
-  
   size_t idx = param_stopline_target_waypoint_ +  (current_velocity_ * param_stopline_target_ratio_);
-  idx = current_finalwaypoints_.waypoints.size() - 1 > idx ?
-		idx : current_finalwaypoints_.waypoints.size() - 1;
 
-  CurrentStoplineTarget_ = current_finalwaypoints_.waypoints.at(idx);
-  
-  for(size_t i = (previous_idx>idx)?idx:previous_idx ; i <= idx; i++){
-	  if(i < current_finalwaypoints_.waypoints.size()){
-		  if (current_finalwaypoints_.waypoints.at(i).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOPLINE){
+	  if(current_finalwaypoints_.waypoints.size() > param_stopline_target_waypoint_){
+		  if (current_finalwaypoints_.waypoints.at(param_stopline_target_waypoint_).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOPLINE){
 			  ctx->setCurrentState(state_machine::DRIVE_ACC_STOPLINE_STATE);
+              CurrentStoplineTarget_ = current_finalwaypoints_.waypoints.at(param_stopline_target_waypoint_);
 			  closest_stopline_waypoint_ = CurrentStoplineTarget_.gid;
 		  }
-		  if (current_finalwaypoints_.waypoints.at(i).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOP)
-			  ctx->setCurrentState(state_machine::DRIVE_ACC_STOP_STATE);
-	  }
+		  if (current_finalwaypoints_.waypoints.at(param_stopline_target_waypoint_).wpstate.stopline_state == autoware_msgs::WaypointState::TYPE_STOP) {
+              ctx->setCurrentState(state_machine::DRIVE_ACC_STOP_STATE);
+          }
   }
-  previous_idx = idx;
 
   // steering
   idx = current_finalwaypoints_.waypoints.size() - 1 > param_target_waypoint_ ?

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_stateupdate.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_stateupdate.cpp
@@ -370,16 +370,12 @@ void DecisionMakerNode::updateStateStop(int status)
         }
         if (found_wp == FOUND_BOTH_WP)
             break;
-        std::cerr << i << " ";
     }
-      std::cerr << "\n";
 
     // if both closet waypoint and closest stopline point were found
     if (found_wp == FOUND_BOTH_WP) {
         double distance_to_stopline = std::hypot(std::hypot((pcw.x - psw.x), pcw.y - psw.y), pcw.z - psw.z);
-        std::cerr << "distance_to_stopline: " << distance_to_stopline << "\n";
         inside_stopping_area = ((closest_waypoint_ < closest_stopline_waypoint_) && distance_to_stopline < STOPPING_AREA_DISTANCE);
-        std::cerr << "inside_stopping_area: " << inside_stopping_area << "\n";
     }
 
     if (std::abs(current_velocity_) < STOPPING_VECLOCITY_EPSILON && !foundOtherVehicleForIntersectionStop_ && !timerflag && inside_stopping_area)

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_stateupdate.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_stateupdate.cpp
@@ -326,9 +326,14 @@ void DecisionMakerNode::updateStateStop(int status)
 {
   static bool timerflag;
   static ros::Timer stopping_timer;
+  // flag to hold the stopline state
+  static bool is_stopline_state_pending = false;
 
   if (status)
   {
+    // set the flag
+    is_stopline_state_pending = true;
+
     if (current_velocity_ == 0.0)
     {
       /*temporary implementation*/
@@ -346,6 +351,8 @@ void DecisionMakerNode::updateStateStop(int status)
                                        },
                                        this, true);
       timerflag = true;
+      // reset stopline holding
+      is_stopline_state_pending = false;
     }
     else
     {
@@ -356,6 +363,11 @@ void DecisionMakerNode::updateStateStop(int status)
       }
       publishStoplineWaypointIdx(closest_stopline_waypoint_);
     }
+  }
+  // if we need to stop and stopline is still pending
+  else if (is_stopline_state_pending)
+  {
+      publishStoplineWaypointIdx(closest_stopline_waypoint_);
   }
 }
 void DecisionMakerNode::callbackInStateStop(int status)

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_stateupdate.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_stateupdate.cpp
@@ -328,20 +328,21 @@ void DecisionMakerNode::updateStateStop(int status)
   static ros::Timer stopping_timer;
   // flag to hold the stopline state
   static bool is_stopline_state_pending = false;
+  const static double STOPPING_VECLOCITY_EPSILON = 1e-2;
 
   if (status)
   {
     // set the flag
     is_stopline_state_pending = true;
 
-    if (current_velocity_ == 0.0)
+    if (std::abs(current_velocity_) < STOPPING_VECLOCITY_EPSILON)
     {
       /*temporary implementation*/
       std_msgs::String layer_msg;
       layer_msg.data = "detectionarea";
       Pubs["filtering_gridmap_layer"].publish(layer_msg);
     }
-    if (current_velocity_ == 0.0 && !foundOtherVehicleForIntersectionStop_ && !timerflag)
+    if (std::abs(current_velocity_) < STOPPING_VECLOCITY_EPSILON && !foundOtherVehicleForIntersectionStop_ && !timerflag)
     {
       stopping_timer = nh_.createTimer(ros::Duration(param_stopline_pause_time_),
                                        [&](const ros::TimerEvent&) {


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
This should fix the problem of stopline behavior with obstacles and randomly missing the stop lines

the changes are:
1. Removed the heuristic to switch to stopline state and this is now controlled by `param_stopline_target_waypoint_`.
2. Stopline state starts before `param_stopline_target_waypoint_` waypoints.
3. when obstacles are present during the stopline, the stopline state is hold until the obstacles are cleared and stopline state is executed.
4. Added epsilon checking for stopping velocity instead of checking with `0.0`

## Steps to Test or Reproduce
1. The car should always stop at all the stoplines
2. When an obstacle is there in the front at a stopline, the car should first stop for the obstacle and once the obstacle is cleared car should stop for stopline and then proceed.
