### PR TITLE
Fix velocity planning at end of waypoint

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.cpp
@@ -242,15 +242,18 @@ bool PurePursuit::canGetCurvature(double *output_kappa)
   }
   // check whether curvature is valid or not
   bool is_valid_curve = false;
-  for(const auto& el : current_waypoints_)
+  for (const auto& el : current_waypoints_)
   {
-    if(getPlaneDistance(el.pose.pose.position, current_pose_.position) > minimum_lookahead_distance_)
+    if (getPlaneDistance(el.pose.pose.position, current_pose_.position) > minimum_lookahead_distance_)
     {
       is_valid_curve = true;
       break;
     }
   }
-  if(!is_valid_curve)return false;
+  if (!is_valid_curve)
+  {
+    return false;
+  }
   // if is_linear_interpolation_ is false or next waypoint is first or last
   if (!is_linear_interpolation_ || next_waypoint_number_ == 0 ||
       next_waypoint_number_ == (static_cast<int>(current_waypoints_.size() - 1)))

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.cpp
@@ -40,6 +40,7 @@ PurePursuit::PurePursuit()
   , next_waypoint_number_(-1)
   , lookahead_distance_(0)
   , current_linear_velocity_(0)
+  , minimum_lookahead_distance_(6)
 {
 }
 
@@ -239,7 +240,17 @@ bool PurePursuit::canGetCurvature(double *output_kappa)
     ROS_INFO("lost next waypoint");
     return false;
   }
-
+  // check whether curvature is valid or not
+  bool is_valid_curve = false;
+  for(const auto& el : current_waypoints_)
+  {
+    if(getPlaneDistance(el.pose.pose.position, current_pose_.position) > minimum_lookahead_distance_)
+    {
+      is_valid_curve = true;
+      break;
+    }
+  }
+  if(!is_valid_curve)return false;
   // if is_linear_interpolation_ is false or next waypoint is first or last
   if (!is_linear_interpolation_ || next_waypoint_number_ == 0 ||
       next_waypoint_number_ == (static_cast<int>(current_waypoints_.size() - 1)))

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.h
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.h
@@ -53,6 +53,10 @@ public:
   {
     lookahead_distance_ = ld;
   }
+  void setMinimumLookaheadDistance(const double &minld)
+  {
+    minimum_lookahead_distance_ = minld;
+  }
   void setCurrentVelocity(const double &cur_vel)
   {
     current_linear_velocity_ = cur_vel;
@@ -87,6 +91,10 @@ public:
   {
     return lookahead_distance_;
   }
+  double getMinimumLookaheadDistance() const
+  {
+    return minimum_lookahead_distance_;
+  }
   // processing
   bool canGetCurvature(double *output_kappa);
 
@@ -100,6 +108,7 @@ private:
   int next_waypoint_number_;
   geometry_msgs::Point next_target_position_;
   double lookahead_distance_;
+  double minimum_lookahead_distance_;
   geometry_msgs::Pose current_pose_;
   double current_linear_velocity_;
   std::vector<autoware_msgs::waypoint> current_waypoints_;

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.cpp
@@ -100,6 +100,7 @@ void PurePursuitNode::run()
     }
 
     pp_.setLookaheadDistance(computeLookaheadDistance());
+    pp_.setMinimumLookaheadDistance(minimum_lookahead_distance_);
 
     double kappa = 0;
     bool can_get_curvature = pp_.canGetCurvature(&kappa);


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
I made a change to /pure_pursuit. autowarefoundation/autoware_ai#136 
I changed it to stop when the following conditions are satisfied:
 **"All the remaining waypoints are within minimum_lookahead_distance for the vehicle."**

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
The startup method is just to start / pure_pursuit just as before.
![image](https://user-images.githubusercontent.com/33311630/39292754-0e47d8b8-4972-11e8-9919-dc0deb1ac19e.png)

**Before this correction**：
The right end is the waypoint termination. Angle control is unstable at the waypoint termination.
![image](https://user-images.githubusercontent.com/33311630/39358309-a1056722-4a50-11e8-8154-35a27b01a3b3.png)

**After this correction**: 
It turns out that the angle control has converged to 0 without sudden change.
![image](https://user-images.githubusercontent.com/33311630/39358256-78b7d28c-4a50-11e8-9a01-5fc5ec20c068.png)
