### PR TITLE
[Feature] ymc uses vehicle_cmd

### DIFF
--- a/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
@@ -4,43 +4,44 @@ project(ymc)
 set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(
-        catkin REQUIRED COMPONENTS
-        autoware_build_flags
-        roscpp
-        geometry_msgs
-        rosconsole
+  catkin REQUIRED COMPONENTS
+  autoware_build_flags
+  roscpp
+  geometry_msgs
+  rosconsole
+  autoware_msgs
 )
 
 catkin_package(
-        CATKIN_DEPENDS
-        roscpp
-        geometry_msgs
-        rosconsole
+  CATKIN_DEPENDS
+  roscpp
+  geometry_msgs
+  rosconsole
+  autoware_msgs
 )
 
-
 IF ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
-    set(LIB_ARCH _aarch64)
+  set(LIB_ARCH _aarch64)
 ELSE ()
-    unset(LIB_ARCH)
+  unset(LIB_ARCH)
 ENDIF ()
 
 include_directories(
-        ${catkin_INCLUDE_DIRS}
-        include
+  ${catkin_INCLUDE_DIRS}
+  include
 )
 
 IF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.1)
-    set(LIB_VERSION 2.0) # _GLIBCXX_USE_CXX11_ABI is 1
+  set(LIB_VERSION 2.0) # _GLIBCXX_USE_CXX11_ABI is 1
 ELSE ()
-    set(LIB_VERSION 1.0) # _GLIBCXX_USE_CXX11_ABI is 0
+  set(LIB_VERSION 1.0) # _GLIBCXX_USE_CXX11_ABI is 0
 ENDIF ()
 
 add_executable(g30esli_interface
-        node/g30esli_interface/g30esli_interface.cpp
-        )
+  node/g30esli_interface/g30esli_interface.cpp
+)
 
 target_link_libraries(g30esli_interface
-        ${catkin_LIBRARIES}
-        ${CMAKE_CURRENT_SOURCE_DIR}/lib/libymc_can_${LIB_VERSION}${LIB_ARCH}.a
-        )
+  ${catkin_LIBRARIES}
+  ${CMAKE_CURRENT_SOURCE_DIR}/lib/libymc_can_${LIB_VERSION}${LIB_ARCH}.a
+)

--- a/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
@@ -41,6 +41,10 @@ add_executable(g30esli_interface
   node/g30esli_interface/g30esli_interface.cpp
 )
 
+add_dependencies(g30esli_interface
+  ${catkin_EXPORTED_TARGETS}
+)
+
 target_link_libraries(g30esli_interface
   ${catkin_LIBRARIES}
   ${CMAKE_CURRENT_SOURCE_DIR}/lib/libymc_can_${LIB_VERSION}${LIB_ARCH}.a

--- a/ros/src/actuation/vehicles/packages/ymc/launch/g30esli_interface.launch
+++ b/ros/src/actuation/vehicles/packages/ymc/launch/g30esli_interface.launch
@@ -4,6 +4,7 @@
   <arg name="device" default="can0"/>
   <arg name="loop_rate" default="100"/>
   <arg name="stop_time_sec" default="2"/>
+  <arg name="steering_offset_deg" default="0.0"/>
 
   <!-- Execute Autoware communicator -->
   <node pkg="ymc" name="g30esli_interface" type="g30esli_interface" output="log">
@@ -12,6 +13,7 @@
     <param name="device" value="$(arg device)"/>
     <param name="loop_rate" value="$(arg loop_rate)"/>
     <param name="stop_time_sec" value="$(arg stop_time_sec)"/>
+    <param name="steering_offset_deg" value="$(arg steering_offset_deg)"/>
   </node>
 
 </launch>

--- a/ros/src/actuation/vehicles/packages/ymc/node/g30esli_interface/g30esli_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/ymc/node/g30esli_interface/g30esli_interface.cpp
@@ -57,6 +57,7 @@ uint16_t g_target_velocity_ui16;
 int16_t g_steering_angle_deg_i16;
 double g_current_vel_kmph = 0.0;
 bool g_terminate_thread = false;
+double g_steering_offset_deg = 0.0;
 
 // cansend tool
 mycansend::CanSender g_cansender;
@@ -67,6 +68,7 @@ void vehicle_cmd_callback(const autoware_msgs::VehicleCmdConstPtr& msg)
   double target_velocity = msg->twist_cmd.twist.linear.x * 3.6;  // [m/s] -> [km/h]
   double target_steering_angle_deg = ymc::computeTargetSteeringAngleDegree(msg->twist_cmd.twist.angular.z,
                                                                            msg->twist_cmd.twist.linear.x, g_wheel_base);
+  target_steering_angle_deg += g_steering_offset_deg;
 
   // factor
   target_velocity *= 10.0;
@@ -152,6 +154,7 @@ int main(int argc, char* argv[])
   private_nh.param<std::string>("device", g_device, "can0");
   private_nh.param<int>("loop_rate", g_loop_rate, 100);
   private_nh.param<int>("stop_time_sec", g_stop_time_sec, 1);
+  private_nh.param<double>("steering_offset_deg", g_steering_offset_deg, 0.0);
 
   // init cansend tool
   g_cansender.init(g_device);

--- a/ros/src/actuation/vehicles/packages/ymc/node/g30esli_interface/g30esli_interface_util.h
+++ b/ros/src/actuation/vehicles/packages/ymc/node/g30esli_interface/g30esli_interface_util.h
@@ -43,14 +43,13 @@
 
 namespace ymc
 {
-
 void reverse_byteorder_memcpy(unsigned char* target, int16_t* source, size_t size)
 {
-    for (unsigned int i = 0; i < size; i++)
-    {
-      unsigned char *address = (unsigned char*)source + (i * sizeof(unsigned char));
-      std::memcpy(&target[size - i - 1], address, sizeof(unsigned char));
-    }
+  for (unsigned int i = 0; i < size; i++)
+  {
+    unsigned char* address = (unsigned char*)source + (i * sizeof(unsigned char));
+    std::memcpy(&target[size - i - 1], address, sizeof(unsigned char));
+  }
 }
 
 // split string with whitespace
@@ -66,7 +65,8 @@ std::vector<std::string> splitString(const std::string& s)
   }
 
   // remove empty elements
-  result.erase(std::remove_if(result.begin(), result.end(), [](const std::string& s) { return s.empty(); }), result.end());
+  result.erase(std::remove_if(result.begin(), result.end(), [](const std::string& s) { return s.empty(); }),
+               result.end());
 
   return result;
 }
