### PR TITLE
Crossbuild aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ matrix:
       os: linux
       sudo: required
       env: ROS_DISTRO=indigo
+    - dist: xenial
+      compiler: gcc
+      os: linux
+      sudo: required
+      services:
+        - docker
+      env: ROS_DISTRO=kinetic CROSS_COMPILE=1
 notifications:
     slack: star4:911NA0lU8gDHitCKLto9LzPJ
 env:
@@ -45,13 +52,18 @@ install:
 # wstool looks for a ROSINSTALL_FILE defined in the environment variables.
 before_script:
   # source dependencies: install using wstool.
-  - cd src
-  - wstool init
-  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
-  - wstool up
+  - if [ $CROSS_COMPILE == "1" ]; then
+    cd docker/generic
+    ./build_cross_aarch64.sh
+    else
+    cd src
+    wstool init
+    if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
+    wstool up
   # package depdencies: install using rosdep.
-  - cd ..
-  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+    cd ..
+    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+    fi
 
 # Compile and test (mark the build as failed if any step fails). If the
 # CATKIN_OPTIONS file exists, use it as an argument to catkin_make, for example
@@ -64,7 +76,11 @@ before_script:
 script:
   - catkin_make clean
   - source devel/setup.bash
-  - catkin_make -j4
+  - if [ $CROSS_COMPILE == "1" ]; then
+    docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -w $TRAVIS_BUILD_DIR/ros sh -c "catkin_make -DCMAKE_TOOLCHAIN_FILE=/sysroot/aarch64/aarch64_toolchain.cmake -j4"
+    else
+    catkin_make -j4
+    fi
 
 #sudo: required
 #dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,9 @@ before_script:
     else
       cd src;
       wstool init;
-      if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
+      if [[ -f $ROSINSTALL_FILE ]] ; then
+        wstool merge $ROSINSTALL_FILE;
+      fi;
       wstool up;
       cd ..;
       rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO;

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,18 +51,16 @@ install:
 # Install all ros dependencies, using wstool first and rosdep second.
 # wstool looks for a ROSINSTALL_FILE defined in the environment variables.
 before_script:
-  # source dependencies: install using wstool.
   - if [ $CROSS_COMPILE == "1" ]; then
-    cd docker/generic
-    ./build_cross_aarch64.sh
+      cd docker/generic;
+      ./build_cross_aarch64.sh;
     else
-    cd src
-    wstool init
-    if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
-    wstool up
-  # package depdencies: install using rosdep.
-    cd ..
-    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+      cd src;
+      wstool init;
+      if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
+      wstool up;
+      cd ..;
+      rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO;
     fi
 
 # Compile and test (mark the build as failed if any step fails). If the

