### PR TITLE
Added missing function declaration to amathutils_lib.hpp

### DIFF
--- a/ros/src/common/libs/amathutils_lib/include/amathutils_lib/amathutils.hpp
+++ b/ros/src/common/libs/amathutils_lib/include/amathutils_lib/amathutils.hpp
@@ -27,6 +27,7 @@ public:
   }
 };
 double find_distance(point *_a, point *_b);
+double find_distance(point &_a, point &_b);
 double find_angle(point *_a, point *_b);
 
 inline double mps2kmph(double _mpsval)


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
amathutils_lib.hpp is missing the declaration of `double find_distance(point &_a, point &_b)`.
