### PR TITLE
[Fix] Reduce the calculation load of points2image

### DIFF
--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/nodes/calibration_publisher/calibration_publisher.cpp
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/nodes/calibration_publisher/calibration_publisher.cpp
@@ -120,9 +120,11 @@ static void image_raw_cb(const sensor_msgs::Image& image_msg)
 
   if (isPublish_cameraInfo) {
     cameraInfo_sender(CameraMat, DistCoeff, ImageSize, DistModel, timeStampOfImage);
+    isPublish_cameraInfo = false;
   }
   if (isPublish_extrinsic) {
     projectionMatrix_sender(CameraExtrinsicMat, timeStampOfImage);
+    isPublish_extrinsic = false;
   }
 
 }
@@ -190,9 +192,9 @@ int main(int argc, char* argv[])
 
   image_sub = n.subscribe(image_topic_name, 10, image_raw_cb);
 
-  camera_info_pub = n.advertise<sensor_msgs::CameraInfo>(camera_info_name, 10, false);
+  camera_info_pub = n.advertise<sensor_msgs::CameraInfo>(camera_info_name, 10, true);
 
-  projection_matrix_pub = n.advertise<autoware_msgs::projection_matrix>(projection_matrix_name, 10, false);
+  projection_matrix_pub = n.advertise<autoware_msgs::projection_matrix>(projection_matrix_name, 10, true);
 
 
   ros::spin();

--- a/ros/src/sensing/fusion/packages/points2image/include/points_image/points_image.hpp
+++ b/ros/src/sensing/fusion/packages/points2image/include/points_image/points_image.hpp
@@ -35,6 +35,7 @@
 #include <sensor_msgs/PointCloud2.h>
 #include "autoware_msgs/PointsImage.h"
 
