### PR TITLE
[bugfix] Static tf broadcaster in ndt_mapping

### DIFF
--- a/ros/src/computing/perception/localization/packages/lidar_localizer/nodes/ndt_mapping/ndt_mapping.cpp
+++ b/ros/src/computing/perception/localization/packages/lidar_localizer/nodes/ndt_mapping/ndt_mapping.cpp
@@ -468,7 +468,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
 
   Eigen::Matrix4f t_localizer(Eigen::Matrix4f::Identity());
   Eigen::Matrix4f t_base_link(Eigen::Matrix4f::Identity());
-  tf::TransformBroadcaster br;
+  static tf::TransformBroadcaster br;
   tf::Transform transform;
 
   current_scan_time = input->header.stamp;


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
When attempting to create points map from velodyne lidar sensor in Gazebo using ndt_mapping node, points_callback() function is called but br.sendTransform() command is not executed and thus transform from map frame to base_link frame is not published. The problem is fixed by declaring tf::TransformBroadcaster object as static into points_callback() function.