### PR TITLE
[Feature] The local waypoints marker is flashing.

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_marker_publisher/waypoint_marker_publisher.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_maker/nodes/waypoint_marker_publisher/waypoint_marker_publisher.cpp
@@ -75,6 +75,15 @@ enum class ChangeFlag : int32_t
 
 typedef std::underlying_type<ChangeFlag>::type ChangeFlagInteger;
 
+void setLifetime(double sec, visualization_msgs::MarkerArray* marker_array)
+{
+  ros::Duration lifetime(sec);
+  for (auto& marker : marker_array->markers)
+  {
+    marker.lifetime = lifetime;
+  }
+}
+
 void publishMarkerArray(const visualization_msgs::MarkerArray& marker_array, const ros::Publisher& publisher, bool delete_markers=false)
 {
   visualization_msgs::MarkerArray msg;
@@ -85,11 +94,15 @@ void publishMarkerArray(const visualization_msgs::MarkerArray& marker_array, con
   if (delete_markers)
   {
     for (auto& marker : msg.markers)
+    {
       marker.action = visualization_msgs::Marker::DELETE;
+    }
   }
 
   publisher.publish(msg);
 }
+
+
 
 void createGlobalLaneArrayVelocityMarker(const autoware_msgs::LaneArray& lane_waypoints_array)
 {
@@ -395,12 +408,12 @@ void laneArrayCallback(const autoware_msgs::LaneArrayConstPtr& msg)
 
 void finalCallback(const autoware_msgs::laneConstPtr& msg)
 {
-  publishMarkerArray(g_local_waypoints_marker_array, g_local_mark_pub, true);
   g_local_waypoints_marker_array.markers.clear();
   if (_closest_waypoint != -1)
     createLocalWaypointVelocityMarker(g_local_color, _closest_waypoint, *msg);
   createLocalPathMarker(g_local_color, *msg);
   createLocalPointMarker(*msg);
+  setLifetime(0.5, &g_local_waypoints_marker_array);
   publishMarkerArray(g_local_waypoints_marker_array, g_local_mark_pub);
 }
 


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Modified `waypoint_marker_publisher` to eliminate the flashing marker. autowarefoundation/autoware_ai#161 

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
![image](https://user-images.githubusercontent.com/33311630/40220164-25d557e2-5ab3-11e8-9d0c-dc6b089a0ad3.png)
It is necessary to start all the nodes necessary for route planning. In addition, rviz must be activated for the display system.
For rviz's config file, `Autoware/ros/src/.config/rviz/default.rviz` is recommended.

You can see that the blink of `/local_waypoints_array` has disappeared before and after the change.