+void resetMatrix();
 autoware_msgs::PointsImage
 pointcloud2_to_image(const sensor_msgs::PointCloud2ConstPtr& pointclound2,
 		     const cv::Mat& cameraExtrinsicMat,

--- a/ros/src/sensing/fusion/packages/points2image/include/points_image/points_image.hpp
+++ b/ros/src/sensing/fusion/packages/points2image/include/points_image/points_image.hpp
@@ -36,14 +36,12 @@
 #include "autoware_msgs/PointsImage.h"
 
 void resetMatrix();
-autoware_msgs::PointsImage
-pointcloud2_to_image(const sensor_msgs::PointCloud2ConstPtr& pointclound2,
-		     const cv::Mat& cameraExtrinsicMat,
-		     const cv::Mat& cameraMat, const cv::Mat& distCoeff,
-		     const cv::Size& imageSize);
+autoware_msgs::PointsImage pointcloud2_to_image(const sensor_msgs::PointCloud2ConstPtr& pointclound2,
+                                                const cv::Mat& cameraExtrinsicMat, const cv::Mat& cameraMat,
+                                                const cv::Mat& distCoeff, const cv::Size& imageSize);
 
 /*points2image::CameraExtrinsic
 pointcloud2_to_3d_calibration(const sensor_msgs::PointCloud2ConstPtr& pointclound2,
-			      const cv::Mat& cameraExtrinsicMat);
+            const cv::Mat& cameraExtrinsicMat);
 */
 #endif /* _POINTS_IMAGE_H_ */

--- a/ros/src/sensing/fusion/packages/points2image/lib/points_image/points_image.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/lib/points_image/points_image.cpp
@@ -38,128 +38,124 @@ static bool init_matrix = false;
 
 void resetMatrix()
 {
-	init_matrix = false;
+  init_matrix = false;
 }
 
 void initMatrix(const cv::Mat& cameraExtrinsicMat)
 {
-	invRt = cameraExtrinsicMat(cv::Rect(0,0,3,3));
-	cv::Mat invT = -invRt.t()*(cameraExtrinsicMat(cv::Rect(3,0,1,3)));
-	invTt = invT.t();
-	init_matrix = true;
+  invRt = cameraExtrinsicMat(cv::Rect(0, 0, 3, 3));
+  cv::Mat invT = -invRt.t() * (cameraExtrinsicMat(cv::Rect(3, 0, 1, 3)));
+  invTt = invT.t();
+  init_matrix = true;
 }
 
-autoware_msgs::PointsImage
-pointcloud2_to_image(const sensor_msgs::PointCloud2ConstPtr& pointcloud2,
-		     const cv::Mat& cameraExtrinsicMat,
-		     const cv::Mat& cameraMat, const cv::Mat& distCoeff,
-		     const cv::Size& imageSize)
+autoware_msgs::PointsImage pointcloud2_to_image(const sensor_msgs::PointCloud2ConstPtr& pointcloud2,
+                                                const cv::Mat& cameraExtrinsicMat, const cv::Mat& cameraMat,
+                                                const cv::Mat& distCoeff, const cv::Size& imageSize)
 {
-	int w = imageSize.width;
-	int h = imageSize.height;
+  int w = imageSize.width;
+  int h = imageSize.height;
 
-	autoware_msgs::PointsImage msg;
+  autoware_msgs::PointsImage msg;
 
-	msg.header = pointcloud2->header;
+  msg.header = pointcloud2->header;
 
-	msg.intensity.assign(w * h, 0);
-	msg.distance.assign(w * h, 0);
-	msg.min_height.assign(w * h, 0);
-	msg.max_height.assign(w * h, 0);
+  msg.intensity.assign(w * h, 0);
+  msg.distance.assign(w * h, 0);
+  msg.min_height.assign(w * h, 0);
+  msg.max_height.assign(w * h, 0);
 
-	uintptr_t cp = (uintptr_t)pointcloud2->data.data();
+  uintptr_t cp = (uintptr_t)pointcloud2->data.data();
 
-	msg.max_y = -1;
-	msg.min_y = h;
+  msg.max_y = -1;
+  msg.min_y = h;
 
-	msg.image_height = imageSize.height;
-	msg.image_width = imageSize.width;
-	if (!init_matrix)
-	{
-		initMatrix(cameraExtrinsicMat);
-	}
+  msg.image_height = imageSize.height;
+  msg.image_width = imageSize.width;
+  if (!init_matrix)
+  {
+    initMatrix(cameraExtrinsicMat);
+  }
 
-	cv::Mat point(1, 3, CV_64F);
-	cv::Point2d imagepoint;
-	for (uint32_t y = 0; y < pointcloud2->height; ++y) {
-		for (uint32_t x = 0; x < pointcloud2->width; ++x) {
-			float* fp = (float *)(cp + (x + y*pointcloud2->width) * pointcloud2->point_step);
-			double intensity = fp[4];
-			for (int i = 0; i < 3; i++)
-			{
-				point.at<double>(i) = invTt.at<double>(i);
-				for (int j = 0; j < 3; j++)
-				{
-					point.at<double>(i) += double(fp[j]) * invRt.at<double>(j, i);
-				}
-			}
+  cv::Mat point(1, 3, CV_64F);
+  cv::Point2d imagepoint;
+  for (uint32_t y = 0; y < pointcloud2->height; ++y)
+  {
+    for (uint32_t x = 0; x < pointcloud2->width; ++x)
+    {
+      float* fp = (float*)(cp + (x + y * pointcloud2->width) * pointcloud2->point_step);
+      double intensity = fp[4];
+      for (int i = 0; i < 3; i++)
+      {
+        point.at<double>(i) = invTt.at<double>(i);
+        for (int j = 0; j < 3; j++)
+        {
+          point.at<double>(i) += double(fp[j]) * invRt.at<double>(j, i);
+        }
+      }
 
-			if (point.at<double>(2) <= 1) {
-				continue;
-			}
+      if (point.at<double>(2) <= 1)
+      {
+        continue;
+      }
 
-			double tmpx = point.at<double>(0) / point.at<double>(2);
-			double tmpy = point.at<double>(1) / point.at<double>(2);
-			double r2 = tmpx * tmpx + tmpy * tmpy;
-			double tmpdist = 1 + distCoeff.at<double>(0) * r2
-				+ distCoeff.at<double>(1) * r2 * r2
-				+ distCoeff.at<double>(4) * r2 * r2 * r2;
+      double tmpx = point.at<double>(0) / point.at<double>(2);
+      double tmpy = point.at<double>(1) / point.at<double>(2);
+      double r2 = tmpx * tmpx + tmpy * tmpy;
+      double tmpdist =
+          1 + distCoeff.at<double>(0) * r2 + distCoeff.at<double>(1) * r2 * r2 + distCoeff.at<double>(4) * r2 * r2 * r2;
 
-			imagepoint.x = tmpx * tmpdist
-				+ 2 * distCoeff.at<double>(2) * tmpx * tmpy
-				+ distCoeff.at<double>(3) * (r2 + 2 * tmpx * tmpx);
-			imagepoint.y = tmpy * tmpdist
-				+ distCoeff.at<double>(2) * (r2 + 2 * tmpy * tmpy)
-				+ 2 * distCoeff.at<double>(3) * tmpx * tmpy;
-			imagepoint.x = cameraMat.at<double>(0,0) * imagepoint.x + cameraMat.at<double>(0,2);
-			imagepoint.y = cameraMat.at<double>(1,1) * imagepoint.y + cameraMat.at<double>(1,2);
+      imagepoint.x =
+          tmpx * tmpdist + 2 * distCoeff.at<double>(2) * tmpx * tmpy + distCoeff.at<double>(3) * (r2 + 2 * tmpx * tmpx);
+      imagepoint.y =
+          tmpy * tmpdist + distCoeff.at<double>(2) * (r2 + 2 * tmpy * tmpy) + 2 * distCoeff.at<double>(3) * tmpx * tmpy;
+      imagepoint.x = cameraMat.at<double>(0, 0) * imagepoint.x + cameraMat.at<double>(0, 2);
+      imagepoint.y = cameraMat.at<double>(1, 1) * imagepoint.y + cameraMat.at<double>(1, 2);
 
-			int px = int(imagepoint.x + 0.5);
-			int py = int(imagepoint.y + 0.5);
-			if(0 <= px && px < w && 0 <= py && py < h)
-			{
-				int pid = py * w + px;
-				if(msg.distance[pid] == 0 ||
-				   msg.distance[pid] > point.at<double>(2))
-				{
-					msg.distance[pid] = float(point.at<double>(2) * 100);
-					msg.intensity[pid] = float(intensity);
+      int px = int(imagepoint.x + 0.5);
+      int py = int(imagepoint.y + 0.5);
+      if (0 <= px && px < w && 0 <= py && py < h)
+      {
+        int pid = py * w + px;
+        if (msg.distance[pid] == 0 || msg.distance[pid] > point.at<double>(2))
+        {
+          msg.distance[pid] = float(point.at<double>(2) * 100);
+          msg.intensity[pid] = float(intensity);
 
-					msg.max_y = py > msg.max_y ? py : msg.max_y;
-					msg.min_y = py < msg.min_y ? py : msg.min_y;
+          msg.max_y = py > msg.max_y ? py : msg.max_y;
+          msg.min_y = py < msg.min_y ? py : msg.min_y;
+        }
+        if (0 == y && pointcloud2->height == 2)  // process simultaneously min and max during the first layer
+        {
+          float* fp2 = (float*)(cp + (x + (y + 1) * pointcloud2->width) * pointcloud2->point_step);
+          msg.min_height[pid] = fp[2];
+          msg.max_height[pid] = fp2[2];
+        }
+        else
+        {
+          msg.min_height[pid] = -1.25;
+          msg.max_height[pid] = 0;
+        }
+      }
+    }
+  }
 
-				}
-				if (0 == y && pointcloud2->height == 2)//process simultaneously min and max during the first layer
-				{
-					float* fp2 = (float *)(cp + (x + (y+1)*pointcloud2->width) * pointcloud2->point_step);
-					msg.min_height[pid] = fp[2];
-					msg.max_height[pid] = fp2[2];
-				}
-				else
-				{
-					msg.min_height[pid] = -1.25;
-					msg.max_height[pid] = 0;
-				}
-			}
-		}
-	}
-
-	return msg;
+  return msg;
 }
 
 /*autoware_msgs::CameraExtrinsic
 pointcloud2_to_3d_calibration(const sensor_msgs::PointCloud2ConstPtr& pointcloud2,
-			      const cv::Mat& cameraExtrinsicMat)
+            const cv::Mat& cameraExtrinsicMat)
 {
-	autoware_msgs::CameraExtrinsic msg;
-	std::vector<double> cali;
-	for (int y = 0; y < msg.ysize ; ++y) {
-		for (int x = 0; x < msg.xsize ; ++x){
-			cali.push_back(cameraExtrinsicMat.at<double>(y,x));
-		}
-	}
+  autoware_msgs::CameraExtrinsic msg;
+  std::vector<double> cali;
+  for (int y = 0; y < msg.ysize ; ++y) {
+    for (int x = 0; x < msg.xsize ; ++x){
+      cali.push_back(cameraExtrinsicMat.at<double>(y,x));
+    }
+  }
 
-	msg.calibration = cali;
-	return msg;
+  msg.calibration = cali;
+  return msg;
 }
 */

--- a/ros/src/sensing/fusion/packages/points2image/nodes/points2image/main.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/points2image/main.cpp
@@ -45,123 +45,125 @@
 
 struct POINT2IMAGE
 {
-    uchar intensity;
-    ushort distance;
+  uchar intensity;
+  ushort distance;
 };
 
 struct POINTS2IMAGE
 {
-    std_msgs::Header header;
-    int height;
-    int width;
-    std::vector<POINT2IMAGE> points;
+  std_msgs::Header header;
+  int height;
+  int width;
+  std::vector<POINT2IMAGE> points;
 };
 
 typedef boost::shared_ptr<POINTS2IMAGE> POINTS2IMAGEPtr;
 
-static POINTS2IMAGEPtr points_to_image(sensor_msgs::PointCloud2ConstPtr velodyneData,
-				       cv::Mat cameraExtrinsicMat,
-				       cv::Mat cameraMat, cv::Mat distCoeff,
-				       cv::Size imageSize)
+static POINTS2IMAGEPtr points_to_image(sensor_msgs::PointCloud2ConstPtr velodyneData, cv::Mat cameraExtrinsicMat,
+                                       cv::Mat cameraMat, cv::Mat distCoeff, cv::Size imageSize)
 {
-    POINTS2IMAGEPtr result(new POINTS2IMAGE);
-    result->header=velodyneData->header;
-    result->height=imageSize.height;
-    result->width=imageSize.width;
-    POINT2IMAGE tmpdata;
-    tmpdata.intensity=0;
-    tmpdata.distance=0;
-    result->points.resize(result->height*result->width,tmpdata);
+  POINTS2IMAGEPtr result(new POINTS2IMAGE);
+  result->header = velodyneData->header;
+  result->height = imageSize.height;
+  result->width = imageSize.width;
+  POINT2IMAGE tmpdata;
+  tmpdata.intensity = 0;
+  tmpdata.distance = 0;
+  result->points.resize(result->height * result->width, tmpdata);
 
-    cv::Mat invR=cameraExtrinsicMat(cv::Rect(0,0,3,3)).t();
-    cv::Mat invT=-invR*(cameraExtrinsicMat(cv::Rect(3,0,1,3)));
+  cv::Mat invR = cameraExtrinsicMat(cv::Rect(0, 0, 3, 3)).t();
+  cv::Mat invT = -invR * (cameraExtrinsicMat(cv::Rect(3, 0, 1, 3)));
 
-    int n=velodyneData->height;
-    int m=velodyneData->width;
-    char * data=(char *)(velodyneData->data.data());
-    for(int i=0;i<n;i++)
+  int n = velodyneData->height;
+  int m = velodyneData->width;
+  char* data = (char*)(velodyneData->data.data());
+  for (int i = 0; i < n; i++)
+  {
+    for (int j = 0; j < m; j++)
     {
-        for(int j=0;j<m;j++)
+      int id = i * m + j;
+      float* dataptr = (float*)(data + id * velodyneData->point_step);
+
+      cv::Mat point(1, 3, CV_64F);
+      point.at<double>(0) = double(dataptr[0]);
+      point.at<double>(1) = double(dataptr[1]);
+      point.at<double>(2) = double(dataptr[2]);
+      point = point * invR.t() + invT.t();
+
+      if (point.at<double>(2) <= 0)
+      {
+        continue;
+      }
+
+      double tmpx = point.at<double>(0) / point.at<double>(2);
+      double tmpy = point.at<double>(1) / point.at<double>(2);
+      double r2 = tmpx * tmpx + tmpy * tmpy;
+      double tmpdist =
+          1 + distCoeff.at<double>(0) * r2 + distCoeff.at<double>(1) * r2 * r2 + distCoeff.at<double>(4) * r2 * r2 * r2;
+
+      cv::Point2d imagepoint;
+      imagepoint.x =
+          tmpx * tmpdist + 2 * distCoeff.at<double>(2) * tmpx * tmpy + distCoeff.at<double>(3) * (r2 + 2 * tmpx * tmpx);
+      imagepoint.y =
+          tmpy * tmpdist + distCoeff.at<double>(2) * (r2 + 2 * tmpy * tmpy) + 2 * distCoeff.at<double>(3) * tmpx * tmpy;
+      imagepoint.x = cameraMat.at<double>(0, 0) * imagepoint.x + cameraMat.at<double>(0, 2);
+      imagepoint.y = cameraMat.at<double>(1, 1) * imagepoint.y + cameraMat.at<double>(1, 2);
+      if (imagepoint.x >= 0 && imagepoint.x < result->width && imagepoint.y >= 0 && imagepoint.y < result->height)
+      {
+        int px = int(imagepoint.x + 0.5);
+        int py = int(imagepoint.y + 0.5);
+        int pid = py * result->width + px;
+        if (result->points[pid].distance == 0 || (result->points[pid].distance / 100.0) > point.at<double>(2))
         {
-            int id=i*m+j;
-            float * dataptr=(float *)(data+id*velodyneData->point_step);
-
-            cv::Mat point(1,3,CV_64F);
-            point.at<double>(0)=double(dataptr[0]);
-            point.at<double>(1)=double(dataptr[1]);
-            point.at<double>(2)=double(dataptr[2]);
-            point=point*invR.t()+invT.t();
-
-            if(point.at<double>(2)<=0)
-            {
-                continue;
-            }
-
-            double tmpx=point.at<double>(0)/point.at<double>(2);
-            double tmpy=point.at<double>(1)/point.at<double>(2);
-            double r2=tmpx*tmpx+tmpy*tmpy;
-            double tmpdist=1+distCoeff.at<double>(0)*r2+distCoeff.at<double>(1)*r2*r2+distCoeff.at<double>(4)*r2*r2*r2;
-
-            cv::Point2d imagepoint;
-            imagepoint.x=tmpx*tmpdist+2*distCoeff.at<double>(2)*tmpx*tmpy+distCoeff.at<double>(3)*(r2+2*tmpx*tmpx);
-            imagepoint.y=tmpy*tmpdist+distCoeff.at<double>(2)*(r2+2*tmpy*tmpy)+2*distCoeff.at<double>(3)*tmpx*tmpy;
-            imagepoint.x=cameraMat.at<double>(0,0)*imagepoint.x+cameraMat.at<double>(0,2);
-            imagepoint.y=cameraMat.at<double>(1,1)*imagepoint.y+cameraMat.at<double>(1,2);
-            if(imagepoint.x>=0&&imagepoint.x<result->width&&imagepoint.y>=0&&imagepoint.y<result->height)
-            {
-                int px=int(imagepoint.x+0.5);
-                int py=int(imagepoint.y+0.5);
-                int pid=py*result->width+px;
-                if(result->points[pid].distance==0||(result->points[pid].distance/100.0)>point.at<double>(2))
-                {
-                    result->points[pid].distance=ushort(point.at<double>(2)*100+0.5);
-                    result->points[pid].intensity=uchar(dataptr[4]);
-                }
-            }
+          result->points[pid].distance = ushort(point.at<double>(2) * 100 + 0.5);
+          result->points[pid].intensity = uchar(dataptr[4]);
         }
+      }
     }
-    return result;
+  }
+  return result;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-    QCoreApplication a(argc, argv);
+  QCoreApplication a(argc, argv);
 
-    if(argc<2)
+  if (argc < 2)
+  {
+    std::cout << "Need calibration filename as the first parameter.";
+    return 0;
+  }
+
+  cv::Mat cameraextrinsicmat;
+  cv::Mat cameramat;
+  cv::Mat distcoeff;
+  cv::Size imagesize;
+
+  cv::FileStorage fs(QString(argv[1]).toStdString(), cv::FileStorage::READ);
+  if (!fs.isOpened())
+  {
+    std::cout << "Invalid calibration filename.";
+    return 0;
+  }
+
+  fs[CAMERAEXTRINSICMAT] >> cameraextrinsicmat;
+  fs[CAMERAMAT] >> cameramat;
+  fs[DISTCOEFF] >> distcoeff;
+  fs[IMAGESIZE] >> imagesize;
+
+  ROSSub<sensor_msgs::PointCloud2ConstPtr>* velodyne =
+      new ROSSub<sensor_msgs::PointCloud2ConstPtr>("points_raw", 1000, 10, "points2image");
+  //   ROSPub<POINTS2IMAGEPtr> * publisher=new ROSPub<POINTS2IMAGEPtr>("points_image",1000,"points2image");
+
+  while (ros::ok())
+  {
+    sensor_msgs::PointCloud2ConstPtr msg = velodyne->getMessage();
+    if (msg == NULL)
     {
-        std::cout<<"Need calibration filename as the first parameter.";
-        return 0;
+      continue;
     }
-
-    cv::Mat cameraextrinsicmat;
-    cv::Mat cameramat;
-    cv::Mat distcoeff;
-    cv::Size imagesize;
-
-    cv::FileStorage fs(QString(argv[1]).toStdString(),cv::FileStorage::READ);
-    if(!fs.isOpened())
-    {
-        std::cout<<"Invalid calibration filename.";
-        return 0;
-    }
-
-    fs[CAMERAEXTRINSICMAT]>>cameraextrinsicmat;
-    fs[CAMERAMAT]>>cameramat;
-    fs[DISTCOEFF]>>distcoeff;
-    fs[IMAGESIZE]>>imagesize;
-
-    ROSSub<sensor_msgs::PointCloud2ConstPtr> * velodyne=new ROSSub<sensor_msgs::PointCloud2ConstPtr>("points_raw",1000,10,"points2image");
- //   ROSPub<POINTS2IMAGEPtr> * publisher=new ROSPub<POINTS2IMAGEPtr>("points_image",1000,"points2image");
-
-    while(ros::ok())
-    {
-        sensor_msgs::PointCloud2ConstPtr msg=velodyne->getMessage();
-        if(msg==NULL)
-        {
-            continue;
-        }
-        POINTS2IMAGEPtr points2image=points_to_image(msg,cameraextrinsicmat,cameramat,distcoeff,imagesize);
- //       publisher->sendMessage(points2image);
-    }
-    return a.exec();
+    POINTS2IMAGEPtr points2image = points_to_image(msg, cameraextrinsicmat, cameramat, distcoeff, imagesize);
+    //       publisher->sendMessage(points2image);
+  }
+  return a.exec();
 }

--- a/ros/src/sensing/fusion/packages/points2image/nodes/points2image/points2image.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/points2image/points2image.cpp
@@ -57,6 +57,7 @@ static void projection_callback(const autoware_msgs::projection_matrix& msg)
 			cameraExtrinsicMat.at<double>(row, col) = msg.projection_matrix[row * 4 + col];
 		}
 	}