--- a/docker/generic/Dockerfile.kinetic-crossbuild-aarch64
+++ b/docker/generic/Dockerfile.kinetic-crossbuild-aarch64
@@ -1,0 +1,143 @@
+FROM multiarch/alpine:aarch64-latest-stable as bootstrap
+
+FROM arm64v8/ubuntu:16.04 as sysroot
+
+COPY --from=bootstrap /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" | tee /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    lsb-release \
+    python-rosdep \
+    sudo
+
+# Autoware dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    freeglut3-dev \
+    libarmadillo-dev \
+    libcurl4-openssl-dev \
+    libeigen3-dev \
+    libgflags-dev \
+    libgl1-mesa-dev \
+    libglew-dev \
+    libglu1-mesa-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libnlopt-dev \
+    libopencv-dev \
+    libpcap0.8-dev \
+    libpcl-dev \
+    libpcl1.7 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5opengl5 \
+    libqt5opengl5-dev \
+    libqt5widgets5 \
+    libssh2-1 \
+    libtinyxml-dev \
+    libx11-dev \
+    libxi-dev \
+    libxml2-dev \
+    libxmu-dev \
+    libyaml-cpp-dev \
+    python-flask \
+    python-serial \
+    qtbase5-dev \
+    ros-kinetic-angles \
+    ros-kinetic-camera-info-manager \
+    ros-kinetic-catkin \
+    ros-kinetic-cmake-modules \
+    ros-kinetic-cv-bridge \
+    ros-kinetic-diagnostic-msgs \
+    ros-kinetic-diagnostic-updater \
+    ros-kinetic-dynamic-reconfigure \
+    ros-kinetic-geometry-msgs \
+    ros-kinetic-gps-common \
+    ros-kinetic-grid-map-cv \
+    ros-kinetic-grid-map-msgs \
+    ros-kinetic-grid-map-ros \
+    ros-kinetic-image-geometry \
+    ros-kinetic-image-transport \
+    ros-kinetic-imu-filter-madgwick \
+    ros-kinetic-imu-tools \
+    ros-kinetic-jsk-recognition-msgs \
+    ros-kinetic-jsk-rviz-plugins \
+    ros-kinetic-message-filters \
+    ros-kinetic-message-generation \
+    ros-kinetic-message-runtime \
+    ros-kinetic-nav-msgs \
+    ros-kinetic-nlopt \
+    ros-kinetic-nmea-msgs \
+    ros-kinetic-nodelet \
+    ros-kinetic-pcl-conversions \
+    ros-kinetic-pcl-msgs \
+    ros-kinetic-pcl-ros \
+    ros-kinetic-pluginlib \
+    ros-kinetic-rosconsole \
+    ros-kinetic-roscpp \
+    ros-kinetic-roslaunch \
+    ros-kinetic-roslib \
+    ros-kinetic-roslint \
+    ros-kinetic-rospy \
+    ros-kinetic-rostest \
+    ros-kinetic-rosunit \
+    ros-kinetic-rqt-plot \
+    ros-kinetic-rviz \
+    ros-kinetic-sensor-msgs \
+    ros-kinetic-shape-msgs \
+    ros-kinetic-sound-play \
+    ros-kinetic-std-msgs \
+    ros-kinetic-std-srvs \
+    ros-kinetic-stereo-msgs \
+    ros-kinetic-tf \
+    ros-kinetic-tf2 \
+    ros-kinetic-tf2-ros \
+    ros-kinetic-visualization-msgs \
+    ros-kinetic-xacro
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    symlinks
+RUN symlinks -cr /
+
+FROM ubuntu:16.04
+COPY --from=sysroot /lib /sysroot/aarch64/lib
+COPY --from=sysroot /usr/include /sysroot/aarch64/usr/include
+COPY --from=sysroot /usr/lib /sysroot/aarch64/usr/lib
+COPY --from=sysroot /usr/share/pkgconfig /sysroot/aarch64/usr/share/pkgconfig
+COPY --from=sysroot /opt /sysroot/aarch64/opt
+COPY --from=sysroot /etc/alternatives /sysroot/aarch64/etc/alternatives
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" | tee /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    crossbuild-essential-arm64/xenial \
+    pkg-config \
+    python-rospkg \
+    qt5-qmake \
+    qtbase5-dev-tools \
+    ros-kinetic-catkin
+RUN find /sysroot/aarch64/opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/opt/ros/kinetic/include#/sysroot/aarch64/opt/ros/kinetic/include#g' {} \;
+RUN find /sysroot/aarch64/opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/opt/ros/kinetic/lib#/sysroot/aarch64/opt/ros/kinetic/lib#g' {} \;
+RUN find /sysroot/aarch64/opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/include#/sysroot/aarch64/usr/include#g' {} \;
+RUN find /sysroot/aarch64/opt/ros/kinetic/share/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/lib#/sysroot/aarch64/usr/lib#g' {} \;
+RUN find /sysroot/aarch64/usr/lib/cmake/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/lib/aarch64-linux-gnu#/sysroot/aarch64/usr/lib/aarch64-linux-gnu#g' {} \;
+RUN find /sysroot/aarch64/usr/lib/cmake/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/lib/openmpi#/sysroot/aarch64/usr/lib/openmpi#g' {} \;
+RUN find /sysroot/aarch64/usr/lib/cmake/ -name "*.cmake" -type f -exec sed -i -e 's#/usr/include#/sysroot/aarch64/usr/include#g' {} \;
+RUN find /sysroot/aarch64/opt/ros/kinetic/lib/pkgconfig/ -name "*.pc" -type f -exec sed -i -e 's#-I/opt/ros/kinetic/usr/include#-I/sysroot/aarch64/opt/ros/kinetic/usr/include#g' {} \;
+RUN find /sysroot/aarch64/opt/ros/kinetic/lib/pkgconfig/ -name "*.pc" -type f -exec sed -i -e 's#-I/usr/include#-I/sysroot/aarch64/usr/include#g' {} \;
+RUN find /sysroot/aarch64/ -name "*.pc" -type f -exec sed -i -e 's#prefix=/#prefix=/sysroot/aarch64/#g' {} \;
+RUN sed -i -e 's#/usr#/sysroot/aarch64/usr#g' /sysroot/aarch64/usr/lib/aarch64-linux-gnu/cmake/pcl/PCLConfig.cmake
+RUN sed -i -e 's#set(imported_location "${_qt5Widgets_install_prefix}/lib/aarch64-linux-gnu/qt5/bin/uic")#set(imported_location "/usr/lib/x86_64-linux-gnu/qt5/bin/uic")#g' \
+    /sysroot/aarch64/usr/lib/aarch64-linux-gnu/cmake/Qt5Widgets/Qt5WidgetsConfigExtras.cmake
+RUN sed -i -e 's#set(imported_location "${_qt5Core_install_prefix}/lib/aarch64-linux-gnu/qt5/bin/#set(imported_location "/usr/lib/x86_64-linux-gnu/qt5/bin/#g' \
+    /sysroot/aarch64/usr/lib/aarch64-linux-gnu/cmake/Qt5Core/Qt5CoreConfigExtras.cmake
+RUN sed -i -e 's#define ARMA_SUPERLU_INCLUDE_DIR /usr/include/superlu/#define ARMA_SUPERLU_INCLUDE_DIR /sysroot/aarch64/usr/include/superlu/#g' \
+    /sysroot/aarch64/usr/include/armadillo_bits/config.hpp
+ENV ROS_DISTRO kinetic
+ENV CC /usr/bin/aarch64-linux-gnu-gcc
+ENV CXX /usr/bin/aarch64-linux-gnu-g++
+ENV AR /usr/bin/aarch64-linux-gnu-ar
+ENV CPP /usr/bin/aarch64-linux-gnu-cpp
+COPY aarch64_toolchain.cmake /sysroot/aarch64
+CMD . /opt/ros/kinetic/setup.sh && /bin/bash

