### PR TITLE
feature/data_rate_checker_plugin

### DIFF
--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/CMakeLists.txt
@@ -27,6 +27,7 @@ if (rviz_QT_VERSION VERSION_LESS "5")
     qt4_wrap_ui(UI_HEADERS
             node/traffic_light_plugin/form.ui
             node/image_viewer_plugin/image_viewer_form.ui
+            node/data_rate_checker_plugin/data_rate_checker_form.ui
             )
 
     # Here we specify which header files need to be run through "moc",
@@ -34,6 +35,7 @@ if (rviz_QT_VERSION VERSION_LESS "5")
     qt4_wrap_cpp(MOC_FILES
             node/traffic_light_plugin/traffic_light_plugin.h
             node/image_viewer_plugin/image_viewer_plugin.h
+            node/data_rate_checker_plugin/data_rate_checker_plugin.h
             )
 else ()
     find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets Quick)
@@ -42,6 +44,7 @@ else ()
     qt5_wrap_ui(UI_HEADERS
             node/traffic_light_plugin/form.ui
             node/image_viewer_plugin/image_viewer_form.ui
+            node/data_rate_checker_plugin/data_rate_checker_form.ui
             )
 
     # Here we specify which header files need to be run through "moc",
@@ -49,6 +52,7 @@ else ()
     qt5_wrap_cpp(MOC_FILES
             node/traffic_light_plugin/traffic_light_plugin.h
             node/image_viewer_plugin/image_viewer_plugin.h
+            node/data_rate_checker_plugin/data_rate_checker_plugin.h
             )
 endif ()
 
@@ -76,6 +80,7 @@ set(SOURCE_FILES
         node/image_viewer_plugin/draw_rects.cpp
         node/image_viewer_plugin/draw_points.cpp
         node/image_viewer_plugin/draw_lane.cpp
+        node/data_rate_checker_plugin/data_rate_checker_plugin.cpp
         ${MOC_FILES}
         ${UI_HEADERS})
 

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_form.ui
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_form.ui
@@ -103,14 +103,23 @@
        </item>
        <item row="3" column="0" colspan="2">
         <widget class="QLCDNumber" name="topic_frequency_lcd_">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>50</height>
+          </size>
+         </property>
          <property name="frameShape">
           <enum>QFrame::NoFrame</enum>
          </property>
-         <property name="segmentStyle">
-          <enum>QLCDNumber::Flat</enum>
+         <property name="smallDecimalPoint">
+          <bool>true</bool>
          </property>
          <property name="digitCount">
           <number>6</number>
