### PR TITLE
Feature/ouster

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "ros/src/sensing/drivers/lidar/packages/robosense"]
 	path = ros/src/sensing/drivers/lidar/packages/robosense
 	url = https://github.com/CPFL/robosense
+[submodule "ros/src/sensing/drivers/lidar/packages/ouster"]
+	path = ros/src/sensing/drivers/lidar/packages/ouster
+	url = https://github.com/CPFL/ouster
+	branch = autoware_branch

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -225,6 +225,26 @@ subs :
         desc : Launches the driver for the selected RoboSense LiDAR sensor and publishes the pointcloud in rslidar_points.
         run  : roslaunch rslidar_pointcloud cloud_nodelet_16.launch
 
+      - name : Ouster OS1
+        desc : Launches the driver for the Ouster OS1 LiDAR and publishes the pointcloud as points_raw.
+        run  : roslaunch ouster_ros os1.launch
+        param: ouster_ros
+        gui  :
+          flags : [ SIGTERM, kill_children ]
+          lidar_address : 
+             user_category : 'Address'
+             flags: [ expand ]
+          pc_address  : 
+             flags: [ expand, nl ]
+          operation_mode :
+             user_category : 'Advanced'
+          pulse_mode : { prop: 0 }
+          window_rejection : { flags: [ nl ] }
+          mode_xyzir : 
+             prop  : 0
+             user_category : 'Misc.'
+          replay : { prop  : 0 }
+          
   - name : Other Sensors
     desc : Other Sensors desc sample
     subs :
@@ -458,6 +478,85 @@ params :
         dash : ''
         delim: ':='
         must : true
+        
+  - name  : ouster_ros
+    vars  :
+    - name : lidar_address
+      desc : OS1 LiDAR hostname or IP address
+      label: 'OS1 address:'
+      kind    : str
+      v       : 'localhost'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : pc_address
+      desc : Computer (PC) hostname or IP address
+      label: 'PC address:'
+      kind    : str
+      v       : '192.168.0.1'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name  : operation_mode
+      desc  : OS1 LiDAR operation mode (hor. res. and scan rate)
+      label : 'lidar operation mode'
+      kind  : menu
+      choices:
+      - 512x10
+      - 1024x10 (default)
+      - 2048x10
+      - 512x20
+      - 1024x20
+      descs :
+      - 512 points horizontal, 10Hz
+      - 1024 points horizontal, 10Hz
+      - 2048 points horizontal, 10Hz
+      - 512 points horizontal, 20Hz
+      - 1024 points horizontal, 20Hz
+      v     : 1
+      cmd_param:
+        dash     : ''
+        delim    : ':='
+    - name  : pulse_mode
+      desc  : OS1 LiDAR pulse width
+      label : 'pulse mode'
+      kind  : menu
+      choices:
+      - STANDARD (8ns, default)
+      - NARROW (4ns)
+      descs :
+      - For full range and specs
+      - For higher resolution, lower range
+      v     : 0
+      cmd_param:
+        dash     : ''
+        delim    : ':='
+    - name  : window_rejection
+      desc  : Window rejection enable, disable for short range operation
+      label : 'Window rejection'
+      kind      : checkbox
+      v         : True
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : mode_xyzir
+      desc  : Velodyne compatible pointcloud mode
+      label : 'Velodyne compatible mode?'
+      kind      : checkbox
+      v         : True
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : replay
+      desc  : For playing rosbag files of raw ouster data
+      label : 'Replay?'
+      kind      : checkbox
+      v         : False
+      cmd_param :
+        dash        : ''
+        delim       : ':='
 
   - name  : grasshopper3_params
     vars  :

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -230,11 +230,22 @@ subs :
         run  : roslaunch ouster_ros os1.launch
         param: ouster_ros
         gui  :
+          dialog_height : 400
           flags : [ SIGTERM, kill_children ]
           lidar_address : 
              user_category : 'Address'
              flags: [ expand ]
           pc_address  : 
