### PR TITLE
fix transformation from localizer to base_link in ndt_mapping

### DIFF
--- a/ros/src/computing/perception/localization/packages/lidar_localizer/nodes/ndt_mapping/ndt_mapping.cpp
+++ b/ros/src/computing/perception/localization/packages/lidar_localizer/nodes/ndt_mapping/ndt_mapping.cpp
@@ -1041,12 +1041,7 @@ int main(int argc, char** argv)
   Eigen::AngleAxisf rot_y_btol(_tf_pitch, Eigen::Vector3f::UnitY());
   Eigen::AngleAxisf rot_z_btol(_tf_yaw, Eigen::Vector3f::UnitZ());
   tf_btol = (tl_btol * rot_z_btol * rot_y_btol * rot_x_btol).matrix();
-
-  Eigen::Translation3f tl_ltob((-1.0) * _tf_x, (-1.0) * _tf_y, (-1.0) * _tf_z);  // tl: translation
-  Eigen::AngleAxisf rot_x_ltob((-1.0) * _tf_roll, Eigen::Vector3f::UnitX());     // rot: rotation
-  Eigen::AngleAxisf rot_y_ltob((-1.0) * _tf_pitch, Eigen::Vector3f::UnitY());
-  Eigen::AngleAxisf rot_z_ltob((-1.0) * _tf_yaw, Eigen::Vector3f::UnitZ());
-  tf_ltob = (tl_ltob * rot_z_ltob * rot_y_ltob * rot_x_ltob).matrix();
+  tf_ltob = tf_btol.inverse();
 
   map.header.frame_id = "map";
 


### PR DESCRIPTION
## Description
This PR is intended to solve autowarefoundation/autoware_ai#273. When lidar is mounted in a different direction from base_link, ndt_mapping may fail due to the wrong calculation of the transform between localizer and base_link. 

## Related PRs
N/A

## Todos
- [x] Tests
- [ ] Documentation
