### PR TITLE
[Fix] add_dependencies into lidar_fake_perception

### DIFF
--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeLists.txt
@@ -38,6 +38,9 @@ add_executable(lidar_fake_perception_node
 target_link_libraries(lidar_fake_perception_node
   ${catkin_LIBRARIES}
 )
+add_dependencies(lidar_fake_perception_node
+        ${catkin_EXPORTED_TARGETS}
+        )
 
 install(TARGETS
   lidar_fake_perception_node


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fixed the following issue of ./catkin_make_release shown at https://github.com/CPFL/Autoware/pull/1439#issuecomment-412413195.
```
Scanning dependencies of target _catkin_empty_exported_target
[  3%] Built target _catkin_empty_exported_target
Scanning dependencies of target lidar_fake_perception_node
[  4%] Building CXX object computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeFiles/lidar_fake_perception_node.dir/nodes/lidar_fake_perception.cpp.o
In file included from /home/funaoka/Autoware/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/nodes/lidar_fake_perception.cpp:four:0:
/home/funaoka/Autoware/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/include/lidar_fake_perception.h:16:42: fatal error: autoware_msgs/DetectedObject.h: No such file or directory
compilation terminated.
computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeFiles/lidar_fake_perception_node.dir/build.make:62: recipe for target 'computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeFiles/lidar_fake_perception_node.dir/nodes/lidar_fake_perception.cpp.o' failed
make[2]: *** [computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeFiles/lidar_fake_perception_node.dir/nodes/lidar_fake_perception.cpp.o] Error 1
CMakeFiles/Makefile2:27891: recipe for target 'computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeFiles/lidar_fake_perception_node.dir/all' failed
make[1]: *** [computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeFiles/lidar_fake_perception_node.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[  4%] Built target points2vscan_automoc
Generating moc_selectionwidget.cpp
```

## Related PRs

branch | PR
------ | ------
feature/lidar_fake_perception | #1439


## Todos
- [x] Tests

## Steps to Test or Reproduce
./catkin_make_release at 589e749