+	resetMatrix();
 }
 
 static void intrinsic_callback(const sensor_msgs::CameraInfo& msg)
@@ -75,6 +76,7 @@ static void intrinsic_callback(const sensor_msgs::CameraInfo& msg)
 	for (int col=0; col<5; col++) {
 		distCoeff.at<double>(col) = msg.D[col];
 	}
+	resetMatrix();
 }
 
 static void callback(const sensor_msgs::PointCloud2ConstPtr& msg)

--- a/ros/src/sensing/fusion/packages/points2image/nodes/points2image/points2image.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/points2image/points2image.cpp
@@ -51,96 +51,103 @@ static ros::Publisher pub;
 
 static void projection_callback(const autoware_msgs::projection_matrix& msg)
 {
-	cameraExtrinsicMat = cv::Mat(4,4,CV_64F);
-	for (int row=0; row<4; row++) {
-		for (int col=0; col<4; col++) {
-			cameraExtrinsicMat.at<double>(row, col) = msg.projection_matrix[row * 4 + col];
-		}
-	}
-	resetMatrix();
+  cameraExtrinsicMat = cv::Mat(4, 4, CV_64F);
+  for (int row = 0; row < 4; row++)
+  {
+    for (int col = 0; col < 4; col++)
+    {
+      cameraExtrinsicMat.at<double>(row, col) = msg.projection_matrix[row * 4 + col];
+    }
+  }
+  resetMatrix();
 }
 
 static void intrinsic_callback(const sensor_msgs::CameraInfo& msg)
 {
-	imageSize.height = msg.height;
-	imageSize.width = msg.width;
+  imageSize.height = msg.height;
+  imageSize.width = msg.width;
 
-	cameraMat = cv::Mat(3,3, CV_64F);
-	for (int row=0; row<3; row++) {
-		for (int col=0; col<3; col++) {
-			cameraMat.at<double>(row, col) = msg.K[row * 3 + col];
-		}
-	}
+  cameraMat = cv::Mat(3, 3, CV_64F);
+  for (int row = 0; row < 3; row++)
+  {
+    for (int col = 0; col < 3; col++)
+    {
+      cameraMat.at<double>(row, col) = msg.K[row * 3 + col];
+    }
+  }
 
-	distCoeff = cv::Mat(1,5,CV_64F);
-	for (int col=0; col<5; col++) {
-		distCoeff.at<double>(col) = msg.D[col];
-	}
-	resetMatrix();
+  distCoeff = cv::Mat(1, 5, CV_64F);
+  for (int col = 0; col < 5; col++)
+  {
+    distCoeff.at<double>(col) = msg.D[col];
+  }
+  resetMatrix();
 }
 
 static void callback(const sensor_msgs::PointCloud2ConstPtr& msg)
 {
-	if (cameraExtrinsicMat.empty() || cameraMat.empty() || distCoeff.empty() || imageSize.height == 0 || imageSize.width == 0)
-	{
-		ROS_INFO("[points2image]Looks like camera_info or projection_matrix are not being published.. Please check that both are running..");
-		return;
-	}
+  if (cameraExtrinsicMat.empty() || cameraMat.empty() || distCoeff.empty() || imageSize.height == 0 ||
+      imageSize.width == 0)
+  {
+    ROS_INFO("[points2image]Looks like camera_info or projection_matrix are not being published.. Please check that "
+             "both are running..");
+    return;
+  }
 
-	autoware_msgs::PointsImage pub_msg
-		= pointcloud2_to_image(msg, cameraExtrinsicMat, cameraMat,
-				       distCoeff, imageSize);
-	pub.publish(pub_msg);
+  autoware_msgs::PointsImage pub_msg = pointcloud2_to_image(msg, cameraExtrinsicMat, cameraMat, distCoeff, imageSize);
+  pub.publish(pub_msg);
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-	ros::init(argc, argv, "points2image");
-	ros::NodeHandle n;
+  ros::init(argc, argv, "points2image");
+  ros::NodeHandle n;
 
-	ros::NodeHandle private_nh("~");
+  ros::NodeHandle private_nh("~");
 
-	std::string camera_info_topic_str;
-	std::string projection_matrix_topic;
-	std::string pub_topic_str="/points_image";
+  std::string camera_info_topic_str;
+  std::string projection_matrix_topic;
+  std::string pub_topic_str = "/points_image";
 
-	private_nh.param<std::string>("projection_matrix_topic", projection_matrix_topic, "/projection_matrix");
-	private_nh.param<std::string>("camera_info_topic", camera_info_topic_str, "/camera_info");
+  private_nh.param<std::string>("projection_matrix_topic", projection_matrix_topic, "/projection_matrix");
+  private_nh.param<std::string>("camera_info_topic", camera_info_topic_str, "/camera_info");
 
-	std::string name_space_str = ros::this_node::getNamespace();
+  std::string name_space_str = ros::this_node::getNamespace();
 
-	if (name_space_str != "/") {
-		if (name_space_str.substr(0, 2) == "//") {
-			/* if name space obtained by ros::this::node::getNamespace()
-			   starts with "//", delete one of them */
-			name_space_str.erase(name_space_str.begin());
-		}
-		pub_topic_str = name_space_str + pub_topic_str;
-		projection_matrix_topic = name_space_str+projection_matrix_topic;
-		camera_info_topic_str = name_space_str + camera_info_topic_str;
-	}
+  if (name_space_str != "/")
+  {
+    if (name_space_str.substr(0, 2) == "//")
+    {
+      /* if name space obtained by ros::this::node::getNamespace()
+         starts with "//", delete one of them */
+      name_space_str.erase(name_space_str.begin());
+    }
+    pub_topic_str = name_space_str + pub_topic_str;
+    projection_matrix_topic = name_space_str + projection_matrix_topic;
+    camera_info_topic_str = name_space_str + camera_info_topic_str;
+  }
 
-	std::string points_topic;
-	if (private_nh.getParam("points_node", points_topic))
-	{
-		ROS_INFO("[points2image]Setting points node to %s", points_topic.c_str());
-	}
-	else
-	{
-		ROS_INFO("[points2image]No points node received, defaulting to points_raw, you can use _points_node:=YOUR_TOPIC");
-		points_topic = "/points_raw";
-	}
+  std::string points_topic;
+  if (private_nh.getParam("points_node", points_topic))
+  {
+    ROS_INFO("[points2image]Setting points node to %s", points_topic.c_str());
+  }
+  else
+  {
+    ROS_INFO("[points2image]No points node received, defaulting to points_raw, you can use _points_node:=YOUR_TOPIC");
+    points_topic = "/points_raw";
+  }
 
-	ROS_INFO("[points2image]Publishing to... %s", pub_topic_str.c_str());
-	pub = n.advertise<autoware_msgs::PointsImage>(pub_topic_str, 10);
+  ROS_INFO("[points2image]Publishing to... %s", pub_topic_str.c_str());
+  pub = n.advertise<autoware_msgs::PointsImage>(pub_topic_str, 10);
 
-	ros::Subscriber sub = n.subscribe(points_topic, 1, callback);
+  ros::Subscriber sub = n.subscribe(points_topic, 1, callback);
 
-	ROS_INFO("[points2image]Subscribing to... %s", projection_matrix_topic.c_str());
-	ros::Subscriber projection = n.subscribe(projection_matrix_topic, 1, projection_callback);
-	ROS_INFO("[points2image]Subscribing to... %s", camera_info_topic_str.c_str());
-	ros::Subscriber intrinsic = n.subscribe(camera_info_topic_str, 1, intrinsic_callback);
+  ROS_INFO("[points2image]Subscribing to... %s", projection_matrix_topic.c_str());
+  ros::Subscriber projection = n.subscribe(projection_matrix_topic, 1, projection_callback);
+  ROS_INFO("[points2image]Subscribing to... %s", camera_info_topic_str.c_str());
+  ros::Subscriber intrinsic = n.subscribe(camera_info_topic_str, 1, intrinsic_callback);
 
-	ros::spin();
-	return 0;
+  ros::spin();
+  return 0;
 }

