### PR TITLE
Replace module_comm_msgs with automotive_platform_msgs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "ros/src/msgs/platform_automation_msgs"]
-	path = ros/src/msgs/platform_automation_msgs
-	url = https://github.com/astuff/platform_automation_msgs.git
-	branch = 51ceed71c28773887648993ceec803ca498698ae
 [submodule "ros/src/sensing/drivers/lidar/packages/robosense"]
 	path = ros/src/sensing/drivers/lidar/packages/robosense
 	url = https://github.com/CPFL/robosense

--- a/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(
         roscpp
         std_msgs
         geometry_msgs
-        module_comm_msgs
+        automotive_platform_msgs
         dbw_mkz_msgs
 )
 
@@ -16,35 +16,29 @@ catkin_package(
         roscpp
         std_msgs
         geometry_msgs
-        module_comm_msgs
+        automotive_platform_msgs
         dbw_mkz_msgs
 )
 
-# If submodule is not cloned this project will not be build.
-set(AS_MSG_PATH "${CMAKE_SOURCE_DIR}/msgs/platform_automation_msgs/module_comm_msgs")
-if (EXISTS "${AS_MSG_PATH}")
+SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
-    SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
+include_directories(
+        ${catkin_INCLUDE_DIRS}
+)
 
-    include_directories(
-            ${catkin_INCLUDE_DIRS}
-    )
+add_executable(pacmod_interface
+        nodes/pacmod_interface/pacmod_interface_node.cpp
+        nodes/pacmod_interface/pacmod_interface.cpp
+        )
+target_link_libraries(pacmod_interface ${catkin_LIBRARIES})
+add_dependencies(pacmod_interface ${catkin_EXPORTED_TARGETS})
 
-    add_executable(pacmod_interface
-            nodes/pacmod_interface/pacmod_interface_node.cpp
-            nodes/pacmod_interface/pacmod_interface.cpp
-            )
-    target_link_libraries(pacmod_interface ${catkin_LIBRARIES})
-    add_dependencies(pacmod_interface ${catkin_EXPORTED_TARGETS})
+install(TARGETS pacmod_interface
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        )
 
-    install(TARGETS pacmod_interface
-            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-            )
-
-    install(DIRECTORY launch/
-            DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-            PATTERN ".svn" EXCLUDE)
-
-endif ()
+install(DIRECTORY launch/
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+        PATTERN ".svn" EXCLUDE)

--- a/ros/src/actuation/vehicles/packages/as/nodes/pacmod_interface/pacmod_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/pacmod_interface/pacmod_interface.cpp
@@ -58,8 +58,8 @@ void PacmodInterface::initForROS()
   speed_sub_        = nh_.subscribe("/vehicle/steering_report", 10, &PacmodInterface::callbackFromSteeringReport, this);
 
   // setup publisher
-  steer_mode_pub_    = nh_.advertise<module_comm_msgs::SteerMode>("/as/arbitrated_steering_commands", 10);
-  speed_mode_pub_    = nh_.advertise<module_comm_msgs::SpeedMode>("/as/arbitrated_speed_commands", 10);
+  steer_mode_pub_    = nh_.advertise<automotive_platform_msgs::SteerMode>("/as/arbitrated_steering_commands", 10);
+  speed_mode_pub_    = nh_.advertise<automotive_platform_msgs::SpeedMode>("/as/arbitrated_speed_commands", 10);
   current_twist_pub_ = nh_.advertise<geometry_msgs::TwistStamped>("as_current_twist", 10);
 }
 
@@ -81,14 +81,14 @@ void PacmodInterface::callbackFromTwistCmd(const geometry_msgs::TwistStampedCons
     mode = 0;
   }
 
-  module_comm_msgs::SpeedMode speed_mode;
+  automotive_platform_msgs::SpeedMode speed_mode;
   speed_mode.header = msg->header;
   speed_mode.mode = mode;
   speed_mode.speed = msg->twist.linear.x;
   speed_mode.acceleration_limit = 3.0;
   speed_mode.deceleration_limit = 3.0;
 
-  module_comm_msgs::SteerMode steer_mode;
+  automotive_platform_msgs::SteerMode steer_mode;
   steer_mode.header = msg->header;
   steer_mode.mode = mode;
   double curvature = msg->twist.angular.z / msg->twist.linear.x;

--- a/ros/src/actuation/vehicles/packages/as/nodes/pacmod_interface/pacmod_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/pacmod_interface/pacmod_interface.h
@@ -35,8 +35,8 @@
 #include <ros/ros.h>
 #include <std_msgs/Bool.h>
 #include <geometry_msgs/TwistStamped.h>
-#include <module_comm_msgs/SteerMode.h>
-#include <module_comm_msgs/SpeedMode.h>
+#include <automotive_platform_msgs/SteerMode.h>
+#include <automotive_platform_msgs/SpeedMode.h>
 #include <dbw_mkz_msgs/SteeringReport.h>
 
 namespace pacmod

--- a/ros/src/actuation/vehicles/packages/as/package.xml
+++ b/ros/src/actuation/vehicles/packages/as/package.xml
@@ -11,13 +11,13 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>module_comm_msgs</build_depend>
+  <build_depend>automotive_platform_msgs</build_depend>
   <build_depend>dbw_mkz_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>module_comm_msgs</run_depend>
+  <run_depend>automotive_platform_msgs</run_depend>
   <run_depend>dbw_mkz_msgs</run_depend>
 
   <export>


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Given that upstream (https://github.com/astuff/automotive_autonomy_msgs) has released the message packages as ROS packages, we can just remove their submodules.

This pull request updates the packages that depend on `module_comm_msgs` to `automotive_platform_msgs`