### PR TITLE
[hotfix] include <random> in lidar_naive_l_shape_detect

### DIFF
--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/include/lidar_naive_l_shape_detect.h
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/include/lidar_naive_l_shape_detect.h
@@ -31,6 +31,8 @@
 #ifndef OBJECT_TRACKING_BOX_FITTING_H
 #define OBJECT_TRACKING_BOX_FITTING_H
 
+#include <random>
+
 #include <ros/ros.h>
 
 #include <opencv2/opencv.hpp>

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/include/lidar_naive_l_shape_detect.h
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/include/lidar_naive_l_shape_detect.h
@@ -31,8 +31,6 @@
 #ifndef OBJECT_TRACKING_BOX_FITTING_H
 #define OBJECT_TRACKING_BOX_FITTING_H
 
-#include <random>
-
 #include <ros/ros.h>
 
 #include <opencv2/opencv.hpp>

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/nodes/lidar_naive_l_shape_detect/lidar_naive_l_shape_detect.cpp
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/nodes/lidar_naive_l_shape_detect/lidar_naive_l_shape_detect.cpp
@@ -28,6 +28,9 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#include <random>
+
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf/transform_datatypes.h>
 


### PR DESCRIPTION
## Status
**PRODUCTIONT**

## Description
Compie error because not inclusing `#include <random>` autowarefoundation/autoware_ai#397 
This PR adds `include <random>` in lidar_naive_l_shape_detect/include/lidar_naive_l_shape_detect.h