### PR TITLE
Added ID for multiple camera frames

### DIFF
--- a/ros/src/sensing/drivers/camera/packages/baumer/nodes/vlg22/src/vlg22_main.cpp
+++ b/ros/src/sensing/drivers/camera/packages/baumer/nodes/vlg22/src/vlg22_main.cpp
@@ -226,13 +226,14 @@ void ros_init_publishers(ros::NodeHandle node_handle, ros::Publisher publishers[
 	}
 }
 
-sensor_msgs::Image ros_prepare_image(int count, cv::Mat image)
+sensor_msgs::Image ros_prepare_image(int count, cv::Mat image, size_t camera_id)
 {
 	//ROS publish*******************
 	sensor_msgs::Image msg;
 
 	msg.header.seq = count;
-	msg.header.frame_id = "camera";
+	std::string frame = "camera" + std::to_string(camera_id);
+	msg.header.frame_id = frame;
 	msg.header.stamp.sec = ros::Time::now().sec;
 	msg.header.stamp.nsec = ros::Time::now().nsec;
 	msg.height = image.size().height;
@@ -361,7 +362,7 @@ int main(int argc, char **argv)
 				                exposure,
 				                exposure_delta);
 
-				sensor_msgs::Image msg = ros_prepare_image(count, resized_color_image);
+				sensor_msgs::Image msg = ros_prepare_image(count, resized_color_image, i);
 
 				pub[i].publish(msg);
 				res = cameraPointers[i]->setImage( pImage );

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/grasshopper3/grasshopper3.cpp
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/grasshopper3/grasshopper3.cpp
@@ -37,7 +37,7 @@
 */
 
 #include <iostream>
-
+#include <stdlib.h>
 #include <FlyCapture2.h>
 #include <ros/ros.h>
 #include <sensor_msgs/image_encodings.h>
@@ -519,7 +519,8 @@ int main(int argc, char **argv)
 			//publish*******************
 
 			msg.header.seq = count;
-			msg.header.frame_id = "camera";
+			std::string frame = "camera" + std::to_string(camera_id);
+			msg.header.frame_id = frame;
 			msg.header.stamp.sec = ros::Time::now().sec;
 			msg.header.stamp.nsec = ros::Time::now().nsec;
 			msg.height = image.GetRows();

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/grasshopper3/grasshopper3.cpp
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/grasshopper3/grasshopper3.cpp
@@ -519,7 +519,7 @@ int main(int argc, char **argv)
 			//publish*******************
 
 			msg.header.seq = count;
-			std::string frame = "camera" + std::to_string(camera_id);
+			std::string frame = "camera" + std::to_string(i);
 			msg.header.frame_id = frame;
 			msg.header.stamp.sec = ros::Time::now().sec;
 			msg.header.stamp.nsec = ros::Time::now().nsec;

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/ladybug/ladybug.cpp
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/ladybug/ladybug.cpp
@@ -1,11 +1,10 @@
 #include <iostream>
 #include <string>
 #include <sstream>
-#include "ladybug.h"
-#include "ladybugstream.h"
 #include <stdexcept>
 #include <unistd.h>
 #include <signal.h>
+#include <stdlib.h>
 
 #include <ros/ros.h>
 #include <sensor_msgs/image_encodings.h>
@@ -20,6 +19,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "ladybug.h"
+#include "ladybugstream.h"
 
 using namespace std;
 
@@ -117,12 +117,13 @@ void GetMatricesFromFile(ros::NodeHandle nh, sensor_msgs::CameraInfo &camerainfo
 	parseCameraInfo(cameraMat, distCoeff, imageSize, camerainfo_msg);
 }
 
-void publishImage(cv::Mat& image, ros::Publisher& image_pub, long int& count)
+void publishImage(cv::Mat& image, ros::Publisher& image_pub, long int& count, size_t camera_id)
 {
 	sensor_msgs::Image msg;
 	//publish*******************
 	msg.header.seq = count;
-	msg.header.frame_id = "camera";
+	std::string frame = "camera" + std::to_string(camera_id);
+	msg.header.frame_id = frame;
 	msg.header.stamp.sec = ros::Time::now().sec; msg.header.stamp.nsec = ros::Time::now().nsec;
 	msg.height = image.size().height; msg.width  = image.size().width;
 	msg.encoding = "rgb8";
@@ -372,11 +373,11 @@ int main (int argc, char **argv)
 
 			unlock_image(currentImage.uiBufferIndex);
 
-			publishImage(image, pub[LADYBUG_NUM_CAMERAS - i], count);
+			publishImage(image, pub[LADYBUG_NUM_CAMERAS - i], count, i);
 
 		}
 		//publish stitched one
-		publishImage(full_size, pub[0], count);
+		publishImage(full_size, pub[0], count, LADYBUG_NUM_CAMERAS);
 		ros::spinOnce();
 		loop_rate.sleep();
 		count++;

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/ladybug/ladybug.cpp
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/nodes/ladybug/ladybug.cpp
@@ -373,7 +373,7 @@ int main (int argc, char **argv)
 
 			unlock_image(currentImage.uiBufferIndex);
 
-			publishImage(image, pub[LADYBUG_NUM_CAMERAS - i], count, i);
+			publishImage(image, pub[LADYBUG_NUM_CAMERAS - i], count, LADYBUG_NUM_CAMERAS - i);
 
 		}
 		//publish stitched one


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fixes autowarefoundation/autoware_ai#165 

## Todos
- [X] Tests

## Steps to Test or Reproduce
Follow steps in autowarefoundation/autoware_ai#165 
1. Run `rostopic echo /topic` on a terminal or rqt topic viewer.
1. Confirm each instance of the camera has a different frame_id.
