### PR TITLE
[Fix] Remove importing darknet in Autoware Docker

### DIFF
--- a/docker/96boards/Dockerfile.kinetic
+++ b/docker/96boards/Dockerfile.kinetic
@@ -59,8 +59,6 @@ RUN sudo rosdep init \
         && rosdep update \
         && echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
 
-# YOLO_V2 -> Unable to install because CMakeLists.txt in vision_yolo2_detect depends on CUDA
-
 # Install Autoware
 RUN cd && git clone https://github.com/CPFL/Autoware.git /home/$USERNAME/Autoware
 RUN /bin/bash -c 'source /opt/ros/kinetic/setup.bash; cd /home/$USERNAME/Autoware/ros/src; git submodule update --init --recursive; catkin_init_workspace; cd ../; ./catkin_make_release -j2'

--- a/docker/generic/Dockerfile.indigo
+++ b/docker/generic/Dockerfile.indigo
@@ -91,11 +91,6 @@ RUN groupadd -f pgrimaging && \
 # Change user
 USER autoware
 
-# YOLO_V2
-RUN cd && git clone https://github.com/pjreddie/darknet.git
-RUN cd ~/darknet && git checkout 56d69e73aba37283ea7b9726b81afd2f79cd1134
-RUN cd ~/darknet/data && wget https://pjreddie.com/media/files/yolo.weights
-
 # Install Autoware
 RUN git clone https://github.com/CPFL/Autoware.git /home/$USERNAME/Autoware
 RUN /bin/bash -c 'source /opt/ros/indigo/setup.bash; cd /home/$USERNAME/Autoware/ros/src; git submodule update --init --recursive; catkin_init_workspace; cd ../; ./catkin_make_release'

--- a/docker/generic/Dockerfile.kinetic
+++ b/docker/generic/Dockerfile.kinetic
@@ -59,11 +59,6 @@ RUN sudo rosdep init \
         && rosdep update \
         && echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
 
-# YOLO_V2
-RUN cd && git clone https://github.com/pjreddie/darknet.git
-RUN cd ~/darknet && git checkout 56d69e73aba37283ea7b9726b81afd2f79cd1134
-RUN cd ~/darknet/data && wget https://pjreddie.com/media/files/yolo.weights
-
 # Install Autoware
 RUN cd && git clone https://github.com/CPFL/Autoware.git /home/$USERNAME/Autoware
 RUN /bin/bash -c 'source /opt/ros/kinetic/setup.bash; cd /home/$USERNAME/Autoware/ros/src; git submodule update --init --recursive; catkin_init_workspace; cd ../; ./catkin_make_release'


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Yolo2/3 implementations were integrated into yolo_darknet_detect.
yolo_darknet_detect is self contained and doesn't require pjreddie/darknet.
Importing darknet outside Autoware repository in Docker is no longer necessary.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/std_perception_msg | #1419

## Steps to Test or Reproduce

```
cd Autoware/docker/generic
./build.sh kinetic
```
