### PR TITLE
Feature/gitlab ci branch in artifact name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,10 +54,11 @@ build_kinetic:
     - lcov --directory build --capture --output-file lcov.test
     - lcov -a lcov.base -a lcov.test -o lcov.total
     - lcov -r lcov.total '*/tests/*' '*/test/*' '*/build/*' '*/devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
-    - COMMIT_REF_NAME="$(echo $CI_COMMIT_REF_NAME | sed 's/\//_/g')"
-    - COVERAGE_REF_NAME="coverage_$COMMIT_REF_NAME"
-    - genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o $COVERAGE_REF_NAME
-    - tar -czvf coverage.tar.gz $COVERAGE_REF_NAME
+    # BRANCH_NAME: gets branch name from CI_COMMIT_REF_NAME variable substituting / with _ (feature/test_this_lib becomes feature_test_this_lib)
+    - BRANCH_NAME="$(echo $CI_COMMIT_REF_NAME | sed 's/\//_/g')"
+    - COVERAGE_FOLDER_NAME="coverage_$BRANCH_NAME"
+    - genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o $COVERAGE_FOLDER_NAME
+    - tar -czvf coverage.tar.gz $COVERAGE_FOLDER_NAME
     - mv coverage.tar.gz $CI_PROJECT_DIR/coverage.tar.gz
     - ls $CI_PROJECT_DIR 
   retry: 1
@@ -113,10 +114,10 @@ pages:
   dependencies:
     - build_kinetic
   script:
-    - COMMIT_REF_NAME="$(echo $CI_COMMIT_REF_NAME | sed 's/\//_/g')"
-    - COVERAGE_REF_NAME="coverage_$COMMIT_REF_NAME"
+    - BRANCH_NAME="$(echo $CI_COMMIT_REF_NAME | sed 's/\//_/g')"
+    - COVERAGE_FOLDER_NAME="coverage_$BRANCH_NAME"
     - tar -xzvf coverage.tar.gz
-    - mv $COVERAGE_REF_NAME public
+    - mv $COVERAGE_FOLDER_NAME public
   artifacts:
     paths:
       - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ build_kinetic:
   artifacts:
     paths:
       - $CI_PROJECT_DIR/coverage.tar.gz
+    expire_in: 48 hrs
   coverage: /\s*lines.*:\s(\d+\.\d+\%\s\(\d+\sof\s\d+.*\))/
     
 build_cross:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,8 +54,10 @@ build_kinetic:
     - lcov --directory build --capture --output-file lcov.test
     - lcov -a lcov.base -a lcov.test -o lcov.total
     - lcov -r lcov.total '*/tests/*' '*/test/*' '*/build/*' '*/devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
-    - genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o coverage
-    - tar -czvf coverage.tar.gz coverage
+    - COMMIT_REF_NAME="$(echo $CI_COMMIT_REF_NAME | sed 's/\//_/g')"
+    - COVERAGE_REF_NAME="coverage_$COMMIT_REF_NAME"
+    - genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o $COVERAGE_REF_NAME
+    - tar -czvf coverage.tar.gz $COVERAGE_REF_NAME
     - mv coverage.tar.gz $CI_PROJECT_DIR/coverage.tar.gz
     - ls $CI_PROJECT_DIR 
   retry: 1
@@ -110,9 +112,15 @@ pages:
   dependencies:
     - build_kinetic
   script:
+    - COMMIT_REF_NAME="$(echo $CI_COMMIT_REF_NAME | sed 's/\//_/g')"
+    - COVERAGE_REF_NAME="coverage_$COMMIT_REF_NAME"
     - tar -xzvf coverage.tar.gz
-    - mv coverage public
+    - mv $COVERAGE_REF_NAME public
   artifacts:
     paths:
       - public
+  only:
+    - master
+    - develop
+
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ build_kinetic:
     - lcov -a lcov.base -a lcov.test -o lcov.total
     - lcov -r lcov.total '*/tests/*' '*/test/*' '*/build/*' '*/devel/*' '/usr/*' '/opt/*' '*/CMakeCCompilerId.c' '*/CMakeCXXCompilerId.cpp' -o lcov.total.filtered
     # BRANCH_NAME: gets branch name from CI_COMMIT_REF_NAME variable substituting / with _ (feature/test_this_lib becomes feature_test_this_lib)
+    # CI_COMMIT_REF_NAME: (from https://docs.gitlab.com/ee/ci/variables/) The branch or tag name for which project is built
     - BRANCH_NAME="$(echo $CI_COMMIT_REF_NAME | sed 's/\//_/g')"
     - COVERAGE_FOLDER_NAME="coverage_$BRANCH_NAME"
     - genhtml -p "$PWD" --legend --demangle-cpp lcov.total.filtered -o $COVERAGE_FOLDER_NAME


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
The artifacts generated during the _build_ stage of the CI will contain the name of the branch in the coverage folder. As _Pages_ is limited to one generation the coverage report for the particular branch can be viewed locally.