### PR TITLE
[Fix] Minor fixes for RViz plugins

### DIFF
--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_form.ui
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/data_rate_checker_plugin/data_rate_checker_form.ui
@@ -51,19 +51,14 @@
        <item row="2" column="0">
         <widget class="QLabel" name="topic_frequency_label_">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>1</height>
-          </size>
-         </property>
          <property name="font">
           <font>
+           <family>Ubuntu</family>
            <pointsize>14</pointsize>
            <weight>75</weight>
            <bold>true</bold>
@@ -81,6 +76,7 @@
         <widget class="QLabel" name="status_icon_label_">
          <property name="font">
           <font>
+           <family>Ubuntu</family>
            <pointsize>14</pointsize>
            <weight>75</weight>
            <bold>true</bold>
@@ -159,6 +155,7 @@
         <widget class="QLabel" name="status_icon_">
          <property name="font">
           <font>
+           <family>Ubuntu</family>
            <pointsize>70</pointsize>
            <weight>75</weight>
            <bold>true</bold>

--- a/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/image_viewer_plugin/image_viewer_plugin.cpp
+++ b/ros/src/computing/perception/detection/viewers/packages/integrated_viewer/node/image_viewer_plugin/image_viewer_plugin.cpp
@@ -445,7 +445,7 @@ namespace integrated_viewer {
         }
       }
 
-      if(config.mapGetInt ("Point_size", &point_size)) {
+      if(config.mapGetInt ("Point size", &point_size)) {
         ui_.point_size_spin_box_->setValue(point_size);
       }
     } // ImageViewerPlugin::load


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fixes some minor issues with the RViz plugins ImageViewerPlugin and DataRateCheckerPlugin.
Implements autowarefoundation/autoware_ai#299 

## Todos
- [ ] Tests

## Steps to Test or Reproduce
Use the RViz plugins ImageViewerPlugin and DataRateCheckerPlugin. All text labels should no longer be able to be obscured and the Point Size property should be consistent.