### PR TITLE
Add radar_msgs from astuff_sensor_msgs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "ros/src/msgs/platform_automation_msgs"]
 	path = ros/src/msgs/platform_automation_msgs
 	url = https://github.com/astuff/platform_automation_msgs.git
+
+[submodule "ros/src/msgs/astuff_sensor_msgs"]
+	path = ros/src/msgs/astuff_sensor_msgs
+	url = https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
The `platform_automation_msgs` repository no longer ships the `radar_msgs` package (see https://github.com/astuff/platform_automation_msgs/pull/5). This PR adds the `astuff_sensor_msgs` repository instead (https://github.com/astuff/astuff_sensor_msgs)