### PR TITLE
[fix] kitti_player header sequence number

### DIFF
--- a/ros/src/util/packages/kitti_pkg/kitti_box_publisher/scripts/kitti_box_publisher.py
+++ b/ros/src/util/packages/kitti_pkg/kitti_box_publisher/scripts/kitti_box_publisher.py
@@ -235,7 +235,8 @@ def run():
 	pub_pictograms = rospy.Publisher('kitti_3d_labels', PictogramArray, queue_size=1)
 	pub_points_clusters = rospy.Publisher('points_cluster', PointCloud2, queue_size=1)
 	#projection_publisher = rospy.Publisher('projection_matrix', projection_matrix, queue_size=1, latch=True)
-	rospy.Subscriber("/kitti_player/hdl64e", PointCloud2, callback)
+	#rospy.Subscriber("/kitti_player/hdl64e", PointCloud2, callback)
+        rospy.Subscriber("/points_raw", PointCloud2, callback)
 	
 	rospy.spin()
 

--- a/ros/src/util/packages/kitti_pkg/kitti_player/src/kitti_player.cpp
+++ b/ros/src/util/packages/kitti_pkg/kitti_player/src/kitti_player.cpp
@@ -119,6 +119,7 @@ int publish_velodyne(ros::Publisher &pub, string infile, std_msgs::Header *heade
 
         pc2.header.frame_id= "velodyne"; //ros::this_node::getName();
         pc2.header.stamp=header->stamp;
+        pc2.header.seq=header->seq;
         points->header = pcl_conversions::toPCL(pc2.header);
         pub.publish(points);
 
@@ -1225,6 +1226,7 @@ int main(int argc, char **argv)
                 timestamps.seekg(30*entries_played);
                 getline(timestamps,str_support);
                 header_support.stamp = parseTime(str_support).stamp;
+                header_support.seq = progress.count();
                 publish_velodyne(map_pub, full_filename_velodyne,&header_support);
             }
 


### PR DESCRIPTION
## Status
**BUG FIX** autowarefoundation/autoware_ai#146 

## Description
Fixed bugs in the kitti_pkg to allow displaying tracklets (labeled data) on ``kitti_player``.
Fixed the kitti_box_publisher to use the points_raw topic instead of the default.

## Todos
- [x] Tests
- [ ] Perhaps, use launch parameters in the ``kitti_box_publisher`` python script.

## Steps to Test or Reproduce
First, read the "ros/src/util/packages/kitti_pkg/README.md" for instructions regarding getting a Kitti data set and other information. Run the following command before and after applying this bug fix, be sure to have the jsk ``BoundingBoxArray`` in rviz with the ``/kitti_box`` topic.

```
roslaunch kitti_launch kittiplayer.launch fps:=10
```
Before applying the bug fix, a few (not all)  bounding boxes appear but do not update; after the fix they all appear and update correctly according to the corresponding rotation and translation.