### PR TITLE
Fix the bug ndt_mapping/matching use GPU resources even when selectin…

### DIFF
--- a/ros/src/computing/perception/localization/lib/ndt_gpu/include/ndt_gpu/MatrixDevice.h
+++ b/ros/src/computing/perception/localization/lib/ndt_gpu/include/ndt_gpu/MatrixDevice.h
@@ -20,6 +20,8 @@ public:
 
 	CUDAH void setBuffer(double *buffer);
 
+	void memAlloc();
+
 	void memFree();
 
 private:
@@ -44,7 +46,7 @@ CUDAH MatrixDevice::MatrixDevice(int rows, int cols, int offset, double *buffer)
 
 CUDAH bool MatrixDevice::isEmpty()
 {
-	return (rows_ == 0 && cols_ == 0);
+	return (rows_ == 0 || cols_ == 0 || buffer_ == NULL);
 }
 
 CUDAH MatrixDevice MatrixDevice::col(int index)

--- a/ros/src/computing/perception/localization/lib/ndt_gpu/src/MatrixDevice.cu
+++ b/ros/src/computing/perception/localization/lib/ndt_gpu/src/MatrixDevice.cu
@@ -7,18 +7,29 @@ MatrixDevice::MatrixDevice(int rows, int cols) {
 	cols_ = cols;
 	offset_ = 1;
 	fr_ = true;
+	buffer_ = NULL;
+}
+
+void MatrixDevice::memAlloc()
+{
+	if (buffer_ != NULL && fr_) {
+		checkCudaErrors(cudaFree(buffer_));
+		buffer_ = NULL;
+	}
 
 	checkCudaErrors(cudaMalloc(&buffer_, sizeof(double) * rows_ * cols_ * offset_));
 	checkCudaErrors(cudaMemset(buffer_, 0, sizeof(double) * rows_ * cols_ * offset_));
 	checkCudaErrors(cudaDeviceSynchronize());
+	fr_ = true;
 }
-
 
 void MatrixDevice::memFree()
 {
 	if (fr_) {
-		if (buffer_ != NULL)
+		if (buffer_ != NULL) {
 			checkCudaErrors(cudaFree(buffer_));
+			buffer_ = NULL;
+		}
 	}
 }
 

--- a/ros/src/computing/perception/localization/lib/ndt_gpu/src/NormalDistributionsTransform.cu
+++ b/ros/src/computing/perception/localization/lib/ndt_gpu/src/NormalDistributionsTransform.cu
@@ -143,6 +143,14 @@ void GNormalDistributionsTransform::setInputTarget(pcl::PointCloud<pcl::PointXYZ
 void GNormalDistributionsTransform::computeTransformation(const Eigen::Matrix<float, 4, 4> &guess)
 {
 
+	if (dj_ang_.isEmpty()) {
+		dj_ang_.memAlloc();
+	}
+
+	if (dh_ang_.isEmpty()) {
+		dh_ang_.memAlloc();
+	}
+
 	nr_iterations_ = 0;
 	converged_ = false;
 
@@ -1129,7 +1137,6 @@ void GNormalDistributionsTransform::computeAngleDerivatives(MatrixHost pose, boo
 		h_ang_(43) = -cx * sy * sz - sx * cz;
 		h_ang_(44) = 0;
 
-
 		h_ang_.moveToGpu(dh_ang_);
 	}
 
@@ -1164,6 +1171,8 @@ void GNormalDistributionsTransform::transformPointCloud(float *in_x, float *in_y
 
 	MatrixHost htrans(3, 4);
 	MatrixDevice dtrans(3, 4);
+
+	dtrans.memAlloc();
 
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 4; j++) {


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fix the bug in which the ndt_matching still uses GPU when selecting pcl_generic from runtime manager (reported in autowarefoundation/autoware_ai#100 ).

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
From runtime manager, select pcl_generic in the app button of ndt_matching.
When ndt_matching is running, run nvidia-smi to check if ndt_matching is using GPU resources.

