### PR TITLE
[fix] Removed python yaml dependency that was causing issues.

### DIFF
--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/README.md
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/README.md
@@ -24,13 +24,13 @@ This file will contain the intrinsic calibration to rectify the image.
 
 ### Parameters available
 
-Parameter| Type| Description|
-----------|-----|--------
-|`SQUARE_SIZE`|*double* |Defines the size of the checkerboard square in meters.|
-|`MxN`|*string* |Defines the layout size of the checkerboard (inner size).|
-|`image`|*string* |Topic name of the camera image source topic in `raw` format (color or b&w).|
-|`min_samples`|*integer* |Defines the minimum number of samples required to allow calibration.|
-
+Flag| Parameter| Type| Description|
+-----|----------|-----|--------
+--square|`SQUARE_SIZE`|*double* |Defines the size of the checkerboard square in meters.|
+--size|`MxN`|*string* |Defines the layout size of the checkerboard (inner size).|
+image:=|`image`|*string* |Topic name of the camera image source topic in `raw` format (color or b&w).|
+--min_samples|`min_samples`|*integer* |Defines the minimum number of samples required to allow calibration.|
+--detection|`engine`|*string*|Chessboard detection engine, default `cv2` or `matlab` |
 For extra details please visit: http://www.ros.org/wiki/camera_calibration
 
 #### Matlab checkerboard detection engine (beta)


### PR DESCRIPTION
## Description
This fix removes python yaml dependency in the intrinsic calibration node, yaml seemed to have come compatibility issues across platforms. Instead opencv FileStorage and python I/O, which seems consistent throughout versions.

Tested on two platforms:
- Ubuntu: 16.04
- ROS: Kinetic
- Python: 2.7.13
- OpenCV: 3.3.1-dev

and:
- Ubuntu 14.04
- ROS: Indigo
- Python: 2.7.6 
- OpenCV: 2.4.8

## Related PRs
See autowarefoundation/autoware_ai#362 for bug description