### PR TITLE
fix can't detect objects with euclidean_cluster on 96boards in V1.8 #…

### DIFF
--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_euclidean_cluster_detect/nodes/lidar_euclidean_cluster_detect/lidar_euclidean_cluster_detect.cpp
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_euclidean_cluster_detect/nodes/lidar_euclidean_cluster_detect/lidar_euclidean_cluster_detect.cpp
@@ -667,7 +667,7 @@ void segmentByDistance(const pcl::PointCloud<pcl::PointXYZ>::Ptr in_cloud_ptr,
           clusterAndColor(cloud_ptr, out_cloud_ptr, in_out_boundingbox_array, in_out_centroids, _clustering_distance);
     }
 #else
-    std::vector<ClusterPtr> all_clusters =
+    all_clusters =
         clusterAndColor(cloud_ptr, out_cloud_ptr, in_out_boundingbox_array, in_out_centroids, _clustering_distance);
 #endif
   }


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
fix issue 1532
don't get clusters/objects on V1.8

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
 fix/euclidean_cluster_96boards | [1532](https://github.com/CPFL/Autoware/issues/1532)


## Todos
- [ ] Tests


## Steps to Test or Reproduce

1. play a bag
2. select eculidean_cluster detector
3. check with topic /bounding_boxes and rviz