### PR TITLE
[Fix] Push Build-Docker for each environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,21 +65,35 @@ before_script:
 # non-zero when a test fails (which notifies Travis the build failed).
 script:
   - if [ "${CROSS_COMPILE}" == "1" ]; then
+      AUTOWARE_HOME=${TRAVIS_BUILD_DIR};
+      AUTOWARE_TARGET_ARCH=aarch64;
+      AUTOWARE_TARGET_PLATFORM=generic-aarch64;
+      AUTOWARE_BUILD_PATH=${AUTOWARE_HOME}/ros/build-${AUTOWARE_TARGET_PLATFORM};
+      AUTOWARE_DEVEL_PATH=${AUTOWARE_HOME}/ros/devel-${AUTOWARE_TARGET_PLATFORM};
+      AUTOWARE_TOOLCHAIN_FILE_PATH=${AUTOWARE_HOME}/ros/cross_toolchain.cmake;
+      AUTOWARE_SYSROOT=/sysroot/${AUTOWARE_TARGET_PLATFORM};
+
       travis_retry docker run
-        -e AUTOWARE_SYSROOT=/sysroot/aarch64
+        -e AUTOWARE_SYSROOT=${AUTOWARE_SYSROOT}
         --rm
-        -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR}
-        -w ${TRAVIS_BUILD_DIR}/ros
-        autoware/crossbuild:aarch64-kinetic-1.0.0
+        -v ${AUTOWARE_HOME}:${AUTOWARE_HOME}
+        -w ${AUTOWARE_HOME}/ros
+        autoware/build:${AUTOWARE_TARGET_PLATFORM}-kinetic-20180809
         bash
           -c "source /opt/ros/kinetic/setup.bash &&
               catkin_make
-                -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/ros/cross_toolchain.cmake
-                -DCMAKE_SYSTEM_PROCESSOR=aarch64 clean &&
-              source devel/setup.bash &&
+                -DCMAKE_TOOLCHAIN_FILE=${AUTOWARE_TOOLCHAIN_FILE_PATH}
+                -DCATKIN_DEVEL_PREFIX=${AUTOWARE_DEVEL_PATH}
+                -DCMAKE_SYSTEM_PROCESSOR=${AUTOWARE_TARGET_ARCH}
+                --build ${AUTOWARE_BUILD_PATH}
+                clean &&
+              source devel-${AUTOWARE_TARGET_PLATFORM}/setup.bash &&
               catkin_make
-                -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/ros/cross_toolchain.cmake
-                -DCMAKE_SYSTEM_PROCESSOR=aarch64 -j4";
+                -DCMAKE_TOOLCHAIN_FILE=${AUTOWARE_TOOLCHAIN_FILE_PATH}
+                -DCATKIN_DEVEL_PREFIX=${AUTOWARE_DEVEL_PATH}
+                -DCMAKE_SYSTEM_PROCESSOR=${AUTOWARE_TARGET_ARCH}
+                --build ${AUTOWARE_BUILD_PATH}
+                -j4";
     else
       catkin_make clean;
       source devel/setup.bash;

--- a/docker/crossbuild/README.md
+++ b/docker/crossbuild/README.md
@@ -8,14 +8,20 @@ Autoware users skip this step.
 ```
 $ cd Autoware/docker/crossbuild/
 
-# aarch64
-$ ./build_cross_image.sh aarch64
+# generic-aarch64
+$ ./build_cross_image.sh generic-aarch64
+
+# synquacer
+$ ./build_cross_image.sh synquacer
 ```
 
 ## How to Build Cross
 ```
 $ cd Autoware/ros/
 
-# aarch64
-$ ./catkin_make_release_cross aarch64
+# generic-aarch64
+$ ./catkin_make_release_cross generic-aarch64
+
+# synquacer
+$ ./catkin_make_release_cross synquacer
 ```

--- a/docker/crossbuild/build_cross_image.sh
+++ b/docker/crossbuild/build_cross_image.sh
@@ -17,7 +17,7 @@ then
         --build-arg AUTOWARE_DOCKER_ARCH=${AUTOWARE_DOCKER_ARCH} \
         --build-arg AUTOWARE_TARGET_ARCH=${AUTOWARE_TARGET_ARCH} \
         --build-arg AUTOWARE_TARGET_PLATFORM=${AUTOWARE_TARGET_PLATFORM} \
-        -t autoware/crossbuild:${AUTOWARE_TARGET_PLATFORM}-kinetic-1.0.0 \
+        -t autoware/build:${AUTOWARE_TARGET_PLATFORM}-kinetic-20180809 \
         -f Dockerfile.kinetic-crossbuild .
 
     # Deregister QEMU as a handler for non-x86 targets

--- a/ros/catkin_make_release_cross
+++ b/ros/catkin_make_release_cross
@@ -28,7 +28,7 @@ then
         -v ${PWD}/../:${AUTOWARE_HOME} \
         -w ${AUTOWARE_HOME}/ros \
         -u ${UID}:${UID} \
-        autoware/crossbuild:${AUTOWARE_TARGET_PLATFORM}-kinetic-1.0.0 \
+        autoware/build:${AUTOWARE_TARGET_PLATFORM}-kinetic-20180809 \
         bash \
         -c "\
         source /opt/ros/kinetic/setup.bash && \


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
DockerHub Repositories
- DockerHub [autoware/build](https://hub.docker.com/r/autoware/build/tags/) will be used instead of [autoware/crossbuild](https://hub.docker.com/r/autoware/crossbuild/tags/) for using Docker with self build mentioned at https://github.com/CPFL/Autoware/pull/1396#issuecomment-409539642.
- DockerHub [autoware/crossbuild](https://hub.docker.com/r/autoware/crossbuild/tags/) can be removed a short time later because it is not included in v1.7.
- autoware/build:${AUTOWARE_TARGET_PLATFORM}-kinetic-YYYYMMDD were pushed to https://hub.docker.com/r/autoware/build/tags/.

Tag Name
- Date YYYYMMDD is used instead of version number such as 1.0.0 because the version number is difficult to show what it means.

Travis
- Travis uses autoware/build:generic-aarch64-kinetic-YYYYMMDD.

## Related PRs
branch | PR
------ | ------
esteve:feature/crosscompile_multiple_platforms | #1398

## Todos
- [x] Tests
- [x] Documentation

## Steps to Test or Reproduce
```
cd Autoware/docker/crossbuild
./build_cross_image generic-aarch64
cd ../../ros
./catkin_make_release_cross generic-aarch64
```