### PR TITLE
[feature] Selectable topics in RTM

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -3276,7 +3276,8 @@ params :
     - name : pose_topic
       desc : position topic name in rosbag file
       label: Pose Topic
-      kind : str
+      kind      : topic
+      topic_type: geometry_msgs/PoseStamped
       v    : '/ndt_pose'
       cmd_param:
         dash     : ''
@@ -4290,7 +4291,8 @@ params :
     - name      : points_topic
       desc      : Subscribing topic for generating a cost map (PointCloud2 message)
       label     : Points Topic
-      kind      : str
+      kind      : topic
+      topic_type: sensor_msgs/PointCloud2
       v         : /points_lanes
       cmd_param :
         dash      : ''

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -1473,7 +1473,8 @@ params :
       desc      : IMU raw data source topic
       label     : imu_topic
       v         : /imu_raw
-      kind      : str
+      kind  : topic
+      topic_type : sensor_msgs/Imu
       cmd_param :
         dash      : ''
         delim     : ':='
@@ -1571,7 +1572,8 @@ params :
     - name      : topic_pose_stamped
       desc      : topic_pose_stamped desc sample
       label     : /current_pose (geometry_msgs/PoseStamped)
-      kind      : str
+      kind  : topic
+      topic_type : geometry_msgs/PoseStamped
       v         : /ndt_pose
       cmd_param :
         dash    : ''
@@ -2094,7 +2096,8 @@ params :
 
     - name : points_topic
       desc : points_topic
-      kind : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v    : /points_lanes
       cmd_param:
               dash : ''
@@ -3881,7 +3884,8 @@ params :
       desc      : IMU raw data source topic
       label     : imu_topic
       v         : /imu_raw
-      kind      : str
+      kind  : topic
+      topic_type : sensor_msgs/Imu
       cmd_param :
         dash      : ''
         delim     : ':='
@@ -3959,7 +3963,8 @@ params :
       desc      : IMU raw data source topic
       label     : imu_topic
       v         : /imu_raw
-      kind      : str
+      kind  : topic
+      topic_type : sensor_msgs/Imu
       cmd_param :
         dash      : ''
         delim     : ':='
@@ -4098,8 +4103,10 @@ params :
     - name      : image_src
       desc      : Image Topic to be fed to the network for detection
       label     : image_src
-      kind      : str
+      kind  : topic
+      topic_type : sensor_msgs/Image
       v         : /image_raw
+      flags : [ nl ]
       cmd_param :
         dash      : ''
         delim     : ':='
@@ -4428,23 +4435,26 @@ params :
     - name      : points_ground_src
       desc      : PointCloud topic containing only the ground
       label     : points_ground_src
-      kind      : str
-      v         : points_ground
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
+      v         : /points_ground
       cmd_param :
         dash      : ''
         delim     : ':='
     - name      : points_no_ground_src
       desc      : PointCloud source topic containing only the obstacle points
       label     : points_no_ground_src
-      kind      : str
-      v         : points_no_ground
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
+      v         : /points_no_ground
       cmd_param :
         dash      : ''
         delim     : ':='
     - name      : wayarea_topic_src
       desc      : Name of the topic containing the grid_map_msgs:GridMap containing the road areas.
       label     : wayarea_topic_src
-      kind      : str
+      kind  : topic
+      topic_type : grid_map_msgs/GridMap
       v         : grid_map_wayarea
       cmd_param :
         dash      : ''
@@ -4574,7 +4584,8 @@ params :
     - name      : image_src
       desc      : Image topic to be fed to the network for detection
       label     : image_src
-      kind      : str
+      kind  : topic
+      topic_type : sensor_msgs/Image
       v         : /image_raw
       cmd_param :
         dash      : ''
@@ -4645,7 +4656,8 @@ params :
     - name      : image_src
       desc      : Image topic to be fed to the network for detection
       label     : image_src
