### PR TITLE
Feature/add code coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,9 +43,9 @@ build_kinetic:
     - git clone https://github.com/linux-test-project/lcov.git
     - cd lcov
     - git checkout v1.12
-    - sudo make install 
+    - make install 
     - cd ..
-    - sudo rm -r lcov
+    - rm -r lcov
     - catkin_make clean
     #- catkin_make -j2
     - catkin_make -j2 --cmake-args -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_BUILD_TYPE=Debug

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,6 @@ build_kinetic:
     - git clone https://github.com/linux-test-project/lcov.git
     - cd lcov
     - git checkout v1.12
-    - cd lcov
     - sudo make install 
     - cd ..
     - sudo rm -r lcov

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ build_kinetic:
   # Install lcov from source as binary installation errors when appending files
     - git clone https://github.com/linux-test-project/lcov.git
     - cd lcov
-    - git checkout v1.12
+    - git checkout v1.13
     - make install 
     - cd ..
     - rm -r lcov

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,6 @@ build_kinetic:
     - cd ..
     - rm -r lcov
     - catkin_make clean
-    #- catkin_make -j2
     - catkin_make -j2 --cmake-args -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_BUILD_TYPE=Debug
     - lcov --initial --directory build --capture --output-file lcov.base
     - catkin_make run_tests
@@ -74,19 +73,9 @@ build_indigo:
   <<: *build_common
   script:
     - catkin_make clean
-    #- catkin_make -j2
     - catkin_make -j2 --cmake-args -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_BUILD_TYPE=Debug
-    #- lcov --initial --directory build --capture --output-file lcov.base
     - catkin_make run_tests
     - catkin_test_results
-    #- lcov --directory build --capture --output-file lcov.test
-    #- lcov -a lcov.base -a lcov.test -o lcov.total
-    #- lcov -r lcov.total 'tests/*' 'test/*' 'build/*' 'devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
-    #- genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o coverage
-    #- tar -czvf coverage.tar.gz coverage
-    #- mv coverage.tar.gz $CI_PROJECT_DIR/coverage.tar.gz
-    #- ls $CI_PROJECT_DIR 
-  
     
 build_cross:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ build_kinetic:
     - catkin_test_results
     - lcov --directory build --capture --output-file lcov.test
     - lcov -a lcov.base -a lcov.test -o lcov.total
-    - lcov -r lcov.total 'tests/*' 'test/*' 'build/*' 'devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
+    - lcov -r lcov.total '*/tests/*' '*/test/*' '*/build/*' '*/devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
     - genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o coverage
     - tar -czvf coverage.tar.gz coverage
     - mv coverage.tar.gz $CI_PROJECT_DIR/coverage.tar.gz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 stages:
   - build
-  - test
+  - deploy
   
 variables:
   ROS_CI_DESKTOP: "`lsb_release -cs`"
@@ -30,11 +30,7 @@ variables:
     - wstool up
     - cd ..
     - rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} 
-  script:
-    - catkin_make clean
-    - catkin_make -j2
-    - catkin_make run_tests
-    - catkin_test_results
+    
 
 build_kinetic:
   stage: build
@@ -42,6 +38,34 @@ build_kinetic:
   variables:
     ROS_DISTRO: kinetic
   <<: *build_common
+  script:
+  # Install lcov from source as binary installation errors when appending files
+    - git clone https://github.com/linux-test-project/lcov.git
+    - cd lcov
+    - git checkout v1.12
+    - cd lcov
+    - sudo make install 
+    - cd ..
+    - sudo rm -r lcov
+    - catkin_make clean
+    #- catkin_make -j2
+    - catkin_make -j2 --cmake-args -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_BUILD_TYPE=Debug
+    - lcov --initial --directory build --capture --output-file lcov.base
+    - catkin_make run_tests
+    - catkin_test_results
+    - lcov --directory build --capture --output-file lcov.test
+    - lcov -a lcov.base -a lcov.test -o lcov.total
+    - lcov -r lcov.total 'tests/*' 'test/*' 'build/*' 'devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
+    - genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o coverage
+    - tar -czvf coverage.tar.gz coverage
+    - mv coverage.tar.gz $CI_PROJECT_DIR/coverage.tar.gz
+    - ls $CI_PROJECT_DIR 
+  artifacts:
+    paths:
+      - $CI_PROJECT_DIR/coverage.tar.gz
+  coverage: /\s*lines.*:\s(\d+\.\d+\%\s\(\d+\sof\s\d+.*\))/
+    
+  
     
 build_indigo:
   stage: build
@@ -49,6 +73,21 @@ build_indigo:
   variables:
     ROS_DISTRO: indigo
   <<: *build_common
+  script:
+    - catkin_make clean
+    #- catkin_make -j2
+    - catkin_make -j2 --cmake-args -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage" -DCMAKE_BUILD_TYPE=Debug
+    #- lcov --initial --directory build --capture --output-file lcov.base
+    - catkin_make run_tests
+    - catkin_test_results
+    #- lcov --directory build --capture --output-file lcov.test
+    #- lcov -a lcov.base -a lcov.test -o lcov.total
+    #- lcov -r lcov.total 'tests/*' 'test/*' 'build/*' 'devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
+    #- genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o coverage
+    #- tar -czvf coverage.tar.gz coverage
+    #- mv coverage.tar.gz $CI_PROJECT_DIR/coverage.tar.gz
+    #- ls $CI_PROJECT_DIR 
+  
     
 build_cross:
   stage: build
@@ -87,6 +126,15 @@ build_cross:
                   --build ${AUTOWARE_BUILD_PATH}
                   -j2"
                   '
-
-
+pages:
+  stage: deploy
+  image: alpine
+  dependencies:
+    - build_kinetic
+  script:
+    - tar -xzvf coverage.tar.gz
+    - mv coverage public
+  artifacts:
+    paths:
+      - public
 


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
Code coverage report generation has been added using lcov.
- `apt-get install` of lcov leads to errors when combining tracefiles, hence source installation of v1.13 has been chosen

## Steps to Test or Reproduce
Code coverage report will be generated on the gitlab CI infrastructure as per https://servandogs.gitlab.io/Autoware/