--- a/docker/generic/Dockerfile.kinetic-sysroot-aarch64
+++ b/docker/generic/Dockerfile.kinetic-sysroot-aarch64
@@ -1,0 +1,105 @@
+FROM multiarch/alpine:aarch64-latest-stable as bootstrap
+
+FROM arm64v8/ubuntu:16.04
+
+COPY --from=bootstrap /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" | tee /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    lsb-release \
+    python-rosdep \
+    sudo
+
+# Autoware dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    freeglut3-dev \
+    libarmadillo-dev \
+    libcurl4-openssl-dev \
+    libeigen3-dev \
+    libgflags-dev \
+    libgl1-mesa-dev \
+    libglew-dev \
+    libglu1-mesa-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libnlopt-dev \
+    libopencv-dev \
+    libpcap0.8-dev \
+    libpcl-dev \
+    libpcl1.7 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5opengl5 \
+    libqt5opengl5-dev \
+    libqt5widgets5 \
+    libssh2-1 \
+    libtinyxml-dev \
+    libx11-dev \
+    libxi-dev \
+    libxml2-dev \
+    libxmu-dev \
+    libyaml-cpp-dev \
+    python-flask \
+    python-serial \
+    qtbase5-dev \
+    ros-kinetic-angles \
+    ros-kinetic-camera-info-manager \
+    ros-kinetic-catkin \
+    ros-kinetic-cmake-modules \
+    ros-kinetic-cv-bridge \
+    ros-kinetic-diagnostic-msgs \
+    ros-kinetic-diagnostic-updater \
+    ros-kinetic-dynamic-reconfigure \
+    ros-kinetic-geometry-msgs \
+    ros-kinetic-gps-common \
+    ros-kinetic-grid-map-cv \
+    ros-kinetic-grid-map-msgs \
+    ros-kinetic-grid-map-ros \
+    ros-kinetic-image-geometry \
+    ros-kinetic-image-transport \
+    ros-kinetic-imu-filter-madgwick \
+    ros-kinetic-imu-tools \
+    ros-kinetic-jsk-recognition-msgs \
+    ros-kinetic-jsk-rviz-plugins \
+    ros-kinetic-message-filters \
+    ros-kinetic-message-generation \
+    ros-kinetic-message-runtime \
+    ros-kinetic-nav-msgs \
+    ros-kinetic-nlopt \
+    ros-kinetic-nmea-msgs \
+    ros-kinetic-nodelet \
+    ros-kinetic-pcl-conversions \
+    ros-kinetic-pcl-msgs \
+    ros-kinetic-pcl-ros \
+    ros-kinetic-pluginlib \
+    ros-kinetic-rosconsole \
+    ros-kinetic-roscpp \
+    ros-kinetic-roslaunch \
+    ros-kinetic-roslib \
+    ros-kinetic-roslint \
+    ros-kinetic-rospy \
+    ros-kinetic-rostest \
+    ros-kinetic-rosunit \
+    ros-kinetic-rqt-plot \
+    ros-kinetic-rviz \
+    ros-kinetic-sensor-msgs \
+    ros-kinetic-shape-msgs \
+    ros-kinetic-sound-play \
+    ros-kinetic-std-msgs \
+    ros-kinetic-std-srvs \
+    ros-kinetic-stereo-msgs \
+    ros-kinetic-tf \
+    ros-kinetic-tf2 \
+    ros-kinetic-tf2-ros \
+    ros-kinetic-visualization-msgs \
+    ros-kinetic-xacro
+
+RUN rosdep init
+
+RUN rosdep update
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    symlinks

