### PR TITLE
Fix/intrinsic calibration opencv check

### DIFF
--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/README.md
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/README.md
@@ -24,13 +24,13 @@ This file will contain the intrinsic calibration to rectify the image.
 
 ### Parameters available
 
-Parameter| Type| Description|
-----------|-----|--------
-|`SQUARE_SIZE`|*double* |Defines the size of the checkerboard square in meters.|
-|`MxN`|*string* |Defines the layout size of the checkerboard (inner size).|
-|`image`|*string* |Topic name of the camera image source topic in `raw` format (color or b&w).|
-|`min_samples`|*integer* |Defines the minimum number of samples required to allow calibration.|
-
+Flag| Parameter| Type| Description|
+-----|----------|-----|--------
+--square|`SQUARE_SIZE`|*double* |Defines the size of the checkerboard square in meters.|
+--size|`MxN`|*string* |Defines the layout size of the checkerboard (inner size).|
+image:=|`image`|*string* |Topic name of the camera image source topic in `raw` format (color or b&w).|
+--min_samples|`min_samples`|*integer* |Defines the minimum number of samples required to allow calibration.|
+--detection|`engine`|*string*|Chessboard detection engine, default `cv2` or `matlab` |
 For extra details please visit: http://www.ros.org/wiki/camera_calibration
 
 #### Matlab checkerboard detection engine (beta)

--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/src/autoware_camera_calibration/camera_calibrator.py
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/src/autoware_camera_calibration/camera_calibrator.py
@@ -256,7 +256,7 @@ class CalibrationNode:
 
 class OpenCVCalibrationNode(CalibrationNode):
     """ Calibration node with an OpenCV Gui """
-    (cv2_version_major, _, _) = cv2.__version__.split(".")
+    cv2_version_major = cv2.__version__.split(".")[0]
     if cv2_version_major == '2': TEXT_AA = cv2.CV_AA
     elif cv2_version_major == '3': TEXT_AA = cv2.LINE_AA
     else: TEXT_AA = 8


### PR DESCRIPTION
## Status
Simple bug fix.

## Description
Fix to autowarefoundation/autoware_ai#405, we can extract the major version of OpenCV without relying on the number of version values.

## Related PRs
Fixing bug autowarefoundation/autoware_ai#362 caused this issue.
