### PR TITLE
Fix/common build flags

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
@@ -24,7 +24,7 @@ catkin_package(
 set(AS_MSG_PATH "${CMAKE_SOURCE_DIR}/msgs/platform_automation_msgs/module_comm_msgs")
 if (EXISTS "${AS_MSG_PATH}")
 
-    SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+    SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
     include_directories(
             ${catkin_INCLUDE_DIRS}

--- a/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ymc)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(
         catkin REQUIRED COMPONENTS

--- a/ros/src/common/cmake/autoware_build_flags/cmake/autoware_build_flags-extras.cmake
+++ b/ros/src/common/cmake/autoware_build_flags/cmake/autoware_build_flags-extras.cmake
@@ -3,3 +3,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
 endif()
+
+# Enable support for C++11
+if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+else()
+  set(CMAKE_CXX_STANDARD 11)
+endif()

--- a/ros/src/common/libs/amathutils_lib/CMakeLists.txt
+++ b/ros/src/common/libs/amathutils_lib/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
         autoware_msgs
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         INCLUDE_DIRS include

--- a/ros/src/common/libs/state_machine_lib/CMakeLists.txt
+++ b/ros/src/common/libs/state_machine_lib/CMakeLists.txt
@@ -13,7 +13,7 @@ catkin_package(
         CATKIN_DEPENDS roscpp autoware_msgs
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         include

--- a/ros/src/common/libvectormap/CMakeLists.txt
+++ b/ros/src/common/libvectormap/CMakeLists.txt
@@ -19,7 +19,7 @@ else ()
     set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 endif ()
 
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 ## Declare things to be passed to dependent projects
 ## INCLUDE_DIRS: uncomment this if you package contains header files

--- a/ros/src/computing/perception/detection/fusion_tools/packages/pixel_cloud_fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/fusion_tools/packages/pixel_cloud_fusion/CMakeLists.txt
@@ -38,7 +38,7 @@ catkin_package(CATKIN_DEPENDS
         tf
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O3 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O3 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 #fusion Library
 add_library(pixel_cloud_fusion_lib SHARED

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_euclidean_cluster_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_euclidean_cluster_detect/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenMP)
 find_package(OpenCV REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         CATKIN_DEPENDS

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_svm_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_svm_detect/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(OpenCV REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS

--- a/ros/src/computing/perception/detection/lidar_tracker/libs/fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/libs/fusion/CMakeLists.txt
@@ -15,7 +15,7 @@ catkin_package(
         CATKIN_DEPENDS roscpp autoware_msgs cv_bridge
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         include

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_euclidean_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_euclidean_track/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   )
 
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_imm_ukf_pda_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_imm_ukf_pda_track/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   )
 
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_contour_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_contour_track/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   )
 
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(OpenCV REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_pf_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_pf_track/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   )
 
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/obj_fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/obj_fusion/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   )
 
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 catkin_package(
   CATKIN_DEPENDS 
   roscpp

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/obj_reproj/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/obj_reproj/CMakeLists.txt
@@ -23,7 +23,7 @@ catkin_package(
   tf
   )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/range_fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/range_fusion/CMakeLists.txt
@@ -19,7 +19,7 @@ catkin_package(
   fusion
   )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/trafficlight_recognizer/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/trafficlight_recognizer/CMakeLists.txt
@@ -78,7 +78,7 @@ catkin_package(
         LIBRARIES libcontext
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall -Wunused-variable ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall -Wunused-variable ${CMAKE_CXX_FLAGS}")
 
 ###########
 ## Build ##

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
         )
 
 set(CMAKE_CXX_FLAGS
-        "-std=c++11 -Wall ${CMAKE_CXX_FLAGS}"
+        "-Wall ${CMAKE_CXX_FLAGS}"
         )
 
 catkin_package(

--- a/ros/src/computing/perception/detection/viewers/packages/viewers/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/viewers/packages/viewers/CMakeLists.txt
@@ -18,7 +18,7 @@ catkin_package(
         CATKIN_DEPENDS roscpp sensor_msgs std_msgs autoware_msgs cv_bridge image_transport
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 
 add_executable(image_viewer nodes/image_viewer/image_viewer.cpp)

--- a/ros/src/computing/perception/detection/vision_detector/libs/dpm_ttic/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/libs/dpm_ttic/CMakeLists.txt
@@ -15,7 +15,7 @@ catkin_package(
 )
 
 set(CMAKE_C_FLAGS "-O2 -g -Wall -Wno-unused-result ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result ${CMAKE_CXX_FLAGS}")
 
 if(CUDA_FOUND)
     include_directories(

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_dpm_ttic_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_dpm_ttic_detect/CMakeLists.txt
@@ -29,7 +29,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_segment_enet_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_segment_enet_detect/CMakeLists.txt
@@ -21,7 +21,7 @@ catkin_package(CATKIN_DEPENDS
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 INCLUDE_DIRECTORIES(
   ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_ssd_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_ssd_detect/CMakeLists.txt
@@ -36,7 +36,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_yolo2_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_yolo2_detect/CMakeLists.txt
@@ -29,7 +29,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_yolo3_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_yolo3_detect/CMakeLists.txt
@@ -24,7 +24,7 @@ catkin_package(CATKIN_DEPENDS
         autoware_msgs
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O3 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O3 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 IF (CUDA_FOUND)
     list(APPEND CUDA_NVCC_FLAGS "--std=c++11 -I$${PROJECT_SOURCE_DIR}/darknet/src -I${PROJECT_SOURCE_DIR}/src -DGPU")

--- a/ros/src/computing/perception/detection/vision_tracker/libs/kf/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/libs/kf/CMakeLists.txt
@@ -26,7 +26,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(${catkin_INCLUDE_DIRS}
         include)

--- a/ros/src/computing/perception/detection/vision_tracker/packages/vision_dummy_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/packages/vision_dummy_track/CMakeLists.txt
@@ -20,7 +20,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/vision_tracker/packages/vision_kf_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/packages/vision_kf_track/CMakeLists.txt
@@ -27,7 +27,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/detection/vision_tracker/packages/vision_klt_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/packages/vision_klt_track/CMakeLists.txt
@@ -26,7 +26,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/localization/packages/gnss_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/gnss_localizer/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package()
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/localization/packages/lidar_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/lidar_localizer/CMakeLists.txt
@@ -63,7 +63,7 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 add_executable(ndt_matching nodes/ndt_matching/ndt_matching.cpp)
 target_link_libraries(ndt_matching ${catkin_LIBRARIES})

--- a/ros/src/computing/perception/localization/packages/orb_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/orb_localizer/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
 
 # Force using C++11
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 find_package(Boost REQUIRED COMPONENTS system serialization python)
 find_package(OpenCV REQUIRED)

--- a/ros/src/computing/perception/semantics/packages/object_map/CMakeLists.txt
+++ b/ros/src/computing/perception/semantics/packages/object_map/CMakeLists.txt
@@ -31,7 +31,7 @@ catkin_package(
         CATKIN_DEPENDS roscpp pcl_ros pcl_conversions tf sensor_msgs nav_msgs autoware_msgs vector_map
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/perception/semantics/packages/road_occupancy_processor/CMakeLists.txt
+++ b/ros/src/computing/perception/semantics/packages/road_occupancy_processor/CMakeLists.txt
@@ -35,7 +35,7 @@ catkin_package(CATKIN_DEPENDS
     vector_map
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O3 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O3 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 #Road Occupancy Processor Library
 add_library(road_occupancy_processor_lib SHARED

--- a/ros/src/computing/planning/common/lib/openplanner/op_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_planner/CMakeLists.txt
@@ -24,7 +24,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -fPIC ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")
 
 include_directories(${catkin_INCLUDE_DIRS}
 		include

--- a/ros/src/computing/planning/common/lib/openplanner/op_ros_helpers/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_ros_helpers/CMakeLists.txt
@@ -39,7 +39,7 @@ catkin_package(
         vector_map_msgs
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 if ("${ROS_VERSION}" MATCHES "(kinetic)")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROS_KINETIC")
 endif ()

--- a/ros/src/computing/planning/common/lib/openplanner/op_simu/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_simu/CMakeLists.txt
@@ -32,7 +32,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -fPIC ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")
 
 include_directories(${catkin_INCLUDE_DIRS}
         include

--- a/ros/src/computing/planning/common/lib/openplanner/op_utility/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_utility/CMakeLists.txt
@@ -22,7 +22,7 @@ catkin_package(
 ## Build ##
 ###########
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(${catkin_INCLUDE_DIRS}
         include)

--- a/ros/src/computing/planning/decision/packages/decision_maker/CMakeLists.txt
+++ b/ros/src/computing/planning/decision/packages/decision_maker/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(decision_maker)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11 -lpthread -pg -Wall)
+add_compile_options(-lpthread -pg -Wall)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
 SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")

--- a/ros/src/computing/planning/mission/packages/freespace_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/freespace_planner/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   CATKIN_DEPENDS autoware_msgs

--- a/ros/src/computing/planning/mission/packages/lane_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/lane_planner/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
         autoware_msgs
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         INCLUDE_DIRS include

--- a/ros/src/computing/planning/mission/packages/way_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/way_planner/CMakeLists.txt
@@ -35,7 +35,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   include include/plannerh

--- a/ros/src/computing/planning/motion/packages/astar_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/astar_planner/CMakeLists.txt
@@ -24,7 +24,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/planning/motion/packages/dp_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/dp_planner/CMakeLists.txt
@@ -49,7 +49,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 if ("${ROS_VERSION}" MATCHES "(kinetic)")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROS_KINETIC")
 endif ()

--- a/ros/src/computing/planning/motion/packages/ff_waypoint_follower/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/ff_waypoint_follower/CMakeLists.txt
@@ -30,7 +30,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   include 

--- a/ros/src/computing/planning/motion/packages/lattice_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/lattice_planner/CMakeLists.txt
@@ -44,7 +44,7 @@ catkin_package(
         autoware_msgs
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         include

--- a/ros/src/computing/planning/motion/packages/op_local_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_local_planner/CMakeLists.txt
@@ -38,7 +38,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 if ("${ROS_VERSION}" MATCHES "(kinetic)")
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROS_KINETIC")
 endif()

--- a/ros/src/computing/planning/motion/packages/op_simulator/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_simulator/CMakeLists.txt
@@ -23,7 +23,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   include 

--- a/ros/src/computing/planning/motion/packages/op_simulator_perception/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_simulator_perception/CMakeLists.txt
@@ -17,7 +17,7 @@ catkin_package(
         CATKIN_DEPENDS roscpp geometry_msgs op_utility op_planner autoware_msgs
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         include

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
@@ -39,7 +39,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         include

--- a/ros/src/computing/planning/motion/packages/waypoint_maker/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/waypoint_maker/CMakeLists.txt
@@ -30,7 +30,7 @@ catkin_package(
         autoware_msgs
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/computing/planning/state/state_machine/CMakeLists.txt
+++ b/ros/src/computing/planning/state/state_machine/CMakeLists.txt
@@ -20,7 +20,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         include

--- a/ros/src/data/packages/map_file/CMakeLists.txt
+++ b/ros/src/data/packages/map_file/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 find_package(CURL REQUIRED)
 
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
 )

--- a/ros/src/data/packages/obj_db/CMakeLists.txt
+++ b/ros/src/data/packages/obj_db/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
         autoware_msgs
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ###################################
 ## catkin specific configuration ##

--- a/ros/src/data/packages/pos_db/CMakeLists.txt
+++ b/ros/src/data/packages/pos_db/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 include(FindLibSsh2.cmake)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         CATKIN_DEPENDS

--- a/ros/src/data/packages/vector_map/CMakeLists.txt
+++ b/ros/src/data/packages/vector_map/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   vector_map_msgs
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
   INCLUDE_DIRS include

--- a/ros/src/data/packages/vector_map_msgs/CMakeLists.txt
+++ b/ros/src/data/packages/vector_map_msgs/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 add_message_files(
   FILES

--- a/ros/src/data/packages/vector_map_server/CMakeLists.txt
+++ b/ros/src/data/packages/vector_map_server/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
         message_generation
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 add_service_files(
         FILES

--- a/ros/src/driveworks/packages/autoware_driveworks_interface/CMakeLists.txt
+++ b/ros/src/driveworks/packages/autoware_driveworks_interface/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(autoware_driveworks_interface)
 
-set(CMAKE_CXX_FLAGS "-O2 -s  -std=c++11 -Wno-error=unused-parameter")
+set(CMAKE_CXX_FLAGS "-O2 -s  -Wno-error=unused-parameter")
 
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/camera/packages/baumer/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/baumer/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PkgConfig REQUIRED)
 find_package(OpenCV REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
     LIBRARIES ${PROJECT_NAME}

--- a/ros/src/sensing/drivers/camera/packages/hexacam/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/hexacam/CMakeLists.txt
@@ -120,7 +120,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS} 
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ## Declare a C++ library
 # add_library(hexacam

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 	tf
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(OpenCV REQUIRED)
 

--- a/ros/src/sensing/drivers/camera/packages/vectacam/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/vectacam/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS} 
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 add_executable(vectacam_node nodes/vectacam/vectacam_node.cpp nodes/vectacam/VectaCam.cpp)
 

--- a/ros/src/sensing/drivers/gnss/packages/garmin/CMakeLists.txt
+++ b/ros/src/sensing/drivers/gnss/packages/garmin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(garmin)
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x") #or -std=c++11
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x") #or
 
 find_package(catkin REQUIRED COMPONENTS
   autoware_build_flags

--- a/ros/src/sensing/drivers/lidar/packages/hokuyo/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/hokuyo/CMakeLists.txt
@@ -14,7 +14,7 @@ catkin_package(
     DEPENDS roscpp sensor_msgs
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_executable(hokuyo_3d nodes/hokuyo_3d/hokuyo_3d.cpp nodes/hokuyo_3d/vssp.hpp)

--- a/ros/src/sensing/filters/packages/image_processor/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/image_processor/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(
         include
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 #Image rotator
 add_executable(image_rotator

--- a/ros/src/sensing/filters/packages/points_downsampler/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/points_downsampler/CMakeLists.txt
@@ -38,7 +38,7 @@ catkin_package(
 ###########
 
 include_directories(include ${catkin_INCLUDE_DIRS})
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 add_executable(voxel_grid_filter nodes/voxel_grid_filter/voxel_grid_filter.cpp)
 add_executable(ring_filter nodes/ring_filter/ring_filter.cpp)

--- a/ros/src/sensing/filters/packages/points_preprocessor/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/points_preprocessor/CMakeLists.txt
@@ -48,7 +48,7 @@ include_directories(
         include
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 link_directories(${PCL_LIBRARY_DIRS})
 

--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
@@ -31,7 +31,7 @@ catkin_package(CATKIN_DEPENDS
     tf
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O3 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O3 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
     ${catkin_INCLUDE_DIRS}

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
@@ -46,7 +46,7 @@ catkin_package(
         autoware_msgs
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall -g ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall -g ${CMAKE_CXX_FLAGS}")
 
 EXECUTE_PROCESS(
         COMMAND pkg-config --variable=host_bins Qt5Core

--- a/ros/src/sensing/fusion/packages/multi_lidar_calibrator/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/multi_lidar_calibrator/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(
         include
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 link_directories(${PCL_LIBRARY_DIRS})
 

--- a/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
@@ -44,7 +44,7 @@ catkin_package(
         pcl_conversions
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         include

--- a/ros/src/sensing/polygon/packages/points2polygon/CMakeLists.txt
+++ b/ros/src/sensing/polygon/packages/points2polygon/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PCL)
 find_package(Qt5Core REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         CATKIN_DEPENDS

--- a/ros/src/socket/packages/mqtt_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/mqtt_socket/CMakeLists.txt
@@ -15,7 +15,7 @@ catkin_package(
 )
 
 if (EXISTS /usr/include/mosquitto.h)
-    set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall -fpermissive ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-O2 -Wall -fpermissive ${CMAKE_CXX_FLAGS}")
 
     include_directories(
             include

--- a/ros/src/socket/packages/tablet_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/tablet_socket/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
         geometry_msgs
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         CATKIN_DEPENDS tf tablet_socket_msgs autoware_msgs gnss

--- a/ros/src/socket/packages/udon_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/udon_socket/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
         tablet_socket_msgs
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         INCLUDE_DIRS include

--- a/ros/src/socket/packages/vehicle_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/vehicle_socket/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
         tablet_socket_msgs
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         CATKIN_DEPENDS roscpp std_msgs autoware_msgs tablet_socket_msgs

--- a/ros/src/system/gazebo/catvehicle/CMakeLists.txt
+++ b/ros/src/system/gazebo/catvehicle/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
         velodyne_pointcloud
         )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS system)

--- a/ros/src/system/sync/CMakeLists.txt
+++ b/ros/src/system/sync/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 find_package(OpenCV REQUIRED)
 
-#set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+#set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 ###################################
 ## catkin specific configuration ##

--- a/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
@@ -23,7 +23,7 @@ catkin_package(
 ## Build ##
 ###########
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
         ${catkin_INCLUDE_DIRS}

--- a/ros/src/util/packages/RobotSDK/glviewer/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/glviewer/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_AUTOMOC ON)
 #set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)

--- a/ros/src/util/packages/RobotSDK/rosinterface/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/rosinterface/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_AUTOMOC ON)
 #set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)

--- a/ros/src/util/packages/autoware_rviz_plugins/CMakeLists.txt
+++ b/ros/src/util/packages/autoware_rviz_plugins/CMakeLists.txt
@@ -45,7 +45,7 @@ catkin_package(
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
 
 
 add_definitions(-DQT_NO_KEYWORDS -g)

--- a/ros/src/util/packages/fake_drivers/CMakeLists.txt
+++ b/ros/src/util/packages/fake_drivers/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
 )
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(OpenCV REQUIRED)
 

--- a/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
+++ b/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kitti_player)
 
-SET(CMAKE_CXX_FLAGS "-O3 -std=c++11")
+SET(CMAKE_CXX_FLAGS "-O3")
 
 find_package(catkin REQUIRED COMPONENTS
         autoware_build_flags

--- a/ros/src/util/packages/log_tools/CMakeLists.txt
+++ b/ros/src/util/packages/log_tools/CMakeLists.txt
@@ -3,6 +3,8 @@ project(log_tools)
 
 add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+    autoware_build_flags
+    )
 
 catkin_package()

--- a/ros/src/util/packages/log_tools/package.xml
+++ b/ros/src/util/packages/log_tools/package.xml
@@ -8,6 +8,7 @@
     <!-- <url type="website">http://wiki.ros.org/log_tools</url> -->
     <author email="akihito.ohsato@tier4.jp">Akihito Ohsato</author>
     <buildtool_depend>catkin</buildtool_depend>
+    <buildtool_depend>autoware_build_flags</buildtool_depend>
 
     <run_depend>rospy</run_depend>
     <run_depend>python-flask</run_depend>

--- a/ros/src/util/packages/map_tf_generator/CMakeLists.txt
+++ b/ros/src/util/packages/map_tf_generator/CMakeLists.txt
@@ -7,7 +7,8 @@ project(map_tf_generator)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED
+find_package(catkin REQUIRED COMPONENTS
+  autoware_build_flags
   roscpp
   std_msgs
   pcl_ros

--- a/ros/src/util/packages/map_tf_generator/package.xml
+++ b/ros/src/util/packages/map_tf_generator/package.xml
@@ -8,6 +8,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>autoware_build_flags</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>

--- a/ros/src/util/packages/map_tools/CMakeLists.txt
+++ b/ros/src/util/packages/map_tools/CMakeLists.txt
@@ -21,7 +21,7 @@ catkin_package(
         DEPENDS PCL
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 

--- a/ros/src/util/packages/sample_data/CMakeLists.txt
+++ b/ros/src/util/packages/sample_data/CMakeLists.txt
@@ -24,7 +24,7 @@ else ()
     set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 endif ()
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 catkin_package(
         DEPENDS roscpp


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
This PR adds the flag to enable C++11 to `autoware_build_flags` and standardizes its use across all packages that previously set the flag directly via `CMAKE_CXX_FLAGS`

## Related PRs

branch | PR
------ | ------
develop | #1385