### PR TITLE
[Fix] link tinyxml

### DIFF
--- a/ros/src/computing/planning/common/lib/openplanner/op_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_planner/CMakeLists.txt
@@ -5,11 +5,14 @@ project(op_planner)
 set(ROS_VERSION $ENV{ROS_DISTRO})
 
 find_package(catkin REQUIRED COMPONENTS
-        autoware_build_flags
+		autoware_build_flags
+		cmake_modules
 		op_utility
 )
 
 find_package(OpenCV REQUIRED)
+
+find_package(TinyXML REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -50,6 +53,7 @@ add_library(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
 		${catkin_LIBRARIES}
 		${OpenCV_LIBS}
+		${TinyXML_LIBRARIES}
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/ros/src/computing/planning/common/lib/openplanner/op_planner/package.xml
+++ b/ros/src/computing/planning/common/lib/openplanner/op_planner/package.xml
@@ -8,6 +8,7 @@
     <license>BSD</license>
     <buildtool_depend>catkin</buildtool_depend>
     <buildtool_depend>autoware_build_flags</buildtool_depend>
+    <build_depend>cmake_modules</build_depend>
     <build_depend>op_utility</build_depend>
     <run_depend>op_utility</run_depend>
 


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
I noticed that TinyXML was missing as a link dependency when I built Autoware with `catkin_make_isolated`.

I've added `cmake-modules` from ROS to find TinyXML from CMake.