--- a/ros/src/sensing/fusion/packages/points2image/nodes/points2vscan/main.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/points2vscan/main.cpp
@@ -1,13 +1,13 @@
 #include "mainwindow.h"
 #include <QApplication>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-    ros::init(argc, argv, "points2vscan");
-    QApplication a(argc, argv);
-    MainWindow w;
+  ros::init(argc, argv, "points2vscan");
+  QApplication a(argc, argv);
+  MainWindow w;
 #ifdef DEBUG_GUI
-    w.show(); //Don't show GUI window
+  w.show();  // Don't show GUI window
 #endif
-    return a.exec();
+  return a.exec();
 }

--- a/ros/src/sensing/fusion/packages/points2image/nodes/points2vscan/mainwindow.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/points2vscan/mainwindow.cpp
@@ -21,268 +21,275 @@ static double IMAGESIZE;
 
 static bool SYNC;
 
-MainWindow::MainWindow(QWidget *parent) :
-    QMainWindow(parent)
+MainWindow::MainWindow(QWidget* parent)
+  : QMainWindow(parent)
 #ifdef DEBUG_GUI
   , ui(new Ui::MainWindow)
 #endif
 {
 #ifdef DEBUG_GUI
-    ui->setupUi(this);
+  ui->setupUi(this);
 #endif
-    ros::NodeHandle private_nh("~");
-    private_nh.param("BEAMNUM", BEAMNUM, 1440);
-    private_nh.param("STEP", STEP, 0.1);
-    private_nh.param("MINFLOOR", MINFLOOR, -3.0);
-    private_nh.param("MAXFLOOR", MAXFLOOR, -1.3);
-    private_nh.param("MAXCEILING", MAXCEILING, 6.0);
-    private_nh.param("MINCEILING", MINCEILING, -0.5);
-    private_nh.param("ROADSLOPMINHEIGHT", ROADSLOPMINHEIGHT, 80.0);
-    private_nh.param("ROADSLOPMAXHEIGHT", ROADSLOPMAXHEIGHT, 30.0);
-    private_nh.param("ROTATION", ROTATION, (double)3);
-    private_nh.param("OBSTACLEMINHEIGHT", OBSTACLEMINHEIGHT, (double)1);
-    private_nh.param("MAXBACKDISTANCE", MAXBACKDISTANCE, (double)1);
-    private_nh.param("PASSHEIGHT", PASSHEIGHT, (double)2);
+  ros::NodeHandle private_nh("~");
+  private_nh.param("BEAMNUM", BEAMNUM, 1440);
+  private_nh.param("STEP", STEP, 0.1);
+  private_nh.param("MINFLOOR", MINFLOOR, -3.0);
+  private_nh.param("MAXFLOOR", MAXFLOOR, -1.3);
+  private_nh.param("MAXCEILING", MAXCEILING, 6.0);
+  private_nh.param("MINCEILING", MINCEILING, -0.5);
+  private_nh.param("ROADSLOPMINHEIGHT", ROADSLOPMINHEIGHT, 80.0);
+  private_nh.param("ROADSLOPMAXHEIGHT", ROADSLOPMAXHEIGHT, 30.0);
+  private_nh.param("ROTATION", ROTATION, (double)3);
+  private_nh.param("OBSTACLEMINHEIGHT", OBSTACLEMINHEIGHT, (double)1);
+  private_nh.param("MAXBACKDISTANCE", MAXBACKDISTANCE, (double)1);
+  private_nh.param("PASSHEIGHT", PASSHEIGHT, (double)2);
 
-    private_nh.param("MAXRANGE", MAXRANGE, 80.0);
-    private_nh.param("MINRANGE", MINRANGE, (double)3);
-    private_nh.param("GRIDSIZE", GRIDSIZE, 10.0);
-    private_nh.param("IMAGESIZE", IMAGESIZE, 1000.0);
+  private_nh.param("MAXRANGE", MAXRANGE, 80.0);
+  private_nh.param("MINRANGE", MINRANGE, (double)3);
+  private_nh.param("GRIDSIZE", GRIDSIZE, 10.0);
+  private_nh.param("IMAGESIZE", IMAGESIZE, 1000.0);
 
-    private_nh.param("SYNC", SYNC, false);
+  private_nh.param("SYNC", SYNC, false);
 
-    if (SYNC == false) {
-        velodyne=new ROSSub<sensor_msgs::PointCloud2ConstPtr>("points_raw",1000,10);
-    } else {
-        velodyne=new ROSSub<sensor_msgs::PointCloud2ConstPtr>("/sync_drivers/points_raw",1000,10);
-    }
-    connect(velodyne,SIGNAL(receiveMessageSignal()),this,SLOT(generateVirtualScanSlot()));
-    vsros=new ROSPub<sensor_msgs::PointCloud2>("/vscan_points",1000);
-    scanros=new ROSPub<sensor_msgs::LaserScan>("/scan",1000);
-
+  if (SYNC == false)
+  {
+    velodyne = new ROSSub<sensor_msgs::PointCloud2ConstPtr>("points_raw", 1000, 10);
+  }
+  else
+  {
+    velodyne = new ROSSub<sensor_msgs::PointCloud2ConstPtr>("/sync_drivers/points_raw", 1000, 10);
+  }
+  connect(velodyne, SIGNAL(receiveMessageSignal()), this, SLOT(generateVirtualScanSlot()));
+  vsros = new ROSPub<sensor_msgs::PointCloud2>("/vscan_points", 1000);
+  scanros = new ROSPub<sensor_msgs::LaserScan>("/scan", 1000);
 
 #ifdef DEBUG_GUI
-    double PI=3.141592654;
-    double density=2*PI/BEAMNUM;
-    for(int i=0;i<BEAMNUM;i++)
-    {
-        ui->comboBox->insertItem(i,QString("%1").arg((i*density-PI)*180.0/PI));
-    }
-    ui->comboBox->insertItem(BEAMNUM,"NULL");
+  double PI = 3.141592654;
+  double density = 2 * PI / BEAMNUM;
+  for (int i = 0; i < BEAMNUM; i++)
+  {
+    ui->comboBox->insertItem(i, QString("%1").arg((i * density - PI) * 180.0 / PI));
+  }
+  ui->comboBox->insertItem(BEAMNUM, "NULL");
 
-    connect(ui->comboBox,SIGNAL(currentIndexChanged(int)),this,SLOT(showMatrixSlot(int)));
-    connect(ui->step,SIGNAL(valueChanged(double)),this,SLOT(recalculateSlot()));
-    connect(ui->rotation,SIGNAL(valueChanged(double)),this,SLOT(recalculateSlot()));
-    connect(ui->minrange,SIGNAL(valueChanged(double)),this,SLOT(recalculateSlot()));
+  connect(ui->comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(showMatrixSlot(int)));
+  connect(ui->step, SIGNAL(valueChanged(double)), this, SLOT(recalculateSlot()));
+  connect(ui->rotation, SIGNAL(valueChanged(double)), this, SLOT(recalculateSlot()));
+  connect(ui->minrange, SIGNAL(valueChanged(double)), this, SLOT(recalculateSlot()));
 
-    ui->label->resize(IMAGESIZE,IMAGESIZE);
-    image=QImage(IMAGESIZE,IMAGESIZE,QImage::Format_RGB888);
-    drawGrid();
+  ui->label->resize(IMAGESIZE, IMAGESIZE);
+  image = QImage(IMAGESIZE, IMAGESIZE, QImage::Format_RGB888);
+  drawGrid();
 #endif
 
-    velodyne->startReceiveSlot();
+  velodyne->startReceiveSlot();
 }
 
 MainWindow::~MainWindow()
 {
-    velodyne->stopReceiveSlot();
-    delete velodyne;
-    delete vsros;
-    delete scanros;
+  velodyne->stopReceiveSlot();
+  delete velodyne;
+  delete vsros;
+  delete scanros;
 #ifdef DEBUG_GUI
-    delete ui;
+  delete ui;
 #endif
 }
 
 void MainWindow::generateVirtualScanSlot()
 {
-    virtualscan.velodyne=velodyne->getMessage();
-    recalculateSlot();
+  virtualscan.velodyne = velodyne->getMessage();
+  recalculateSlot();
 }
 
 void MainWindow::showMatrixSlot(int beamid)
 {
-    if(beamid>=BEAMNUM)
-    {
-        return;
-    }
-    ui->tableWidget->clear();
-    int size=int((MAXCEILING-MINFLOOR)/STEP+0.5);
-    ui->tableWidget->setRowCount(size);
-    ui->tableWidget->setColumnCount(5);
-    for(int i=0;i<size;i++)
-    {
-        ui->tableWidget->setVerticalHeaderItem(i,new QTableWidgetItem(QString("%1").arg(MINFLOOR+i*STEP)));
-    }
-    ui->tableWidget->setHorizontalHeaderLabels(QStringList()<<"RotID"<<"RotLength"<<"RotHeight"<<"Length"<<"Height");
+  if (beamid >= BEAMNUM)
+  {
+    return;
+  }
+  ui->tableWidget->clear();
+  int size = int((MAXCEILING - MINFLOOR) / STEP + 0.5);
+  ui->tableWidget->setRowCount(size);
+  ui->tableWidget->setColumnCount(5);
+  for (int i = 0; i < size; i++)
+  {
+    ui->tableWidget->setVerticalHeaderItem(i, new QTableWidgetItem(QString("%1").arg(MINFLOOR + i * STEP)));
+  }
+  ui->tableWidget->setHorizontalHeaderLabels(QStringList() << "RotID"
+                                                           << "RotLength"
+                                                           << "RotHeight"
+                                                           << "Length"
+                                                           << "Height");
 
-    for(int i=0;i<size;i++)
-    {
-        ui->tableWidget->setItem(i,0,new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].rotid)));
-        ui->tableWidget->setItem(i,1,new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].rotlength)));
-        ui->tableWidget->setItem(i,2,new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].rotheight)));
-        ui->tableWidget->setItem(i,3,new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].length)));
-        ui->tableWidget->setItem(i,4,new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].height)));
-    }
-    drawBeam(beamid);
+  for (int i = 0; i < size; i++)
+  {
+    ui->tableWidget->setItem(i, 0, new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].rotid)));
+    ui->tableWidget->setItem(i, 1, new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].rotlength)));
+    ui->tableWidget->setItem(i, 2, new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].rotheight)));
+    ui->tableWidget->setItem(i, 3, new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].length)));
+    ui->tableWidget->setItem(i, 4, new QTableWidgetItem(QString("%1").arg(virtualscan.svs[beamid][i].height)));
+  }
+  drawBeam(beamid);
 }
 
 void MainWindow::recalculateSlot()
 {
-    double PI=3.141592654;
-    double density=2*PI/BEAMNUM;
+  double PI = 3.141592654;
+  double density = 2 * PI / BEAMNUM;
 #ifdef DEBUG_GUI
-    QTime start=QTime::currentTime();
+  QTime start = QTime::currentTime();
 #endif
-    virtualscan.calculateVirtualScans(BEAMNUM,STEP,MINFLOOR,MAXCEILING,OBSTACLEMINHEIGHT,MAXBACKDISTANCE,ROTATION*PI/180.0, MINRANGE);
+  virtualscan.calculateVirtualScans(BEAMNUM, STEP, MINFLOOR, MAXCEILING, OBSTACLEMINHEIGHT, MAXBACKDISTANCE,
+                                    ROTATION * PI / 180.0, MINRANGE);
 #ifdef DEBUG_GUI
-    QTime end=QTime::currentTime();
+  QTime end = QTime::currentTime();
 #endif
-    virtualscan.getVirtualScan(ROADSLOPMINHEIGHT*PI/180.0,ROADSLOPMAXHEIGHT*PI/180.0,MAXFLOOR,MINCEILING,PASSHEIGHT,beams);
+  virtualscan.getVirtualScan(ROADSLOPMINHEIGHT * PI / 180.0, ROADSLOPMAXHEIGHT * PI / 180.0, MAXFLOOR, MINCEILING,
+                             PASSHEIGHT, beams);
 #ifdef DEBUG_GUI
-    ui->tc->setText(QString("%1").arg(start.msecsTo(end)));
+  ui->tc->setText(QString("%1").arg(start.msecsTo(end)));
 #endif
 
+  {
+    sensor_msgs::PointCloud2 msg;
+    msg.header = virtualscan.velodyne->header;
+    msg.fields = virtualscan.velodyne->fields;
+    msg.height = 2;
+    msg.width = BEAMNUM;
+    msg.point_step = 8 * sizeof(float);
+    msg.row_step = msg.width * msg.point_step;
+    msg.data.resize(msg.height * msg.width * msg.point_step);
+    unsigned char* base = msg.data.data();
+
+    for (int i = 0; i < BEAMNUM; i++)
     {
-        sensor_msgs::PointCloud2 msg;
-        msg.header=virtualscan.velodyne->header;
-        msg.fields=virtualscan.velodyne->fields;
-        msg.height=2;
-        msg.width=BEAMNUM;
-        msg.point_step=8*sizeof(float);
-        msg.row_step=msg.width*msg.point_step;
-        msg.data.resize(msg.height*msg.width*msg.point_step);
-        unsigned char * base=msg.data.data();
+      double theta = i * density - PI;
+      float* data;
+      int* ring;
 
+      data = (float*)(base + (2 * i) * msg.point_step);
+      data[0] = beams[i] * cos(theta);
+      data[1] = beams[i] * sin(theta);
+      data[2] = virtualscan.minheights[i];
+      data[4] = 255;
+      ring = (int*)(data + 5 * sizeof(float));
+      *ring = 0;
 
-        for(int i=0;i<BEAMNUM;i++)
-        {
-            double theta=i*density-PI;
-            float * data;
-            int * ring;
-
-            data=(float *)(base + (2*i) * msg.point_step);
-            data[0]=beams[i]*cos(theta);
-            data[1]=beams[i]*sin(theta);
-            data[2]=virtualscan.minheights[i];
-            data[4]=255;
-            ring=(int *)(data+5*sizeof(float));
-            *ring=0;
-
-            data=(float *)(base + (2*i+1) * msg.point_step);
-            data[0]=beams[i]*cos(theta);
-            data[1]=beams[i]*sin(theta);
-            data[2]=virtualscan.maxheights[i];
-            data[4]=255;
-            ring=(int *)(data+5*sizeof(float));
-            *ring=1;
-        }
-        vsros->sendMessage(msg);
+      data = (float*)(base + (2 * i + 1) * msg.point_step);
+      data[0] = beams[i] * cos(theta);
+      data[1] = beams[i] * sin(theta);
+      data[2] = virtualscan.maxheights[i];
+      data[4] = 255;
+      ring = (int*)(data + 5 * sizeof(float));
+      *ring = 1;
     }
+    vsros->sendMessage(msg);
+  }
 
+  {
+    sensor_msgs::LaserScan msg;
+    msg.header.frame_id = virtualscan.velodyne->header.frame_id;
+    msg.header.seq = virtualscan.velodyne->header.seq;
+    msg.header.stamp = virtualscan.velodyne->header.stamp;
+    msg.angle_min = -PI;
+    msg.angle_max = PI;
+    msg.angle_increment = density;
+    msg.time_increment = 0;
+    msg.scan_time = 0.1;
+    msg.range_min = 0.1;
+    msg.range_max = 100;
+    msg.ranges.resize(BEAMNUM);
+    msg.intensities.resize(BEAMNUM);
+    for (int i = 0; i < BEAMNUM; i++)
     {
-        sensor_msgs::LaserScan msg;
-        msg.header.frame_id=virtualscan.velodyne->header.frame_id;
-        msg.header.seq=virtualscan.velodyne->header.seq;
-        msg.header.stamp=virtualscan.velodyne->header.stamp;
-        msg.angle_min=-PI;
-        msg.angle_max=PI;
-        msg.angle_increment=density;
-        msg.time_increment=0;
-        msg.scan_time=0.1;
-        msg.range_min=0.1;
-        msg.range_max=100;
-        msg.ranges.resize(BEAMNUM);
-        msg.intensities.resize(BEAMNUM);
-        for(int i=0;i<BEAMNUM;i++)
-        {
-            msg.ranges[i]=beams[i];
-            msg.intensities[i]=255;
-        }
-        scanros->sendMessage(msg);
+      msg.ranges[i] = beams[i];
+      msg.intensities[i] = 255;
     }
+    scanros->sendMessage(msg);
+  }
 
 #ifdef DEBUG_GUI
-    drawGrid();
-    drawPoints();
-    showMatrixSlot(ui->comboBox->currentIndex());
+  drawGrid();
+  drawPoints();
+  showMatrixSlot(ui->comboBox->currentIndex());
 #endif
 }
 
 QPointF MainWindow::convert2RealPoint(QPoint point)
 {
-    QPointF result;
-    double ratio=2*MAXRANGE/IMAGESIZE;
+  QPointF result;
+  double ratio = 2 * MAXRANGE / IMAGESIZE;
 
-    result.setX((IMAGESIZE/2.0-point.y())*ratio);
-    result.setY((IMAGESIZE/2.0-point.x())*ratio);
+  result.setX((IMAGESIZE / 2.0 - point.y()) * ratio);
+  result.setY((IMAGESIZE / 2.0 - point.x()) * ratio);
 
-    return result;
+  return result;
 }
 
 QPoint MainWindow::convert2ImagePoint(QPointF point)
 {
-    QPoint result;
-    double ratio=IMAGESIZE/(2*MAXRANGE);
+  QPoint result;
+  double ratio = IMAGESIZE / (2 * MAXRANGE);
 
-    result.setX(int(IMAGESIZE/2.0-point.y()*ratio+0.5));
-    result.setY(int(IMAGESIZE/2.0-point.x()*ratio+0.5));
+  result.setX(int(IMAGESIZE / 2.0 - point.y() * ratio + 0.5));
+  result.setY(int(IMAGESIZE / 2.0 - point.x() * ratio + 0.5));
 
-    return result;
+  return result;
 }
 
 void MainWindow::drawGrid()
 {
-    image.fill(QColor(255,255,255));
-    QPainter painter;
-    painter.begin(&image);
-    painter.setPen(QColor(128,128,128));
+  image.fill(QColor(255, 255, 255));
+  QPainter painter;
+  painter.begin(&image);
+  painter.setPen(QColor(128, 128, 128));
 
-    QPoint center(IMAGESIZE/2,IMAGESIZE/2);
-    double gridstep=(GRIDSIZE/MAXRANGE)*(IMAGESIZE/2);
-    for(int i=gridstep;i<=IMAGESIZE/2;i+=gridstep)
-    {
-        painter.drawEllipse(center,i,i);
-    }
-    painter.end();
-    ui->label->setPixmap(QPixmap::fromImage(image));
+  QPoint center(IMAGESIZE / 2, IMAGESIZE / 2);
+  double gridstep = (GRIDSIZE / MAXRANGE) * (IMAGESIZE / 2);
+  for (int i = gridstep; i <= IMAGESIZE / 2; i += gridstep)
+  {
+    painter.drawEllipse(center, i, i);
+  }
+  painter.end();
+  ui->label->setPixmap(QPixmap::fromImage(image));
 }
 
 void MainWindow::drawPoints()
 {
-    QPainter painter;
-    painter.begin(&image);
-    painter.setPen(QColor(255,0,0));
-    double PI=3.141592654;
-    double density=2*PI/BEAMNUM;
+  QPainter painter;
+  painter.begin(&image);
+  painter.setPen(QColor(255, 0, 0));
+  double PI = 3.141592654;
+  double density = 2 * PI / BEAMNUM;
 
-    for(int i=0;i<BEAMNUM;i++)
-    {
-        double theta=i*density-PI;
-        QPoint point=convert2ImagePoint(QPointF(beams[i]*cos(theta),beams[i]*sin(theta)));
-        painter.drawEllipse(point,1,1);
-    }
-    painter.end();
-    ui->label->setPixmap(QPixmap::fromImage(image));
+  for (int i = 0; i < BEAMNUM; i++)
+  {
+    double theta = i * density - PI;
+    QPoint point = convert2ImagePoint(QPointF(beams[i] * cos(theta), beams[i] * sin(theta)));
+    painter.drawEllipse(point, 1, 1);
+  }
+  painter.end();
+  ui->label->setPixmap(QPixmap::fromImage(image));
 }
 
 void MainWindow::drawBeam(int beamid)
 {
-    drawGrid();
-    drawPoints();
-    if(beamid>=BEAMNUM)
-    {
-        return;
-    }
-    QPainter painter;
-    painter.begin(&image);
-    painter.setPen(QColor(0,0,255));
-    QPoint center(IMAGESIZE/2,IMAGESIZE/2);
-    double PI=3.141592654;
-    double density=2*PI/BEAMNUM;
-    double theta=beamid*density-PI;
-    QPoint point=convert2ImagePoint(QPointF(beams[beamid]*cos(theta),beams[beamid]*sin(theta)));
-    painter.drawLine(center,point);
-    painter.end();
-    ui->label->setPixmap(QPixmap::fromImage(image));
+  drawGrid();
+  drawPoints();
+  if (beamid >= BEAMNUM)
+  {
+    return;
+  }
+  QPainter painter;
+  painter.begin(&image);
+  painter.setPen(QColor(0, 0, 255));
+  QPoint center(IMAGESIZE / 2, IMAGESIZE / 2);
+  double PI = 3.141592654;
+  double density = 2 * PI / BEAMNUM;
+  double theta = beamid * density - PI;
+  QPoint point = convert2ImagePoint(QPointF(beams[beamid] * cos(theta), beams[beamid] * sin(theta)));
+  painter.drawLine(center, point);
+  painter.end();
+  ui->label->setPixmap(QPixmap::fromImage(image));
 }