--- a/docker/generic/aarch64_toolchain.cmake
+++ b/docker/generic/aarch64_toolchain.cmake
@@ -1,0 +1,35 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_CROSSCOMPILING ON)
+set(CMAKE_SYSROOT /sysroot/${CMAKE_SYSTEM_PROCESSOR})
+set(CMAKE_PREFIX_PATH ${CMAKE_SYSROOT}/opt/ros/kinetic)
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER /usr/bin/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu-g++)
+
+set(_pkgconfig_paths)
+list(APPEND _pkgconfig_paths "${CMAKE_SYSROOT}/usr/lib/aarch64-linux-gnu/pkgconfig")
+list(APPEND _pkgconfig_paths "${CMAKE_SYSROOT}/usr/lib/openmpi/lib/pkgconfig")
+list(APPEND _pkgconfig_paths "${CMAKE_SYSROOT}/usr/lib/pkgconfig")
+list(APPEND _pkgconfig_paths "${CMAKE_SYSROOT}/usr/share/pkgconfig")
+list(APPEND _pkgconfig_paths "${CMAKE_SYSROOT}/opt/ros/kinetic/lib/aarch64-linux-gnu/pkgconfig")
+list(APPEND _pkgconfig_paths "${CMAKE_SYSROOT}/opt/ros/kinetic/lib/pkgconfig")
+# message(FATAL_ERROR "${_pkgconfig_paths}")
+string(REPLACE ";" ":" foo "${_pkgconfig_paths}")
+set(ENV{PKG_CONFIG_PATH} "${foo}")
+
+# message(FATAL_ERROR "$ENV{PKG_CONFIG_PATH}")
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_LIST_DIR}/devel;${CMAKE_CURRENT_LIST_DIR}/build")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# This assumes that pthread will be available on the target system
+# (this emulates that the return of the TRY_RUN is a return code "0"
+set(THREADS_PTHREAD_ARG "0"
+  CACHE STRING "Result from TRY_RUN" FORCE)

