### PR TITLE
Added Docker file and script for generating aarch64 sysroots

### DIFF
--- a/docker/generic/Dockerfile.kinetic-sysroot-aarch64
+++ b/docker/generic/Dockerfile.kinetic-sysroot-aarch64
@@ -1,6 +1,8 @@
+FROM multiarch/alpine:aarch64-latest-stable as bootstrap
+
 FROM arm64v8/ubuntu:16.04
 
-COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static
+COPY --from=bootstrap /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" | tee /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116

--- a/docker/generic/Dockerfile.kinetic-sysroot-aarch64
+++ b/docker/generic/Dockerfile.kinetic-sysroot-aarch64
@@ -1,0 +1,103 @@
+FROM arm64v8/ubuntu:16.04
+
+COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" | tee /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    lsb-release \
+    python-rosdep \
+    sudo
+
+# Autoware dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    freeglut3-dev \
+    libarmadillo-dev \
+    libcurl4-openssl-dev \
+    libeigen3-dev \
+    libgflags-dev \
+    libgl1-mesa-dev \
+    libglew-dev \
+    libglu1-mesa-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libnlopt-dev \
+    libopencv-dev \
+    libpcap0.8-dev \
+    libpcl-dev \
+    libpcl1.7 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5opengl5 \
+    libqt5opengl5-dev \
+    libqt5widgets5 \
+    libssh2-1 \
+    libtinyxml-dev \
+    libx11-dev \
+    libxi-dev \
+    libxml2-dev \
+    libxmu-dev \
+    libyaml-cpp-dev \
+    python-flask \
+    python-serial \
+    qtbase5-dev \
+    ros-kinetic-angles \
+    ros-kinetic-camera-info-manager \
+    ros-kinetic-catkin \
+    ros-kinetic-cmake-modules \
+    ros-kinetic-cv-bridge \
+    ros-kinetic-diagnostic-msgs \
+    ros-kinetic-diagnostic-updater \
+    ros-kinetic-dynamic-reconfigure \
+    ros-kinetic-geometry-msgs \
+    ros-kinetic-gps-common \
+    ros-kinetic-grid-map-cv \
+    ros-kinetic-grid-map-msgs \
+    ros-kinetic-grid-map-ros \
+    ros-kinetic-image-geometry \
+    ros-kinetic-image-transport \
+    ros-kinetic-imu-filter-madgwick \
+    ros-kinetic-imu-tools \
+    ros-kinetic-jsk-recognition-msgs \
+    ros-kinetic-jsk-rviz-plugins \
+    ros-kinetic-message-filters \
+    ros-kinetic-message-generation \
+    ros-kinetic-message-runtime \
+    ros-kinetic-nav-msgs \
+    ros-kinetic-nlopt \
+    ros-kinetic-nmea-msgs \
+    ros-kinetic-nodelet \
+    ros-kinetic-pcl-conversions \
+    ros-kinetic-pcl-msgs \
+    ros-kinetic-pcl-ros \
+    ros-kinetic-pluginlib \
+    ros-kinetic-rosconsole \
+    ros-kinetic-roscpp \
+    ros-kinetic-roslaunch \
+    ros-kinetic-roslib \
+    ros-kinetic-roslint \
+    ros-kinetic-rospy \
+    ros-kinetic-rostest \
+    ros-kinetic-rosunit \
+    ros-kinetic-rqt-plot \
+    ros-kinetic-rviz \
+    ros-kinetic-sensor-msgs \
+    ros-kinetic-shape-msgs \
+    ros-kinetic-sound-play \
+    ros-kinetic-std-msgs \
+    ros-kinetic-std-srvs \
+    ros-kinetic-stereo-msgs \
+    ros-kinetic-tf \
+    ros-kinetic-tf2 \
+    ros-kinetic-tf2-ros \
+    ros-kinetic-visualization-msgs \
+    ros-kinetic-xacro
+
+RUN rosdep init
+
+RUN rosdep update
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    symlinks

--- a/docker/generic/build_sysroot.sh
+++ b/docker/generic/build_sysroot.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eufo pipefail
+
+# Build Docker Image
+docker build -t autoware-kinetic:sysroot-aarch64 -f Dockerfile.kinetic-sysroot-aarch64 .
+
+# Fix up symlinks so that they are relative in the sysroot
+docker run --name autoware-kinetic-sysroot-aarch64 autoware-kinetic:sysroot-aarch64 sh -c "\
+symlinks -cr / && \
+find /opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/opt/ros/kinetic/include#\${CMAKE_SYSROOT}/opt/ros/kinetic/include#g' {} \;  && \
+find /opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/opt/ros/kinetic/lib#\${CMAKE_SYSROOT}/opt/ros/kinetic/lib#g' {} \; && \
+find /opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/include#\${CMAKE_SYSROOT}/usr/include#g' {} \; && \
+find /opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/lib#\${CMAKE_SYSROOT}/usr/lib#g' {} \; && \
+find /usr/lib/cmake/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/lib/aarch64-linux-gnu#\${CMAKE_SYSROOT}/usr/lib/aarch64-linux-gnu#g' {} \; && \
+find /usr/lib/cmake/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/lib/openmpi#\${CMAKE_SYSROOT}/usr/lib/openmpi#g' {} \; && \
+find /usr/lib/cmake/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/include#\${CMAKE_SYSROOT}/usr/include#g' {} \; && \
+sed -i -e 's#/usr#\${CMAKE_SYSROOT}/usr#g' /usr/lib/aarch64-linux-gnu/cmake/pcl/PCLConfig.cmake \
+"
+
+docker export -o autoware-kinetic-sysroot-aarch64.tar autoware-kinetic-sysroot-aarch64
+docker container rm autoware-kinetic-sysroot-aarch64

--- a/docker/generic/build_sysroot.sh
+++ b/docker/generic/build_sysroot.sh
@@ -3,7 +3,7 @@
 set -eufo pipefail
 
 # Build Docker Image
-docker build -t autoware-kinetic:sysroot-aarch64 -f Dockerfile.kinetic-sysroot-aarch64 .
+cat Dockerfile.kinetic-sysroot-aarch64 | docker build -t autoware-kinetic:sysroot-aarch64 -
 
 # Fix up symlinks so that they are relative in the sysroot
 docker run --name autoware-kinetic-sysroot-aarch64 autoware-kinetic:sysroot-aarch64 sh -c "\


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
This PR includes a script to generate an aarch64 sysroot (that includes all the Autoware dependencies for Kinetic) that can be used for crosscompiling Autoware.

## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce

```
cd docker/generic
./build_sysroot.sh
```
This should generate tarball named `autoware-kinetic-sysroot-aarch64.tar` in the current directory, which contains all the Autoware dependencies for aarch64