--- a/ros/src/sensing/fusion/packages/points2image/nodes/points2vscan/mainwindow.h
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/points2vscan/mainwindow.h
@@ -11,41 +11,43 @@
 #include <fastvirtualscan/fastvirtualscan.h>
 #include <sensor_msgs/LaserScan.h>
 
-
 //#define DEBUG_GUI
 
-namespace Ui {
+namespace Ui
+{
 class MainWindow;
 }
 
 class MainWindow : public QMainWindow
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = 0);
-    ~MainWindow();
+  explicit MainWindow(QWidget* parent = 0);
+  ~MainWindow();
 
 private:
-    Ui::MainWindow *ui;
+  Ui::MainWindow* ui;
+
 protected:
-    ROSSub<sensor_msgs::PointCloud2ConstPtr> * velodyne;
-    ROSPub<sensor_msgs::PointCloud2> * vsros;
-    ROSPub<sensor_msgs::LaserScan> * scanros;
-    FastVirtualScan virtualscan;
-    QVector<double> beams;
-    QVector<double> heights;
-    QImage image;
+  ROSSub<sensor_msgs::PointCloud2ConstPtr>* velodyne;
+  ROSPub<sensor_msgs::PointCloud2>* vsros;
+  ROSPub<sensor_msgs::LaserScan>* scanros;
+  FastVirtualScan virtualscan;
+  QVector<double> beams;
+  QVector<double> heights;
+  QImage image;
 public slots:
-    void generateVirtualScanSlot();
-    void showMatrixSlot(int beamid);
-    void recalculateSlot();
+  void generateVirtualScanSlot();
+  void showMatrixSlot(int beamid);
+  void recalculateSlot();
+
 protected:
-    QPointF convert2RealPoint(QPoint point);
-    QPoint convert2ImagePoint(QPointF point);
-    void drawGrid();
-    void drawPoints();
-    void drawBeam(int beamid);
+  QPointF convert2RealPoint(QPoint point);
+  QPoint convert2ImagePoint(QPointF point);
+  void drawGrid();
+  void drawPoints();
+  void drawBeam(int beamid);
 };
 
-#endif // MAINWINDOW_H
+#endif  // MAINWINDOW_H

--- a/ros/src/sensing/fusion/packages/points2image/nodes/vscan2image/vscan2image.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/vscan2image/vscan2image.cpp
@@ -42,7 +42,6 @@
 #define DISTCOEFF "DistCoeff"
 #define IMAGESIZE "ImageSize"
 
-
 static cv::Mat cameraExtrinsicMat;
 static cv::Mat cameraMat;
 static cv::Mat distCoeff;
@@ -51,78 +50,83 @@ static ros::Publisher pub;
 
 static void projection_callback(const autoware_msgs::projection_matrix& msg)
 {
-	cameraExtrinsicMat = cv::Mat(4,4,CV_64F);
-	for (int row=0; row<4; row++) {
-		for (int col=0; col<4; col++) {
-			cameraExtrinsicMat.at<double>(row, col) = msg.projection_matrix[row * 4 + col];
-		}
-	}
+  cameraExtrinsicMat = cv::Mat(4, 4, CV_64F);
+  for (int row = 0; row < 4; row++)
+  {
+    for (int col = 0; col < 4; col++)
+    {
+      cameraExtrinsicMat.at<double>(row, col) = msg.projection_matrix[row * 4 + col];
+    }
+  }
 }
 
 static void intrinsic_callback(const sensor_msgs::CameraInfo& msg)
 {
-	imageSize.height = msg.height;
-	imageSize.width = msg.width;
+  imageSize.height = msg.height;
+  imageSize.width = msg.width;
 
-	cameraMat = cv::Mat(3,3, CV_64F);
-	for (int row=0; row<3; row++) {
-		for (int col=0; col<3; col++) {
-			cameraMat.at<double>(row, col) = msg.K[row * 3 + col];
-		}
-	}
+  cameraMat = cv::Mat(3, 3, CV_64F);
+  for (int row = 0; row < 3; row++)
+  {
+    for (int col = 0; col < 3; col++)
+    {
+      cameraMat.at<double>(row, col) = msg.K[row * 3 + col];
+    }
+  }
 
-	distCoeff = cv::Mat(1,5,CV_64F);
-	for (int col=0; col<5; col++) {
-		distCoeff.at<double>(col) = msg.D[col];
-	}
+  distCoeff = cv::Mat(1, 5, CV_64F);
+  for (int col = 0; col < 5; col++)
+  {
+    distCoeff.at<double>(col) = msg.D[col];
+  }
 }
 
 static void callback(const sensor_msgs::PointCloud2ConstPtr& msg)
 {
-	if (cameraExtrinsicMat.empty() || cameraMat.empty() || distCoeff.empty() || imageSize.height == 0 || imageSize.width == 0)
-	{
-		ROS_INFO("Looks like /camera/camera_info or /projection_matrix are not being published.. Please check that both are running..");
-		return;
-	}
-	autoware_msgs::PointsImage pub_msg
-		= pointcloud2_to_image(msg, cameraExtrinsicMat,
-				       cameraMat, distCoeff, imageSize);
-	pub.publish(pub_msg);
+  if (cameraExtrinsicMat.empty() || cameraMat.empty() || distCoeff.empty() || imageSize.height == 0 ||
+      imageSize.width == 0)
+  {
+    ROS_INFO("Looks like /camera/camera_info or /projection_matrix are not being published.. Please check that both "
+             "are running..");
+    return;
+  }
+  autoware_msgs::PointsImage pub_msg = pointcloud2_to_image(msg, cameraExtrinsicMat, cameraMat, distCoeff, imageSize);
+  pub.publish(pub_msg);
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-	ros::init(argc, argv, "vscan2image");
-	ros::NodeHandle n;
-	ros::NodeHandle private_nh("~");
-	std::string cameraInfo_topic_name;
-	private_nh.param<std::string>("camera_info_topic", cameraInfo_topic_name, "/camera/camera_info");
-	std::string projectionMat_topic_name;
-	private_nh.param<std::string>("projection_matrix_topic", projectionMat_topic_name, "/projection_matrix");
+  ros::init(argc, argv, "vscan2image");
+  ros::NodeHandle n;
+  ros::NodeHandle private_nh("~");
+  std::string cameraInfo_topic_name;
+  private_nh.param<std::string>("camera_info_topic", cameraInfo_topic_name, "/camera/camera_info");
+  std::string projectionMat_topic_name;
+  private_nh.param<std::string>("projection_matrix_topic", projectionMat_topic_name, "/projection_matrix");
 
-	/*if(argc < 2){
-		std::cout<<"Need calibration filename as the first parameter.";
-		return 0;
-	}
+  /*if(argc < 2){
+    std::cout<<"Need calibration filename as the first parameter.";
+    return 0;
+  }
 
-	cv::FileStorage fs(argv[1], cv::FileStorage::READ);
-	if(!fs.isOpened()){
-		std::cout<<"Invalid calibration filename.";
-		return 0;
-	}
+  cv::FileStorage fs(argv[1], cv::FileStorage::READ);
+  if(!fs.isOpened()){
+    std::cout<<"Invalid calibration filename.";
+    return 0;
+  }
 
-	fs[CAMERAEXTRINSICMAT] >> cameraExtrinsicMat;
-	fs[CAMERAMAT] >> cameraMat;
-	fs[DISTCOEFF] >> distCoeff;
+  fs[CAMERAEXTRINSICMAT] >> cameraExtrinsicMat;
+  fs[CAMERAMAT] >> cameraMat;
+  fs[DISTCOEFF] >> distCoeff;
     fs[IMAGESIZE] >> imageSize;*/
-	//imageSize.width = IMAGE_WIDTH;
-	//imageSize.height = IMAGE_HEIGHT;
+  // imageSize.width = IMAGE_WIDTH;
+  // imageSize.height = IMAGE_HEIGHT;
 
-	pub = n.advertise<autoware_msgs::PointsImage>("vscan_image", 10);
-	ros::Subscriber sub = n.subscribe("vscan_points", 1, callback);
-	ros::Subscriber projection = n.subscribe(projectionMat_topic_name, 1, projection_callback);
-	ros::Subscriber intrinsic = n.subscribe(cameraInfo_topic_name, 1, intrinsic_callback);
+  pub = n.advertise<autoware_msgs::PointsImage>("vscan_image", 10);
+  ros::Subscriber sub = n.subscribe("vscan_points", 1, callback);
+  ros::Subscriber projection = n.subscribe(projectionMat_topic_name, 1, projection_callback);
+  ros::Subscriber intrinsic = n.subscribe(cameraInfo_topic_name, 1, intrinsic_callback);
 
-	ros::spin();
-	return 0;
+  ros::spin();
+  return 0;
 }

