### PR TITLE
Improve lidar_kf_track

### DIFF
--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/include/lidar_kf_track.h
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/include/lidar_kf_track.h
@@ -59,9 +59,12 @@ public:
 
   float CalculateDistance(const cv::Rect_<float> &in_rect) { return 0.0f; }
 
+  void Prediction() {
+    prediction_point_ = kf_.GetPrediction();
+  }
+
   void Update(const autoware_msgs::CloudCluster &in_cluster,
               bool in_data_correct, size_t in_max_trace_length) {
-    kf_.GetPrediction();
     prediction_point_ =
         kf_.Update(cv::Point2f(in_cluster.centroid_point.point.x,
                                in_cluster.centroid_point.point.y),
@@ -79,6 +82,8 @@ public:
   }
 
   autoware_msgs::CloudCluster GetCluster() { return cluster; }
+
+  cv::Point2f GetPredictedPosition() { return prediction_point_; }
 };
 
 // --------------------------------------------------------------------------

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/nodes/lidar_kf_track/kalman.cpp
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/nodes/lidar_kf_track/kalman.cpp
@@ -70,8 +70,7 @@ cv::Point2f TKalmanFilter::Update(cv::Point2f p, bool DataCorrect)
 	cv::Mat_<float> measurement(2, 1, CV_32FC(1));
 	if(!DataCorrect)
 	{
-		measurement.at<float>(0) = LastResult.x;  //update using prediction
-		measurement.at<float>(1) = LastResult.y;
+		return LastResult;
 	}
 	else
 	{


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
The lidar_kf_track node has wrong data association.
On the other hand, the Kalman Filter is also misused.

## Todos
- [x] Tests
      Already tested with our rosbag.
- [ ] Documentation

## Steps to Test or Reproduce
```
roslaunch lidar_kf_track lidar_kf_track.launch
```
When the self-driving vehicle stops, the IDs of the static objects around shouldn't change.
Before this pull request, the IDs change due to the wrong data association.