-      kind      : str
+      kind  : topic
+      topic_type : sensor_msgs/Image
       v         : /image_raw
       cmd_param :
         dash      : ''
@@ -4730,6 +4742,7 @@ params :
       label   : 'downsample_cloud'
       kind    : checkbox
       v       : False
+      flags : [ nl ]
       cmd_param :
         dash        : ''
         delim       : ':='
@@ -4737,8 +4750,9 @@ params :
     - name    : points_node
       desc    : points_node desc sample
       label   : 'input_points_node'
-      kind    : str
-      v       : points_raw
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
+      v       : /points_raw
       cmd_param :
         dash        : ''
         delim       : ':='
@@ -4816,7 +4830,8 @@ params :
     - name    : wayarea_gridmap_topic
       desc    : Topic name of the wayarea grid_map, this is published by wayarea2grid node in Computing/Semantics. default. grid_map_wayarea
       label   : 'wayarea_gridmap_topic'
-      kind    : str
+      kind  : topic
+      topic_type : grid_map_msgs/GridMap
       v       : grid_map_wayarea
       cmd_param :
         dash        : ''
@@ -4935,7 +4950,8 @@ params :
     - name    : input_topic
       desc    : input_topic desc sample
       label   : 'input_topic'
-      kind    : str
+      kind  : topic
+      topic_type : autoware_msgs/DetectedObjectArray
       v       : /detection/lidar_objects
       cmd_param :
         dash        : ''
@@ -4998,7 +5014,8 @@ params :
     - name    : real_objects_topic
       desc    : input objects
       label   : 'input objects'
-      kind    : str
+      kind  : topic
+      topic_type : autoware_msgs/DetectedObjectArray
       v       : /detected_objects
       cmd_param :
         dash  : ''
@@ -5006,7 +5023,8 @@ params :
     - name    : real_points_topic
       desc    : input points
       label   : 'input points'
-      kind    : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v       : /points_raw
       cmd_param :
         dash  : ''
@@ -5171,7 +5189,8 @@ params :
     - name  : points_src
       desc  : Point cloud source topic
       label : points_src
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash      : ''
@@ -5179,7 +5198,8 @@ params :
     - name  : image_src
       desc  : Image source topic
       label : image_src
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/Image
       v     : /image_raw
       cmd_param :
         dash      : ''
@@ -5187,7 +5207,8 @@ params :
     - name  : camera_info_src
       desc  : CameraInfo source topic
       label : camera_info_src
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/CameraInfo
       v     : /camera_info
       cmd_param :
         dash      : ''
@@ -5197,9 +5218,10 @@ params :
   - name  : range_vision_fusion_params
     vars  :
     - name  : detected_objects_range
-      desc  : Point cloud source topic
+      desc  : Point cloud detected objects
       label : detected_objects_range
-      kind  : str
+      kind  : topic
+      topic_type : autoware_msgs/DetectedObjectArray
       v     : /detection/lidar_objects
       cmd_param :
         dash      : ''
@@ -5207,7 +5229,8 @@ params :
     - name  : detected_objects_vision
       desc  : Image source topic
       label : detected_objects_vision
-      kind  : str
+      kind  : topic
+      topic_type : autoware_msgs/DetectedObjectArray
       v     : /detection/vision_objects
       cmd_param :
         dash      : ''
@@ -5215,7 +5238,8 @@ params :
     - name  : camera_info_src
       desc  : CameraInfo source topic
       label : camera_info_src
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/CameraInfo
       v     : /camera_info
       cmd_param :
         dash      : ''
@@ -5234,7 +5258,8 @@ params :
     - name  : camera_info_src
       desc  : CameraInfo source topic
       label : camera_info_src
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/CameraInfo
       v     : /camera_info
       cmd_param :
         dash      : ''
@@ -5242,7 +5267,8 @@ params :
     - name  : objects_topic_src
       desc  : Detected Objects Topic Source
       label : objects_topic_src
