### PR TITLE
handles the blinkers for autoware_command_bridge

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
@@ -166,8 +166,8 @@ void PacmodInterface::publishToPacmod()
   // if lidar is not fine
   if (lidar_detect_cmd_ != 0)
   {
-    // hazard lights
-    turn_signal.turn_signal = 3;
+    // hazard lights (dont work!!!)
+    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::RIGHT;;
   }
   else    // if lidar driver is fine
   {

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
@@ -167,7 +167,7 @@ void PacmodInterface::publishToPacmod()
   if (lidar_detect_cmd_ != 0)
   {
     // hazard lights (dont work!!!)
-    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::RIGHT;;
+    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::RIGHT;
   }
   else    // if lidar driver is fine
   {

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.cpp
@@ -71,6 +71,11 @@ void PacmodInterface::initForROS()
   control_mode_sub_ = nh_.subscribe("/as/control_mode", 1, &PacmodInterface::callbackFromControlMode, this);
   lamp_cmd_sub_ = nh_.subscribe("/lamp_cmd", 1, &PacmodInterface::callbackFromLampCmd, this);
 
+  lidar_detect_cmd_sub_ = nh_.subscribe("/lidar_detect_command", 1, &PacmodInterface::callbackLidarDetectCmd, this);
+
+  // initialise
+  lidar_detect_cmd_ = 0;
+
   // sease_link"up timer
   if (use_timer_publisher_)
   {
@@ -134,6 +139,11 @@ void PacmodInterface::callbackPacmodTimer(const ros::TimerEvent& event)
   publishToPacmod();
 }
 
+void PacmodInterface::callbackLidarDetectCmd(const std_msgs::UInt8ConstPtr msg)
+{
+  lidar_detect_cmd_ = msg->data;
+}
+
 void PacmodInterface::publishToPacmod()
 {
   module_comm_msgs::SpeedMode speed_mode;
@@ -152,17 +162,22 @@ void PacmodInterface::publishToPacmod()
   platform_comm_msgs::TurnSignalCommand turn_signal;
   turn_signal.header.stamp = ros::Time::now();
   turn_signal.mode = speed_mode.mode;
-  if (lamp_cmd_.l == 1)
+
+  // if lidar is not fine
+  if (lidar_detect_cmd_ != 0)
   {
-    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::LEFT;
+    // hazard lights
+    turn_signal.turn_signal = 3;
   }
-  else if (lamp_cmd_.r == 1)
+  else    // if lidar driver is fine
   {
-    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::RIGHT;
-  }
-  else
-  {
-    turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::NONE;
+    if (lamp_cmd_.l == 1) {
+      turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::LEFT;
+    } else if (lamp_cmd_.r == 1) {
+      turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::RIGHT;
+    } else {
+      turn_signal.turn_signal = platform_comm_msgs::TurnSignalCommand::NONE;
+    }
   }
 
   platform_comm_msgs::GearCommand gear_comm;

--- a/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/as_interface/as_interface.h
@@ -51,6 +51,7 @@
 
 #include <autoware_msgs/CurvatureCommandStamped.h>
 #include <autoware_msgs/lamp_cmd.h>
+#include <std_msgs/UInt8.h>
 
 namespace pacmod
 {
@@ -82,6 +83,7 @@ private:
   ros::Subscriber curvature_cmd_sub_;
   ros::Subscriber lamp_cmd_sub_;
   ros::Subscriber speed_sub_;
+  ros::Subscriber lidar_detect_cmd_sub_;
 
   message_filters::Subscriber<module_comm_msgs::VelocityAccel>* current_velocity_sub_;
   message_filters::Subscriber<platform_comm_msgs::CurvatureFeedback>* current_curvature_sub_;
@@ -107,6 +109,7 @@ private:
   double curvature_ = 0.0;
   std_msgs::Header header_;
   autoware_msgs::lamp_cmd lamp_cmd_;
+  uint8_t lidar_detect_cmd_;
 
   // callbacks
   void callbackFromCurvatureCmd(const autoware_msgs::CurvatureCommandStampedConstPtr& msg);
@@ -115,6 +118,7 @@ private:
   void callbackFromSyncedCurrentTwist(const module_comm_msgs::VelocityAccelConstPtr& msg_velocity, const platform_comm_msgs::CurvatureFeedbackConstPtr& msg_curvature);
   void callbackPacmodTimer(const ros::TimerEvent& event);
   void callbackFromLampCmd(const autoware_msgs::lamp_cmdConstPtr& msg);
+  void callbackLidarDetectCmd(const std_msgs::UInt8ConstPtr msg);
 
   // publisher
   void publishToPacmod();


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
This handles the blinkers for `autoware_command_bridge`

## Steps to Test or Reproduce
This should enable hazard lights when LiDAR is not running or the driver reports a bad state. Blinkers in other conditions should be as before.