@@ -74,29 +74,29 @@ std::vector<std::string> splitString(const std::string& s)
 // detect hit of keyboard
 int kbhit()
 {
-    struct termios oldt, newt;
-    int ch;
-    int oldf;
+  struct termios oldt, newt;
+  int ch;
+  int oldf;
 
-    tcgetattr(STDIN_FILENO, &oldt);
-    newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
-    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-    oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
-    fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
+  tcgetattr(STDIN_FILENO, &oldt);
+  newt = oldt;
+  newt.c_lflag &= ~(ICANON | ECHO);
+  tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+  oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
+  fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
 
-    ch = getchar();
+  ch = getchar();
 
-    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    fcntl(STDIN_FILENO, F_SETFL, oldf);
+  tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+  fcntl(STDIN_FILENO, F_SETFL, oldf);
 
-    if (ch != EOF)
-    {
-        ungetc(ch, stdin);
-        return 1;
-    }
+  if (ch != EOF)
+  {
+    ungetc(ch, stdin);
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
 double computeTargetSteeringAngleDegree(double angular_z, double velocity_mps, double wheel_base)
@@ -106,21 +106,21 @@ double computeTargetSteeringAngleDegree(double angular_z, double velocity_mps, d
 
   if (velocity_mps == 0)
   {
-    //steering_angle_rad = 0;
+    // steering_angle_rad = 0;
     steering_angle_rad = prev_steering_angle_rad;
   }
   else
   {
-    steering_angle_rad = std::asin(wheel_base * angular_z / velocity_mps); // radian
+    steering_angle_rad = std::asin(wheel_base * angular_z / velocity_mps);  // radian
   }
 
   prev_steering_angle_rad = steering_angle_rad;
-  
+
   double steering_angle_degree = steering_angle_rad / M_PI * 180.0;
 
   return steering_angle_degree;
 }
 
-} // namespace ymc
+}  // namespace ymc
 
 #endif

--- a/ros/src/actuation/vehicles/packages/ymc/package.xml
+++ b/ros/src/actuation/vehicles/packages/ymc/package.xml
@@ -11,10 +11,12 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>autoware_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>autoware_msgs</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
## Status
** DEVELOPMENT**

## Description
Modify `ymc` actuation package to use `vehicle_cmd` instead of `twist_cmd` for woriking with `twist_gate` function.

## Todos
- [x] Tests

## Steps to Test or Reproduce
1. Connect to your ymc vehicle
1. `$ roscd ymc`
1. `$ ./g30esli_interface.sh`
1. Your car should move.