### PR TITLE
Enable crosscompilation

### DIFF
--- a/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
@@ -18,14 +18,7 @@ catkin_package(
 )
 
 
-EXECUTE_PROCESS(
-        COMMAND uname -m
-        OUTPUT_VARIABLE ARCHITECTURE
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-
-IF ("${ARCHITECTURE}" STREQUAL "aarch64")
+IF ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
     set(LIB_ARCH _aarch64)
 ELSE ()
     unset(LIB_ARCH)
@@ -42,12 +35,11 @@ ELSE ()
     set(LIB_VERSION 1.0) # _GLIBCXX_USE_CXX11_ABI is 0
 ENDIF ()
 
-find_library(ymc_can NAMES libymc_can_${LIB_VERSION}${LIB_ARCH}.a PATHS lib)
 add_executable(g30esli_interface
         node/g30esli_interface/g30esli_interface.cpp
         )
 
 target_link_libraries(g30esli_interface
         ${catkin_LIBRARIES}
-        ${ymc_can}
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/libymc_can_${LIB_VERSION}${LIB_ARCH}.a
         )

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
@@ -150,7 +150,15 @@ target_link_libraries(calibration_publisher
         ${catkin_LIBRARIES}
         )
 
-install(TARGETS calibration_publisher calibration_toolkit
+if(TARGET calibration_toolkit)
+        install(TARGETS calibration_toolkit
+                ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+                LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+                RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+                )
+endif()
+
+install(TARGETS calibration_publisher
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
These are some minor fixes that enable crosscompiling Autoware for aarch64, namely:

- Use `CMAKE_SYSTEM_PROCESSOR` instead of running `uname -m` to check if we're building for aarch64. `CMAKE_SYSTEM_PROCESSOR` can be defined in a CMake toolchain to target a specific architecture
- Use the path to `ymc_can` directly instead of `find_library`
- Only install `calibration_toolkit` if the target exists (it might not, if `ROS_DISTRO` is not defined)