### PR TITLE
#1497 Added cuda library paths to catkin_make_release

### DIFF
--- a/ros/catkin_make_release
+++ b/ros/catkin_make_release
@@ -9,8 +9,9 @@ if [[ -d devel ]]; then
     rm -rf devel
 fi
 
-catkin_make -DCMAKE_BUILD_TYPE=Release clean
+catkin_make -DCMAKE_BUILD_TYPE=Release clean -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 source devel/setup.bash
 
 export LIBRARY_PATH=/usr/lib/OpenNI2/Drivers:$LIBRARY_PATH
-catkin_make -DCMAKE_BUILD_TYPE=Release $@
+catkin_make -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs -DCMAKE_BUILD_TYPE=Release $@
+


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
The CUDA library location has been added to catkin_make_release which fixes the NO_FOUND issue when building Autoware in docker 1.8.0 at the first step of #1416 

## Related PRs
develop | #1416 

## Steps to Test or Reproduce
sudo sh build.sh kinetic

The build should complete without cmake error