### PR TITLE
[Fix] Default path of coco.names

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -4599,7 +4599,7 @@ params :
       desc     : Names file. Label map
       label    : 'names file (names)'
       kind     : path
-      v        : $(rospack find vision_darknet_detect)/darknet/data/coco.names
+      v        : $(rospack find vision_darknet_detect)/darknet/cfg/coco.names
       cmd_param:
         dash     : ''
         delim    : ':='
@@ -4670,7 +4670,7 @@ params :
       desc     : Names file. Label map
       label    : 'names file (names)'
       kind     : path
-      v        : $(rospack find vision_darknet_detect)/darknet/data/coco.names
+      v        : $(rospack find vision_darknet_detect)/darknet/cfg/coco.names
     - name      : gpu_device_id
       desc      : gpu_device_id desc sample
       label     : gpu_device_id


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fix the default path of coco.names in feature/darknet_custom_names.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/darknet_custom_names | #1535