+             flags: [ expand, nl ]
+          lidar_frame_name  : 
+             user_category : 'PointCloud'
+             flags: [ expand ]
+          lidar_topic_name  : 
+             flags: [ expand, nl ]
+          imu_frame_name  : 
+             user_category : 'IMU'
+             flags: [ expand ]
+          imu_topic_name  : 
              flags: [ expand, nl ]
           operation_mode :
              user_category : 'Advanced'
@@ -485,7 +496,7 @@ params :
       desc : OS1 LiDAR hostname or IP address
       label: 'OS1 address:'
       kind    : str
-      v       : 'localhost'
+      v       : '192.168.0.100'
       cmd_param :
         dash        : ''
         delim       : ':='
@@ -495,6 +506,42 @@ params :
       label: 'PC address:'
       kind    : str
       v       : '192.168.0.1'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : lidar_frame_name
+      desc : PointCloud frame name (use 'os1' for native Ouster, 'velodyne' for compatible mode)
+      label: 'Cloud frame:'
+      kind    : str
+      v       : 'velodyne'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : lidar_topic_name
+      desc : PointCloud topic name (use '/points' for native Ouster, '/points_raw' for compatible mode)
+      label: 'Cloud topic:'
+      kind    : str
+      v       : '/points_raw'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : imu_frame_name
+      desc : IMU frame name (use 'os1_imu' for native Ouster, 'imu' for general use)
+      label: 'IMU frame:'
+      kind    : str
+      v       : 'imu'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : imu_topic_name
+      desc : IMU topic name (use 'imu' for native Ouster, '/imu_raw' for general use)
+      label: 'IMU topic:'
+      kind    : str
+      v       : 'imu'
       cmd_param :
         dash        : ''
         delim       : ':='
@@ -543,7 +590,7 @@ params :
         delim       : ':='
     - name  : mode_xyzir
       desc  : Velodyne compatible pointcloud mode
-      label : 'Velodyne compatible mode?'
+      label : 'Velodyne compatible pointcloud mode?'
       kind      : checkbox
       v         : True
       cmd_param :
@@ -551,7 +598,7 @@ params :
         delim       : ':='
     - name  : replay
       desc  : For playing rosbag files of raw ouster data
-      label : 'Replay?'
+      label : 'Play rawdata on rosbag?'
       kind      : checkbox
       v         : False
       cmd_param :


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Added support for Ouster OS1 3D LiDAR. This includes, a new option on the sensing tab (including configuration options) and the actual lidar driver as a submodule at `ros/src/sensing/drivers/lidar/packages/ouster`

autowarefoundation/autoware_ai#442 

## Related PRs
List related PRs against other branches:
None

## Todos
- [X] Tests
- [X] Documentation

## Steps to Test or Reproduce
(Note: You need an Ouster OS1 LiDAR to test the following)
1. Clone the `feature/ouster` branch:
`git clone https://github.com/CPFL/Autoware.git --recurse-submodules -b "feature/ouster" autoware-ouster`
2. Build Autoware as usual
3. Start the runtime manager
4. (optional) On Setup tab, set `velodyne` as localizer and the `/base_link` to localizer tf.
5. Follow the instructions on `ros/src/sensing/drivers/lidar/packages/ouster/readme.md` regarding OS1 address configuration (you may need to install dnsmasq and configure it accordingly). Confirm the OS1 LiDAR has an IP address by running `ping <OS1-IP-ADDRESS>`
6. On Sensing tab, click on the Ouster OS1 `[config]` link, and type the LiDAR address and your computer address (in the same network interface), make sure `Velodyne compatible mode` is checked. Then click `OK`. Here is an example:
![image](https://user-images.githubusercontent.com/16696954/49139526-5df5b480-f335-11e8-8139-9611b55bb38a.png)

7. Click the launch check button of Ouster OS1.
8. On RVIZ, set the `fixed frame` as `velodyne`, and add the `/points_raw` PointCloud2 topic, confirm you are receiving data. Here is an example:
![image](https://user-images.githubusercontent.com/16696954/49140185-f8a2c300-f336-11e8-8c16-f49c384e671a.png)


