### PR TITLE
Fix build failures on Aarch64

### DIFF
--- a/ros/src/computing/perception/detection/lib/image/dpm_ttic/cpu/get_boxes.cpp
+++ b/ros/src/computing/perception/detection/lib/image/dpm_ttic/cpu/get_boxes.cpp
@@ -480,7 +480,7 @@ FLOAT *dpm_ttic_cpu_get_boxes(FLOAT **features,FLOAT *scales,int *FSIZE,MODEL *M
 		}
 	}
 
-	FLOAT AS_OFF = abs(thresh);
+	FLOAT AS_OFF = std::abs(thresh);
 
 	//accumulated score calculation
 	FLOAT max_ac = 0.0;

--- a/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_decision.cpp
+++ b/ros/src/computing/planning/decision/packages/decision_maker/nodes/decision_maker/decision_maker_node_decision.cpp
@@ -1,3 +1,4 @@
+#include <numeric>
 #include <stdio.h>
 
 #include <geometry_msgs/PoseStamped.h>

--- a/ros/src/util/packages/kitti_pkg/kitti_player/src/kitti_player.cpp
+++ b/ros/src/util/packages/kitti_pkg/kitti_player/src/kitti_player.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <ros/ros.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 //#include <boost/locale.hpp>
 #include <boost/program_options.hpp>


### PR DESCRIPTION
Following issues are detected and fixed while building Autoware on Aarch64 host:

1. FLOAT = abs(FLOAT) doesn't really makes sense. Hence modify that to use std::abs.
2. Include <numeric> header for using accumulate API.
3. Include <boost/format.hpp> header for using boost format API's.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