-      kind  : str
+      kind  : topic
+      topic_type : autoware_msgs/DetectedObjectArray
       v     : /detection/vision_objects
       cmd_param :
         dash      : ''

--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -2358,6 +2358,14 @@ class VarPanel(wx.Panel):
 		if self.kind == 'hide':
 			self.Hide()
 			return
+		if self.kind == 'topic':
+			topic_type = self.var.get('topic_type')
+			topics = self._get_topics_by_type(topic_type)
+			self.obj = wx.ComboBox(self, id=wx.ID_ANY, value=v, choices=topics, style=wx.CB_DROPDOWN)
+			self.lb = wx.StaticText(self, wx.ID_ANY, label)
+			flag = wx.LEFT | wx.ALIGN_CENTER_VERTICAL
+			sizer_wrap((self.lb, self.obj), wx.HORIZONTAL, 0, flag, 4, self)
+			return
 
 		szr = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -2410,6 +2418,14 @@ class VarPanel(wx.Panel):
 
 		self.SetSizer(szr)
 
+	def _get_topics_by_type(self, message_type):
+		#get list of current available topics:
+		ros_topics = rospy.get_published_topics()
+		matched_topics = list(filter(lambda x: x[1]==message_type,ros_topics))
+		topic_names = [x[0] for x in matched_topics]
+		topic_names.sort()
+		return topic_names
+
 	def setup_tooltip(self):
 		if get_tooltips(self.var):
 			set_tooltips(self.obj, self.var)
@@ -2428,7 +2444,7 @@ class VarPanel(wx.Panel):
 	def get_v(self):
 		if self.kind in [ 'radio_box', 'menu' ]:
 			return self.choices_sel_get()
-		if self.kind in [ 'checkbox', 'toggle_button' ]:
+		if self.kind in [ 'checkbox', 'toggle_button', 'topic' ]:
 			return self.obj.GetValue()
 		if self.kind == 'checkboxes':
 			return self.obj.get()

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -622,7 +622,8 @@ params :
     - name  : points_topic
       desc  : input point topic to downsample
       label : Points topic
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -654,7 +655,8 @@ params :
     - name  : points_topic
       desc  : input point topic to downsample
       label : Points topic
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -692,7 +694,8 @@ params :
     - name  : points_topic
       desc  : input point topic to downsample
       label : Points topic
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -724,7 +727,8 @@ params :
     - name  : points_topic
       desc  : input point topic to downsample
       label : Points topic
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -756,7 +760,8 @@ params :
     - name  : point_topic
       desc  : Input PointCloud Topic name, ground filtering will be performed.
       label : 'input_point_topic'
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -1016,7 +1021,8 @@ params :
     - name  : input_point_topic
       desc  : Input PointCloud Topic name, ground filtering will be performed.
       label : 'input_point_topic'
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -1135,7 +1141,8 @@ params :
     - name  : input_point_topic
       desc  : Input PointCloud Topic name, i.e. /points_raw
       label : input_point_topic
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -1164,7 +1171,8 @@ params :
     - name  : input_point_topic
       desc  : Input PointCloud Topic name, i.e. /points_raw
       label : input_point_topic
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : /points_raw
       cmd_param :
         dash        : ''
@@ -1324,7 +1332,8 @@ params :
     - name  : points_parent_src
       desc  : PointCloud Topic of the parent
       label : points_parent_src
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : lidar0/points_raw
       cmd_param :
         dash        : ''
@@ -1332,7 +1341,8 @@ params :
     - name  : points_child_src
       desc  : Serial Port of the LiDAR
       label : points_child_src
-      kind  : str
+      kind  : topic
+      topic_type : sensor_msgs/PointCloud2
       v     : lidar1/points_raw
       cmd_param :
         dash        : ''


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
autowarefoundation/autoware_ai#348 

## Steps to Test or Reproduce
Open the app button on any of the configurable topics in the sensing or computing tabs nodes.
Instead of a regular textbox, there will be an combo selection box with the currently available topics of the corresponding message type.