### PR TITLE
Fix the error that causes new allocated voxel grid corrupted.

### DIFF
--- a/ros/src/computing/perception/localization/lib/fast_pcl/ndt_cpu/src/VoxelGrid.cpp
+++ b/ros/src/computing/perception/localization/lib/fast_pcl/ndt_cpu/src/VoxelGrid.cpp
@@ -54,6 +54,7 @@ void VoxelGrid<PointSourceType>::initialize()
 
 	icovariance_.resize(voxel_num_);
 
+	points_id_.clear();
 	points_id_.resize(voxel_num_);
 
 	points_per_voxel_.resize(voxel_num_);
@@ -225,7 +226,7 @@ void VoxelGrid<PointSourceType>::computeCentroidAndCovariance()
 
 		if (ipoint_num >= min_points_per_voxel_) {
 
-			covariance_[i] = (covariance_[i] - 2 * (pt_sum * centroid_[i].transpose())) / point_num + centroid_[i] * centroid_[i].transpose();
+			covariance_[i] = (covariance_[i] - 2.0 * (pt_sum * centroid_[i].transpose())) / point_num + centroid_[i] * centroid_[i].transpose();
 			covariance_[i] *= (point_num - 1.0) / point_num;
 
 			SymmetricEigensolver3x3 sv(covariance_[i]);


### PR DESCRIPTION
## Status

## Description
Free the old vectors to prevent them from corrupting new voxel grid, which is reported in autowarefoundation/autoware_ai#109.

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
In the runtime manager, select Use Fast PCL from the app button of ndt_mapping.