### PR TITLE
Fix/intrinsic calibration gui aa

### DIFF
--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/src/autoware_camera_calibration/camera_calibrator.py
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/src/autoware_camera_calibration/camera_calibrator.py
@@ -79,7 +79,6 @@ from std_msgs.msg import String
 from std_srvs.srv import Empty
 from os import path
 
-
 class DisplayThread(threading.Thread):
     """
     Thread that displays the current images
@@ -257,6 +256,16 @@ class CalibrationNode:
 
 class OpenCVCalibrationNode(CalibrationNode):
     """ Calibration node with an OpenCV Gui """
+    (cv2_version_major, _, _) = cv2.__version__.split(".")
+    if cv2_version_major == '2':
+        print "Version CV2"
+        TEXT_AA = cv2.CV_AA
+    elif cv2_version_major == '3':
+        print "Version CV3"
+        TEXT_AA = cv2.LINE_AA
+    else:
+        print "There's something wrong with your CV2 version, might cause trouble."
+        TEXT_AA = cv2.CV_AA
     FONT_FACE = cv2.FONT_HERSHEY_SIMPLEX
     FONT_SCALE = 0.4
     FONT_THICKNESS = 1
@@ -272,7 +281,8 @@ class OpenCVCalibrationNode(CalibrationNode):
 
     @classmethod
     def putText(cls, img, text, org, color = (0,0,0)):
-        cv2.putText(img, text, org, cls.FONT_FACE, cls.FONT_SCALE, color, thickness = cls.FONT_THICKNESS, lineType = cv2.CV_AA)
+        cv2.putText(img, text, org, cls.FONT_FACE, cls.FONT_SCALE, color, thickness = cls.FONT_THICKNESS,
+                    lineType = cls.TEXT_AA)
 
     @classmethod
     def getTextSize(cls, text):

--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/src/autoware_camera_calibration/camera_calibrator.py
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/src/autoware_camera_calibration/camera_calibrator.py
@@ -257,15 +257,9 @@ class CalibrationNode:
 class OpenCVCalibrationNode(CalibrationNode):
     """ Calibration node with an OpenCV Gui """
     (cv2_version_major, _, _) = cv2.__version__.split(".")
-    if cv2_version_major == '2':
-        print "Version CV2"
-        TEXT_AA = cv2.CV_AA
-    elif cv2_version_major == '3':
-        print "Version CV3"
-        TEXT_AA = cv2.LINE_AA
-    else:
-        print "There's something wrong with your CV2 version, might cause trouble."
-        TEXT_AA = cv2.CV_AA
+    if cv2_version_major == '2': TEXT_AA = cv2.CV_AA
+    elif cv2_version_major == '3': TEXT_AA = cv2.LINE_AA
+    else: TEXT_AA = 8
     FONT_FACE = cv2.FONT_HERSHEY_SIMPLEX
     FONT_SCALE = 0.4
     FONT_THICKNESS = 1


### PR DESCRIPTION
## Status
Tested on Indigo and Kinetic (CV2 and CV3)

## Description
Error running calibration UI on kinetic due to CV3 having different text anti-aliasing. Now version is checked and appropriate AA is applied.

## Steps to Test or Reproduce
Play a rosbag and run intrinsic calibration node with OpenCV 3.xx and there will be an AA related error.
```
rosrun autoware_camera_lidar_calibrator cameracalibrator.py --square 0.1 --size 8x5 image:=/image_raw
```
After this, version is checked and error is fixed.