--- a/ros/src/sensing/fusion/packages/points2image/nodes/vscan2linelist/vscan2linelist.cpp
+++ b/ros/src/sensing/fusion/packages/points2image/nodes/vscan2linelist/vscan2linelist.cpp
@@ -45,52 +45,51 @@ const std::string FRAME = "/velodyne";
 
 static void Callback(const sensor_msgs::PointCloud2ConstPtr& msg)
 {
+  pcl::fromROSMsg(*msg, _vscan);
+  //  int i = 0;
+  for (pcl::PointCloud<pcl::PointXYZ>::const_iterator item = _vscan.begin(); item != _vscan.end(); item++)
+  {
+    if ((item->x == 0 && item->y == 0))
+      continue;
+    // if (i < _loop_limit) {
+    // std::cout << "vscan_points : ( " << item->x << " , " << item->y << " , " << item->z << " )" << std::endl;
 
-    pcl::fromROSMsg(*msg, _vscan);
-    //  int i = 0;
-    for (pcl::PointCloud<pcl::PointXYZ>::const_iterator item = _vscan.begin(); item != _vscan.end(); item++) {
-        if ((item->x == 0 && item->y == 0))
-            continue;
-        // if (i < _loop_limit) {
-            // std::cout << "vscan_points : ( " << item->x << " , " << item->y << " , " << item->z << " )" << std::endl;
+    geometry_msgs::Point point;
+    point.x = item->x;
+    point.y = item->y;
+    point.z = item->z;
+    _linelist.points.push_back(point);
 
-            geometry_msgs::Point point;
-            point.x = item->x;
-            point.y = item->y;
-            point.z = item->z;
-            _linelist.points.push_back(point);
-
-            //}else{
-            // break;
-            // }
-            //i++;
-
-    }
-   // std::cout << "i = " << i << std::endl;
-    _pub.publish(_linelist);
-    _linelist.points.clear();
+    //}else{
+    // break;
+    // }
+    // i++;
+  }
+  // std::cout << "i = " << i << std::endl;
+  _pub.publish(_linelist);
+  _linelist.points.clear();
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-    ros::init(argc, argv, "vscan2linelist");
-    ros::NodeHandle nh;
+  ros::init(argc, argv, "vscan2linelist");
+  ros::NodeHandle nh;
 
-    _pub = nh.advertise<visualization_msgs::Marker>("vscan_linelist", 10);
-    ros::Subscriber sub = nh.subscribe("vscan_points", 100, Callback);
+  _pub = nh.advertise<visualization_msgs::Marker>("vscan_linelist", 10);
+  ros::Subscriber sub = nh.subscribe("vscan_points", 100, Callback);
 
-    _linelist.header.frame_id = FRAME;
-    _linelist.header.stamp = ros::Time(0);
-    _linelist.ns = "vscan_linelist";
-    _linelist.id = 0;
-    _linelist.type = visualization_msgs::Marker::LINE_LIST;
-    _linelist.action = visualization_msgs::Marker::ADD;
-    _linelist.scale.x = 0.15;
-    _linelist.color.a = 0.5;
-    _linelist.color.r = 0.0;
-    _linelist.color.g = 1.0;
-    _linelist.color.b = 0.0;
-    
-    ros::spin();
-    return 0;
+  _linelist.header.frame_id = FRAME;
+  _linelist.header.stamp = ros::Time(0);
+  _linelist.ns = "vscan_linelist";
+  _linelist.id = 0;
+  _linelist.type = visualization_msgs::Marker::LINE_LIST;
+  _linelist.action = visualization_msgs::Marker::ADD;
+  _linelist.scale.x = 0.15;
+  _linelist.color.a = 0.5;
+  _linelist.color.r = 0.0;
+  _linelist.color.g = 1.0;
+  _linelist.color.b = 0.0;
+
+  ros::spin();
+  return 0;
 }


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fixed /points2image and /calibration_publisher. autowarefoundation/autoware_ai#162 
In order to reduce processing load, we changed the following two points.
(1) Improve the part calculated using OpenCV.
(2) We stopped wasteful memory allocation processing and optimized it.

Also, the /camera_info and /projection_matrix topics are useless because they are designed to keep publishing the same value. Changed calibration_publisher to publish in latch.

## Todos
- [x] Tests
- [ ] Documentation


## Steps to Test or Reproduce
Prepare a rosbag file containing / points_raw and / image_raw and a camera calibration file in advance.
After calibration publisher and points image are started up, compare the CPU load before and after change.
![image](https://user-images.githubusercontent.com/33311630/40289570-2204f648-5cf4-11e8-9e2e-a543975a2100.png)

Before : 50% to 110% CPU(When HDL32e LiDAR is used)
![image](https://user-images.githubusercontent.com/33311630/40288871-5e8830fc-5cf0-11e8-9cdd-b76594849fa4.png)

After : 20% or less CPU(When HDL32e LiDAR is used)
![image](https://user-images.githubusercontent.com/33311630/40288855-4577384c-5cf0-11e8-9226-4816c8270402.png)
