### PR TITLE
[Hotfix] Revert Slack URI in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Autoware is provided under the [New BSD License](https://github.com/CPFL/Autowar
 
 ## Contact
 
-Autoware Developers Slack Team (https://autoware-developer.slack.com/)
+Autoware Developers Slack Team (https://autoware.herokuapp.com/)
 
 Autoware Developers (<autoware@googlegroups.com>)
 


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
Because Autoware is open source software, everyone can be join the Developer Slack.

At 312a848ab659129f5cf7017f0a16e30cb2b0795f, Slack URI was replaced as follows by mistake. This PR reverts it.

```diff
-Autoware Developers Slack Team (https://autoware.herokuapp.com/)
+Autoware Developers Slack Team (https://autoware-developer.slack.com/)
```

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
develop | #1379