### PR TITLE
Feature/velocity interpolation

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.cpp
@@ -41,6 +41,7 @@ PurePursuit::PurePursuit()
   , lookahead_distance_(0)
   , current_linear_velocity_(0)
   , minimum_lookahead_distance_(6)
+  , past_closest_waypoints_(2)
 {
 }
 
@@ -276,6 +277,54 @@ bool PurePursuit::canGetCurvature(double *output_kappa)
 
   *output_kappa = calcCurvature(next_target_position_);
   return true;
+}
+
+double PurePursuit::calcInterpolateVelocity()
+{
+  if (current_waypoints_.empty())
+  {
+    return 0.0;
+  }
+  else if (current_waypoints_.size() < 1)
+  {
+    return current_waypoints_.at(0).twist.twist.linear.x;
+  }
+
+  const autoware_msgs::waypoint& wp = current_waypoints_.at(1);
+  const geometry_msgs::Point& pw = wp.pose.pose.position;
+  double dist = 0.0;
+  if (past_closest_waypoints_.size() == 2)
+  {
+    const geometry_msgs::Point& p1 = past_closest_waypoints_[1].pose.pose.position;
+    dist = std::hypot(pw.x - p1.x, pw.y - p1.y);
+  }
+  if (past_closest_waypoints_.size() < 2 || dist > 0.0)
+  {
+    past_closest_waypoints_.push_back(wp);
+  }
+
+  const geometry_msgs::Point& p0 = past_closest_waypoints_[0].pose.pose.position;
+  const geometry_msgs::Point& pc = current_pose_.position;
+  const double v0 = past_closest_waypoints_[0].twist.twist.linear.x;
+  const double v1 = wp.twist.twist.linear.x;
+  const double d[3] =
+  {
+    (pw.x - p0.x) * (pw.x - p0.x) + (pw.y - p0.y) * (pw.y - p0.y),
+    (pc.x - p0.x) * (pc.x - p0.x) + (pc.y - p0.y) * (pc.y - p0.y),
+    (pw.x - pc.x) * (pw.x - pc.x) + (pw.y - pc.y) * (pw.y - pc.y)
+  };
+  if (d[0] < 1e-8)
+  {
+    return v0;
+  }
+  else
+  {
+    const double rate = (d[0] + d[1] - d[2]) / (2 * d[0]);
+    const double vel = (rate < 0.0) ? v0 :
+                       (rate > 1.0) ? v1 :
+                       v1 * rate + v0 * (1.0 - rate);
+    return vel;
+  }
 }
 
 }  // waypoint_follower

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.h
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit.h
@@ -31,6 +31,7 @@
 #ifndef PURE_PURSUIT_H
 #define PURE_PURSUIT_H
 
+#include <boost/circular_buffer.hpp>
 // ROS includes
 #include <ros/ros.h>
 
@@ -102,7 +103,7 @@ public:
   }
   // processing
   bool canGetCurvature(double *output_kappa);
-
+  double calcInterpolateVelocity();
 private:
   // constant
   const double RADIUS_MAX_;
@@ -117,6 +118,7 @@ private:
   geometry_msgs::Pose current_pose_;
   double current_linear_velocity_;
   std::vector<autoware_msgs::waypoint> current_waypoints_;
+  boost::circular_buffer<autoware_msgs::waypoint> past_closest_waypoints_;
 
   // functions
   double calcCurvature(geometry_msgs::Point target) const;

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.cpp
@@ -199,6 +199,7 @@ void PurePursuitNode::callbackFromConfig(const autoware_msgs::ConfigWaypointFoll
   const_velocity_ = config->velocity;
   lookahead_distance_ratio_ = config->lookahead_ratio;
   minimum_lookahead_distance_ = config->minimum_lookahead_distance;
+  velocity_interpolation_mode_ = config->velocity_interpolation_mode;
   is_config_set_ = true;
 }
 
@@ -237,10 +238,9 @@ void PurePursuitNode::callbackFromCurrentVelocity(const geometry_msgs::TwistStam
 
 void PurePursuitNode::callbackFromWayPoints(const autoware_msgs::laneConstPtr &msg)
 {
-  if (!msg->waypoints.empty())
-    command_linear_velocity_ = msg->waypoints.at(0).twist.twist.linear.x;
-  else
-    command_linear_velocity_ = 0;
+  command_linear_velocity_ = (msg->waypoints.empty()) ? 0 :
+                             (velocity_interpolation_mode_) ? pp_.calcInterpolateVelocity() :
+                             msg->waypoints.at(0).twist.twist.linear.x;
 
   pp_.setCurrentWaypoints(msg->waypoints);
   is_waypoint_set_ = true;

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.h
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/pure_pursuit/pure_pursuit_core.h
@@ -88,6 +88,7 @@ private:
 
   // variables
   bool is_linear_interpolation_, publishes_for_steering_robot_;
+  bool velocity_interpolation_mode_;
   bool is_waypoint_set_, is_pose_set_, is_velocity_set_, is_config_set_;
   double current_linear_velocity_, command_linear_velocity_;
   double wheel_base_;

--- a/ros/src/msgs/autoware_msgs/msg/config/ConfigWaypointFollower.msg
+++ b/ros/src/msgs/autoware_msgs/msg/config/ConfigWaypointFollower.msg
@@ -6,3 +6,4 @@ float32 lookahead_ratio
 float32 minimum_lookahead_distance
 float32 displacement_threshold
 float32 relative_angle_threshold
+bool velocity_interpolation_mode

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -1092,7 +1092,7 @@ params :
       cmd_param :
         dash        : ''
         delim       : ':='
-        
+
   - name  : lidar_kf_contour_track_param
     vars  :
     - name : tracking_type
@@ -1568,6 +1568,14 @@ params :
     - name    : is_linear_interpolation
       desc    : linear_interpolate_mode desc sample
       label   : 'Linear Interpolation'
+      kind    : checkbox
+      v       : True
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name    : velocity_interpolation_mode
+      desc    : linear_interpolate_mode desc sample
+      label   : 'Velocity Interpolation Mode'
       kind    : checkbox
       v       : True
       cmd_param :


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Change the speed control value to linear interpolation. autowarefoundation/autoware_ai#189 
The changes are as follows.
Embed the target speed in waypoint with velocity_set and refer to that value with pure_pursuit and output it.
⇒ Calculate the target speed with pure_pursuit and output it.

![image](https://user-images.githubusercontent.com/33311630/41339794-b5863762-6f30-11e8-8ccd-1602fbdc7d90.png)

## Todos
- [x] Tests
- [ ] Documentation

## Steps to Test or Reproduce
Compare speed control during vehicle braking.
/wf_sim can be easily checked.
![image](https://user-images.githubusercontent.com/33311630/41340958-841cdd2c-6f33-11e8-87ee-92849b4c9050.png)

Before: 
![image](https://user-images.githubusercontent.com/33311630/41340006-4c80880c-6f31-11e8-8ca2-3e22c1cb3039.png)
After:
![image](https://user-images.githubusercontent.com/33311630/41340020-552755da-6f31-11e8-9131-95faa76b6ba5.png)