+         </property>
+         <property name="segmentStyle">
+          <enum>QLCDNumber::Flat</enum>
          </property>
         </widget>
        </item>

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_form.ui
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_form.ui
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>data_rate_checker_form</class>
+ <widget class="QWidget" name="data_rate_checker_form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>646</width>
+    <height>527</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <layout class="QFormLayout" name="formLayout">
+       <property name="horizontalSpacing">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="topic_label_">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <family>Ubuntu</family>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Topic: </string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QComboBox" name="topic_combo_box_"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="topic_frequency_label_">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Topic frequency:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="status_icon_label_">
+         <property name="font">
+          <font>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Status:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QLabel" name="status_text_">
+         <property name="text">
+          <string>No topic selected</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
+        <widget class="QLCDNumber" name="topic_frequency_lcd_">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="segmentStyle">
+          <enum>QLCDNumber::Flat</enum>
+         </property>
+         <property name="digitCount">
+          <number>6</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="min_frequency_label_">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <family>Ubuntu</family>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Min. Hz: </string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QSpinBox" name="min_frequency_spin_box_">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum frequency&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
+        <widget class="QLabel" name="status_icon_">
+         <property name="font">
+          <font>
+           <pointsize>70</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>◉</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.cpp
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.cpp
@@ -1,0 +1,188 @@
+#include <ros/ros.h>
+// #include <cmath>
+// #include <deque>
+// #include <iostream>
+// #include <string>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <QString>
+#include <QImage>
+
+#include "data_rate_checker_plugin.h"
+
+namespace integrated_viewer {
+
+    const QString DataRateCheckerPlugin::kBlankTopic = "-----";
+    std::string DummyMsg::md5 = "*";
+    std::string DummyMsg::data_type = "/";
+
+    DataRateCheckerPlugin::DataRateCheckerPlugin(QWidget *parent)
+            : rviz::Panel(parent) {
+
+        // Initialize form
+        ui_.setupUi(this);
+
+        // Set minimum frequency parameter
+        ui_.min_frequency_spin_box_->setMinimum(1);
+        ui_.min_frequency_spin_box_->setValue(5);
+
+        ui_.topic_frequency_lcd_->setMinimumWidth(ui_.topic_frequency_lcd_->width()+2);
+
+        UpdateTopicList();
+
+        // If combobox is clicked, topic list will be update
+        ui_.topic_combo_box_->installEventFilter(this);
+    } // DataRateCheckerPlugin::DataRateCheckerPlugin
+
+
+    void DataRateCheckerPlugin::UpdateTopicList(void) {
+        // The topic list that can be selected from the UI
+        QStringList topic_list;
+
+        // The topic name currently chosen
+        QString topic_current = ui_.topic_combo_box_->currentText();
+
+        if (topic_current == "") {
+            topic_current = kBlankTopic;
+            ui_.status_icon_->setStyleSheet("QLabel {color: #b3b3b3;}");
+            ui_.status_text_->setText(QString("No topic selected"));
+            ui_.topic_frequency_lcd_->setStyleSheet("QLCDNumber {color: #b3b3b3;}");
+            ui_.topic_frequency_lcd_->display(0.0);
+        }
+
+        // Insert blank topic name to the top of the lists
+        topic_list << kBlankTopic;
+
+        // Get all available topic
+        ros::master::V_TopicInfo master_topics;
+        ros::master::getTopics(master_topics);
+
+        // Convert topic names
+        for (ros::master::V_TopicInfo::iterator it = master_topics.begin(); it != master_topics.end(); it++) {
+            const ros::master::TopicInfo &info = *it;
+            const QString topic_name = QString::fromStdString(info.name);
+            const QString topic_type = QString::fromStdString(info.datatype);
+            topic_list << topic_name;
+        }
+
+        // Remove all list items from combo box
+        ui_.topic_combo_box_->clear();
+
+        // Set new items to combo box
+        ui_.topic_combo_box_->addItems(topic_list);
+
+        ui_.topic_combo_box_->insertSeparator(1);
+
+        // Set last topic as current
+        int topic_index = ui_.topic_combo_box_->findText(topic_current);
+
+        if (topic_index != -1) {
+            ui_.topic_combo_box_->setCurrentIndex(topic_index);
+        }
+    } // DataRateCheckerPlugin::UpdateTopicList
+
+
+    // The behavior of combo box
+    void DataRateCheckerPlugin::on_topic_combo_box__activated(int index) {
+        // Extract selected topic name from combo box
+        std::string selected_topic = ui_.topic_combo_box_->itemText(index).toStdString();
+        if (selected_topic == kBlankTopic.toStdString() || selected_topic == "") {
+            topic_sub_.shutdown();
+            timer_.stop();
+            ui_.status_icon_->setStyleSheet("QLabel {color: #b3b3b3;}");
+            ui_.status_text_->setText(QString("No topic selected"));
+            ui_.topic_frequency_lcd_->setStyleSheet("QLCDNumber {color: #b3b3b3;}");
+            ui_.topic_frequency_lcd_->display(0.0);
+            return;
+        }
+
+        // If selected topic is not blank or empty, start callback functions
+        topic_sub_ = node_handle_.subscribe(selected_topic,
+                                            1,
+                                            &DataRateCheckerPlugin::MessageCallback,
+                                            this);
+
+        timer_ = node_handle_.createWallTimer(ros::WallDuration(1.0),
+                                              &DataRateCheckerPlugin::TimerCallback,
+                                              this);
+
+    } // DataRateCheckerPlugin::on_topic_combo_box__activated
+
+    void DataRateCheckerPlugin::MessageCallback(const DummyMsg &msg) {
+      // Record time message arrives
+      auto time = std::chrono::system_clock::now();
+      double diff = std::chrono::duration<double>(time - last_).count();
+      last_ = time;
+
+      message_count_++;
+
+      if (message_count_ < 2) {
+        return;
+      }
+
+      times_.push_back(diff);
+
+      if (times_.size() + 1 > window_size_) {
+        times_.pop_front();
+      }
+    } // DataRateCheckerPlugin::MessageCallback
+
+    void DataRateCheckerPlugin::TimerCallback(const ros::WallTimerEvent &event) {
+      // Check average frame rates
+      double avg_delay = std::accumulate(times_.begin(), times_.end(), 0.0) / times_.size();
+      double frequency = 1.0 / avg_delay;
+
+      // Warn if no new messages have arrived
+      if (status_count_ == message_count_ || times_.size() < 2) {
+        ui_.status_icon_->setStyleSheet("QLabel {color: #ff0000}");
+        ui_.status_text_->setText(QString("No incoming messages"));
+        ui_.topic_frequency_lcd_->setStyleSheet("QLCDNumber {color: #ff0000;}");
+        ui_.topic_frequency_lcd_->display(0.0);
+        return;
+      }
+
+      // Warn if message frequency is too low
+      else if (frequency < (double)(ui_.min_frequency_spin_box_->value())) {
+        ui_.status_icon_->setStyleSheet("QLabel {color: #ff0000;}");
+        ui_.status_text_->setText(QString("Message frequency too low"));
+        ui_.topic_frequency_lcd_->setStyleSheet("QLCDNumber {color: #ff0000;}");
+        ui_.topic_frequency_lcd_->display(frequency);
+        status_count_ = message_count_;
+        return;
+      }
+
+      // Otherwise, we are good!
+      else if (frequency > (double)(ui_.min_frequency_spin_box_->value())) {
+        ui_.status_icon_->setStyleSheet("QLabel {color: #00ff00;}");
+        ui_.status_text_->setText(QString ("Messages rate is OK"));
+        ui_.topic_frequency_lcd_->setStyleSheet("QLCDNumber {color: #00ff00;}");
+        ui_.topic_frequency_lcd_->display(frequency);
+        status_count_ = message_count_;
+        return;
+      }
+    } // DataRateCheckerPlugin::TimerCallback
+
+    void DataRateCheckerPlugin::resizeEvent(QResizeEvent *) {
+        //ShowImageOnUi();
+    } // DataRateCheckerPlugin::resizeEvent
+
+    bool DataRateCheckerPlugin::eventFilter(QObject *object, QEvent *event) {
+        if (event->type() == QEvent::MouseButtonPress) {
+            // Combo box will update its contents if this filter is applied
+            UpdateTopicList();
+        }
+
+        return QObject::eventFilter(object, event);
+    } // DataRateCheckerPlugin::eventFilter
+
+} // End namespace integrated_viewer
+
+
+// Tell pluginlib about this class.  Every class which should be
+// loadable by pluginlib::ClassLoader must have these two lines
+// compiled in its .cpp file, outside of any namespace scope.
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(integrated_viewer::DataRateCheckerPlugin, rviz::Panel)
+// END_TUTORIAL

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.cpp
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.cpp
@@ -145,7 +145,7 @@ namespace integrated_viewer {
       // Warn if message frequency is too low
       else if (frequency < (double)(ui_.min_frequency_spin_box_->value())) {
         ui_.status_icon_->setStyleSheet("QLabel {color: #ff0000;}");
-        ui_.status_text_->setText(QString("Message frequency too low"));
+        ui_.status_text_->setText(QString("Message rate is too low"));
         ui_.topic_frequency_lcd_->setStyleSheet("QLCDNumber {color: #ff0000;}");
         ui_.topic_frequency_lcd_->display(frequency);
         status_count_ = message_count_;

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.cpp
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.cpp
@@ -155,7 +155,7 @@ namespace integrated_viewer {
       // Otherwise, we are good!
       else if (frequency > (double)(ui_.min_frequency_spin_box_->value())) {
         ui_.status_icon_->setStyleSheet("QLabel {color: #00ff00;}");
-        ui_.status_text_->setText(QString ("Messages rate is OK"));
+        ui_.status_text_->setText(QString ("Message rate is OK"));
         ui_.topic_frequency_lcd_->setStyleSheet("QLCDNumber {color: #00ff00;}");
         ui_.topic_frequency_lcd_->display(frequency);
         status_count_ = message_count_;

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
@@ -60,7 +60,7 @@ namespace integrated_viewer
     ros::WallTimer timer_;
 
     // Variables for message timing
-    unsigned int window_size_ = 1000;
+    unsigned int window_size_ = 100;
 
     unsigned int message_count_ = 0;
     std::deque<double> times_;
@@ -68,9 +68,9 @@ namespace integrated_viewer
 
     unsigned int status_count_ = 0;
 
-    QPalette red_palette;
-    QPalette green_palette;
-    QPalette grey_palette;
+    // QPalette red_text_palette;
+    // QPalette green_text_palette;
+    // QPalette grey_text_palette;
 
   private:
     // The UI components

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
@@ -60,7 +60,7 @@ namespace integrated_viewer
     ros::WallTimer timer_;
 
     // Variables for message timing
-    unsigned int window_size_ = 100;
+    unsigned int window_size_ = 10;
 
     unsigned int message_count_ = 0;
     std::deque<double> times_;

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
@@ -68,9 +68,9 @@ namespace integrated_viewer
 
     unsigned int status_count_ = 0;
 
-    // QPalette red_text_palette;
-    // QPalette green_text_palette;
-    // QPalette grey_text_palette;
+    // Save and load overrides
+    virtual void save(rviz::Config config) const;
+    virtual void load(const rviz::Config& config);
 
   private:
     // The UI components

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_plugin.h
@@ -1,0 +1,87 @@
+#ifndef DATA_RATE_CHECKER_PLUGIN_H
+#define DATA_RATE_CHECKER_PLUGIN_H
+
+#ifndef Q_MOC_RUN
+#include <ros/ros.h>
+#include <opencv/cv.h>
+#include <opencv/highgui.h>
+#include <rviz/panel.h>
+#include <chrono>
+#include <string>
+#include <map>
+
+#include <QStringList>
+#include <QWidget>
+#include <QEvent>
+
+#include "convert_image.h"
+#include "ui_data_rate_checker_form.h"
+#endif
+
+namespace integrated_viewer
+{
+  class DummyMsg {
+  public:
+    static std::string md5;
+    static std::string data_type;
+    static std::string const &__s_getMD5Sum() { return md5; }
+    static std::string const &__s_getDataType() { return data_type; }
+    void deserialize(void *) {}
+}; // End class DummyMsg
+
+  class DataRateCheckerPlugin: public rviz::Panel {
+  Q_OBJECT
+  public:
+    explicit DataRateCheckerPlugin(QWidget* parent = 0);
+
+    // Override resize event
+    virtual void resizeEvent(QResizeEvent *);
+
+  protected:
+    // The function to update topic list that can be selected from the UI
+    void UpdateTopicList(void);
+
+    // The event filter to catch clicking on combo box
+    bool eventFilter(QObject* object, QEvent* event);
+
+    // The Callback functions
+    void MessageCallback(const DummyMsg &msg);
+    void TimerCallback(const ros::WallTimerEvent &event);
+
+    // The blank topic name
+    static const QString kBlankTopic;
+
+    // The ROS node handle
+    ros::NodeHandle node_handle_;
+
+    // The ROS subscriber
+    ros::Subscriber topic_sub_;
+    // The ROS timer
+    ros::WallTimer timer_;
+
+    // Variables for message timing
+    unsigned int window_size_ = 1000;
+
+    unsigned int message_count_ = 0;
+    std::deque<double> times_;
+    std::chrono::system_clock::time_point last_;
+
+    unsigned int status_count_ = 0;
+
+    QPalette red_palette;
+    QPalette green_palette;
+    QPalette grey_palette;
+
+  private:
+    // The UI components
+    Ui::data_rate_checker_form ui_;
+
+    // The behavior definition of the UI
+    private Q_SLOTS:
+      void on_topic_combo_box__activated(int index);
+
+  }; // End class DataRateCheckerPlugin
+
+} // End namespace integrated_viewer
+
+#endif // DATA_RATE_CHECKER_PLUGIN_H

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/rviz_plugin_description.xml
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/rviz_plugin_description.xml
@@ -16,4 +16,12 @@
     </description>
   </class>
 
+  <class name="integrated_viewer/DataRateCheckerPlugin"
+         type="integrated_viewer::DataRateCheckerPlugin"
+         base_class_type="rviz::Panel">
+    <description>
+      A panel widget to check the frequency of a particular topic is above a minimum threshold
+    </description>
+  </class>
+
 </library>


### PR DESCRIPTION
## Status
Development

## Description
An RViz plugin to show if a topic has messages being published at the required rate. The topic and required frequency can be selected, and the plugin shows the topic frequency and an icon to allow easy monitoring. Implements autowarefoundation/autoware_ai#281 

## Related PRs
None

## Todos
~- Test building with industrial_ci~
- Readme - if required?


## Steps to Test or Reproduce
- Open RViz
- Add an instance of the plugin from Panels->Add new panel->DataRateCheckerPlugin
- Select desired topic and minimum required frequency
- Save the RViz configuration to keep spawned instances and settings for each next time you open