### PR TITLE
Updated generic/Dockerfile* to copy from local version of repo instea…

### DIFF
--- a/docker/generic/Dockerfile.indigo
+++ b/docker/generic/Dockerfile.indigo
@@ -97,7 +97,8 @@ RUN cd ~/darknet && git checkout 56d69e73aba37283ea7b9726b81afd2f79cd1134
 RUN cd ~/darknet/data && wget https://pjreddie.com/media/files/yolo.weights
 
 # Install Autoware
-RUN git clone https://github.com/CPFL/Autoware.git /home/$USERNAME/Autoware
+RUN cd && mkdir /home/$USERNAME/Autoware
+COPY --chown=autoware ./ /home/$USERNAME/Autoware/
 RUN /bin/bash -c 'source /opt/ros/indigo/setup.bash; cd /home/$USERNAME/Autoware/ros/src; git submodule update --init --recursive; catkin_init_workspace; cd ../; ./catkin_make_release'
 RUN echo "source /home/$USERNAME/Autoware/ros/devel/setup.bash" >> /home/$USERNAME/.bashrc
 

--- a/docker/generic/Dockerfile.kinetic
+++ b/docker/generic/Dockerfile.kinetic
@@ -65,7 +65,8 @@ RUN cd ~/darknet && git checkout 56d69e73aba37283ea7b9726b81afd2f79cd1134
 RUN cd ~/darknet/data && wget https://pjreddie.com/media/files/yolo.weights
 
 # Install Autoware
-RUN cd && git clone https://github.com/CPFL/Autoware.git /home/$USERNAME/Autoware
+RUN cd && mkdir /home/$USERNAME/Autoware
+COPY --chown=autoware ./ /home/$USERNAME/Autoware/
 RUN /bin/bash -c 'source /opt/ros/kinetic/setup.bash; cd /home/$USERNAME/Autoware/ros/src; git submodule update --init --recursive; catkin_init_workspace; cd ../; ./catkin_make_release'
 RUN echo "source /home/$USERNAME/Autoware/ros/devel/setup.bash" >> /home/$USERNAME/.bashrc
 

--- a/docker/generic/build.sh
+++ b/docker/generic/build.sh
@@ -4,7 +4,7 @@
 if [ "$1" = "kinetic" ] || [ "$1" = "indigo" ]
 then
     echo "Use $1"
-    nvidia-docker build -t autoware-$1 -f Dockerfile.$1 . --no-cache
+    nvidia-docker build -t autoware-$1 -f Dockerfile.$1 ./../.. --no-cache
 else
     echo "Select distribution, kinetic|indigo"
 fi


### PR DESCRIPTION
…d of git cloning

## Status
**PRODUCTION / DEVELOPMENT**

## Description
The Dockerfiles in docker/generic have been updated to copy the local repo instead of downloading a clone from the master branch on Github. This will also avoid the need to do modifications to the Dockerfiles when developing on other branches as local changes will be used for the image build.

## Steps to Test or Reproduce
`sudo sh build.sh indigo` or `sudo sh build.sh kinetic` as required