--- a/docker/generic/build_cross_aarch64.sh
+++ b/docker/generic/build_cross_aarch64.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Register QEMU as a handler for aarch64
+docker run --rm --privileged multiarch/qemu-user-static:register
+
+# Build Docker Image
+docker build -t autoware-kinetic:crossbuild-aarch64 -f Dockerfile.kinetic-crossbuild-aarch64 .
+
+# Deregister QEMU as a handler for aarch64
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
@@ -18,14 +18,7 @@ catkin_package(
 )
 
 
-EXECUTE_PROCESS(
-        COMMAND uname -m
-        OUTPUT_VARIABLE ARCHITECTURE
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-
-IF ("${ARCHITECTURE}" STREQUAL "aarch64")
+IF ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
     set(LIB_ARCH _aarch64)
 ELSE ()
     unset(LIB_ARCH)
@@ -42,12 +35,11 @@ ELSE ()
     set(LIB_VERSION 1.0) # _GLIBCXX_USE_CXX11_ABI is 0
 ENDIF ()
 
-find_library(ymc_can NAMES libymc_can_${LIB_VERSION}${LIB_ARCH}.a PATHS lib)
 add_executable(g30esli_interface
         node/g30esli_interface/g30esli_interface.cpp
         )
 
 target_link_libraries(g30esli_interface
         ${catkin_LIBRARIES}
-        ${ymc_can}
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/libymc_can_${LIB_VERSION}${LIB_ARCH}.a
         )

--- a/ros/src/computing/perception/detection/trafficlight_recognizer/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/trafficlight_recognizer/CMakeLists.txt
@@ -46,6 +46,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 
+find_package(OpenGL REQUIRED)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -108,6 +110,7 @@ target_link_libraries(region_tlr
         ${catkin_LIBRARIES}
         ${OpenCV_LIBS}
         libcontext
+        ${OPENGL_LIBRARIES}
         )
 
 add_dependencies(region_tlr
@@ -168,6 +171,7 @@ target_link_libraries(tlr_tuner
         ${OpenCV_LIBS}
         Qt5::Core
         Qt5::Widgets
+        ${OPENGL_LIBRARIES}
         )
 
 
@@ -230,6 +234,7 @@ target_link_libraries(label_maker
         Qt5::Core
         Qt5::Gui
         Qt5::Widgets
+        ${OPENGL_LIBRARIES}
         )
 
 

--- a/ros/src/computing/perception/detection/viewers/packages/viewers/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/viewers/packages/viewers/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
         )
 
 find_package(OpenCV REQUIRED)
+find_package(OpenGL REQUIRED)
 
 catkin_package(
         CATKIN_DEPENDS roscpp sensor_msgs std_msgs autoware_msgs cv_bridge image_transport
@@ -18,6 +19,7 @@ add_executable(image_viewer nodes/image_viewer/image_viewer.cpp)
 target_link_libraries(image_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(image_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -25,6 +27,7 @@ add_executable(scan_image_viewer nodes/scan_image_viewer/scan_image_viewer.cpp)
 target_link_libraries(scan_image_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(scan_image_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -32,6 +35,7 @@ add_executable(scan_image_d_viewer nodes/scan_image_d_viewer/scan_image_d_viewer
 target_link_libraries(scan_image_d_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(scan_image_d_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -39,6 +43,7 @@ add_executable(points_image_viewer nodes/points_image_viewer/points_image_viewer
 target_link_libraries(points_image_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(points_image_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -46,6 +51,7 @@ add_executable(image_d_viewer nodes/image_d_viewer/image_d_viewer.cpp)
 target_link_libraries(image_d_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(image_d_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -53,6 +59,7 @@ add_executable(points_image_d_viewer nodes/points_image_d_viewer/points_image_d_
 target_link_libraries(points_image_d_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(points_image_d_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -60,6 +67,7 @@ add_executable(vscan_image_viewer nodes/vscan_image_viewer/vscan_image_viewer.cp
 target_link_libraries(vscan_image_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(vscan_image_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -67,6 +75,7 @@ add_executable(vscan_image_d_viewer nodes/vscan_image_d_viewer/vscan_image_d_vie
 target_link_libraries(vscan_image_d_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(vscan_image_d_viewer ${catkin_EXPORTED_TARGETS})
 
@@ -78,6 +87,7 @@ add_executable(traffic_light_viewer nodes/traffic_light_viewer/traffic_light_vie
 target_link_libraries(traffic_light_viewer
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(traffic_light_viewer ${catkin_EXPORTED_TARGETS})
 

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_lane_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_lane_detect/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
         autoware_msgs
         )
 find_package(OpenCV REQUIRED)
+find_package(OpenGL REQUIRED)
 
 catkin_package(
         #  INCLUDE_DIRS include
@@ -33,6 +34,7 @@ add_executable(vision_lane_detect
 target_link_libraries(vision_lane_detect
         ${catkin_LIBRARIES}
         ${OpenCV_LIBRARIES}
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(vision_lane_detect
         ${catkin_EXPORTED_TARGETS}

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
@@ -106,7 +106,7 @@ if ("${ROS_VERSION}" MATCHES "(indigo|jade|kinetic)")
             "-DPARAM_YAML=${PARAM_YAML} -DCAMERA_YAML=${CAMERA_YAML}")
 
     target_link_libraries(calibration_test
-            ${catkin_LIBRARIES} ${OpenCV_LIBS} xml2)
+            ${catkin_LIBRARIES} ${OpenCV_LIBS} xml2 ${OPENGL_LIBRARIES})
 endif ()
 ## 3D
 if ("${ROS_VERSION}" MATCHES "(indigo|jade|kinetic)")
@@ -150,7 +150,15 @@ target_link_libraries(calibration_publisher
         ${catkin_LIBRARIES}
         )
 
-install(TARGETS calibration_publisher calibration_toolkit
+if(TARGET calibration_toolkit)
+        install(TARGETS calibration_toolkit
+                ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+                LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+                RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+                )
+endif()
+
+install(TARGETS calibration_publisher
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
@@ -25,6 +25,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 
+find_package(GLUT REQUIRED)
+find_package(OpenGL REQUIRED)
+
 catkin_package(
         CATKIN_DEPENDS roscpp
         std_msgs
@@ -68,6 +71,7 @@ target_link_libraries(points2vscan
         Qt5::Core
         Qt5::Widgets
         points_image
+        ${OPENGL_LIBRARIES}
         )
 add_dependencies(points2vscan
         ${catkin_EXPORTED_TARGETS}


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
This PR supersedes #1361 and #1366 so that the entire process of crosscompiling Autoware is self-contained

## Related PRs
#1361
#1366

## Steps to Test or Reproduce

```
cd docker/generic
./build_cross_aarch64.sh
cd ../../
docker run -v ${PWD}:${PWD} -w ${PWD}/ros sh -c "catkin_make -DCMAKE_TOOLCHAIN_FILE=/sysroot/aarch64/aarch64_toolchain.cmake -j4"
```
Binaries of Autoware built for aarch64 should should up in `Autoware/ros/devel`.