### PR TITLE
[fix] update dpkg to 1.17.5ubuntu5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ before_install:
       sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list";
       sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116;
       sudo apt-get update;
-      sudo apt-get install -y  python-catkin-pkg python-rosdep python-wstool ros-${ROS_DISTRO}-catkin;
+      sudo apt-get install -y dpkg;
+      sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-${ROS_DISTRO}-catkin;
       source /opt/ros/${ROS_DISTRO}/setup.bash;
       sudo rosdep init;
       rosdep update;


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Indigo builds on Travis are failing with this message when installing `python-catkin-pkg` and `python-catkin-pkg-modules`.

```
dpkg-deb: error: archive '/var/cache/apt/archives/python-catkin-pkg-modules_0.4.7-1_all.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
dpkg: error processing archive /var/cache/apt/archives/python-catkin-pkg-modules_0.4.7-1_all.deb (--unpack):
 subprocess dpkg-deb --control returned error exit status 2
dpkg-deb: error: archive '/var/cache/apt/archives/python-catkin-pkg_0.4.7-100_all.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
dpkg: error processing archive /var/cache/apt/archives/python-catkin-pkg_0.4.7-100_all.deb (--unpack):
 subprocess dpkg-deb --control returned error exit status 2
```

Updating to `dpkg` 1.17.5ubuntu5.8 fixes that issue according to https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627