### PR TITLE
[fix] Larger queue size to achieve synchronization in obj_fusion

### DIFF
--- a/ros/src/computing/perception/detection/lidar_tracker/packages/obj_fusion/nodes/obj_fusion/obj_fusion.cpp
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/obj_fusion/nodes/obj_fusion/obj_fusion.cpp
@@ -24,6 +24,7 @@ using vector_map::Key;
 
 static constexpr uint32_t SUBSCRIBE_QUEUE_SIZE = 1;
 static constexpr uint32_t ADVERTISE_QUEUE_SIZE = 1;
+static constexpr uint32_t SYNCHRONIZE_QUEUE_SIZE = 10;
 static constexpr bool ADVERTISE_LATCH = false;
 static constexpr double LOOP_RATE = 15.0;
 
@@ -351,12 +352,12 @@ int main(int argc, char *argv[])
   private_n.param("vmap_threshold", vmap_threshold, 5.0);
   vmap_threshold *= vmap_threshold;  // squared
 
-  typedef message_filters::sync_policies::ApproximateTime<autoware_msgs::obj_label, autoware_msgs::CloudClusterArray>
-      SyncPolicy;
   message_filters::Subscriber<autoware_msgs::obj_label> obj_label_sub(n, "obj_label", SUBSCRIBE_QUEUE_SIZE);
   message_filters::Subscriber<autoware_msgs::CloudClusterArray> cluster_centroids_sub(n, "/cloud_clusters",
                                                                                       SUBSCRIBE_QUEUE_SIZE);
-  message_filters::Synchronizer<SyncPolicy> sync(SyncPolicy(SUBSCRIBE_QUEUE_SIZE), obj_label_sub,
+  typedef message_filters::sync_policies::ApproximateTime<autoware_msgs::obj_label, autoware_msgs::CloudClusterArray>
+      SyncPolicy;
+  message_filters::Synchronizer<SyncPolicy> sync(SyncPolicy(SYNCHRONIZE_QUEUE_SIZE), obj_label_sub,
                                                  cluster_centroids_sub);
   sync.registerCallback(boost::bind(&fusion_cb, _1, _2));
 


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
When attempting to detect an object in Gazebo and compute its pose using obj_fusion node and there are big differences in the time stamps of messages arriving at the subscribed topics, synchronization can not be achieved and thus fusion_cb() function is never actually called. In this case, the queue size argument in the ApproximateTime constructor must be large enough so as to achieve message matching [(ROS wiki)](http://wiki.ros.org/message_filters/ApproximateTime).