### PR TITLE
Feature/pointcloud renaming in bag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "ros/src/sensing/drivers/lidar/packages/robosense"]
 	path = ros/src/sensing/drivers/lidar/packages/robosense
 	url = https://github.com/CPFL/robosense
+[submodule "ros/src/sensing/drivers/lidar/packages/ouster"]
+	path = ros/src/sensing/drivers/lidar/packages/ouster
+	url = https://github.com/CPFL/ouster
+	branch = autoware_branch

--- a/ros/src/util/packages/autoware_bag_tools/README.md
+++ b/ros/src/util/packages/autoware_bag_tools/README.md
@@ -22,9 +22,26 @@ rosrun autoware_bag_tools change_frame_id.py -o out.bag -i in.bag -t /camera2/im
 Extract GPS data from rosbag file(s) into .kml and .csv files. 
 .kml file could be viewed by Google Earth. color information indicate the quality of GPS satellite coverage (dark to light red) - (bad - good coverage) 
 
-How to Run: 
+###How to Run: 
 
 ```
 rosrun autoware_bag_tools nmea2kml bag_file_name.bag
 rosrun autoware_bag_tools nmea2kml bag_files_folder/
 ```
+
+
+## pointcloud_renaming tool 
+Enable to rename the topic name and/or the frame name of `sensor_msgs/PointCloud2` messages on a BAG file.
+Additionally, makes sure the field name for the intensity channel is actually 'intensity'.
+
+###How to Run: 
+
+1. Help and available options:
+````
+python pointcloud_renaming.py -h
+````
+2. Changing pointcloud topic name from "/kitti/velo/pointcloud" to "/points_raw", and frame name to "velodyne"
+````
+python pointcloud_renaming.py -i input.bag -n "/points_raw" -f "velodyne" -o output3.bag -t "/kitti/velo/pointcloud"
+````
+

--- a/ros/src/util/packages/autoware_bag_tools/nodes/pointcloud_renaming/pointcloud_renaming.py
+++ b/ros/src/util/packages/autoware_bag_tools/nodes/pointcloud_renaming/pointcloud_renaming.py
@@ -1,32 +1,17 @@
 #!/usr/bin/env python
 """
-  Copyright (c) 2018, Nagoya University
-  All rights reserved.
-
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
-
-  * Redistributions of source code must retain the above copyright notice, this
-    list of conditions and the following disclaimer.
-
-  * Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
-
-  * Neither the name of Autoware nor the names of its
-    contributors may be used to endorse or promote products derived from
-    this software without specific prior written permission.
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ Copyright 2017 Autoware Foundation. All rights reserved.
+  
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at 
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 """
 
 __author__ = "Alexander Carballo"

--- a/ros/src/util/packages/autoware_bag_tools/nodes/pointcloud_renaming/pointcloud_renaming.py
+++ b/ros/src/util/packages/autoware_bag_tools/nodes/pointcloud_renaming/pointcloud_renaming.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""
+  Copyright (c) 2018, Nagoya University
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of Autoware nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+__author__ = "Alexander Carballo"
+__email__ = "alexander@g.sp.m.is.nagoya-u.ac.jp"
+__copyright__ = "Copyright (c) 2018, Nagoya University"
+__version__ = "1.0"
+__date__ = "2018/12/04"
+
+"""
+Allows to rename the topic name and frame name of a pointcloud topic inside a BAG file.
+Additionally, makes sure the field name for the intensity channel is actually 'intensity'.
+"""
+
+import sys
+import rosbag
+import argparse
+import progressbar
+
+def main():
+    
+    parser = argparse.ArgumentParser(description = "Rename intensity field on rosbag")
+    parser.add_argument("-i", "--input", required=True, help = "Input BAG filename.")
+    parser.add_argument("-o", "--output", default = "output.bag", help = "Output BAG filename.")
+    parser.add_argument("-t", "--topic", default = "/kitti/velo/pointcloud", help = "PointCloud topic name to change (empty to change all pointcloud topics).")
+    parser.add_argument("-n", "--newtopic", default = "", help = "New topic name to use instead of the original (empty to avoid changing the name).")
+    parser.add_argument("-f", "--frame", default = "", help = "New frame name to use instead of the original (empty to avoid changing the name).")
+    args = parser.parse_args()
+    
+    if args.input == None:
+        print("Input BAG filename not given.")
+        parser.print_help()
+        sys.exit(1)
+    
+    with rosbag.Bag(args.output, 'w') as outbag:
+    	inbag = rosbag.Bag(args.input, 'r')
+    	instances = inbag.get_message_count()
+    	progress = progressbar.ProgressBar(maxval=instances)
+    	progress.start()
+    	instance = 0
+        for topic, msg, t in inbag.read_messages():
+            # This replaces the pointcloud 4th field name to "intensity"
+            # Additionally, topic name and frame name can be replaced
+            
+            #if msg type is sensor_msgs/PointCloud2 and arg.topic either matches the current topic or is empty (any name)
+            if msg._type == 'sensor_msgs/PointCloud2' and (topic == args.topic or args.topic == ''):
+            	new_topic = topic
+            	if args.topic <> '' and args.newtopic <> '':
+                    new_topic = args.newtopic
+                if args.frame <> '':
+            	    msg.header.frame_id = args.frame
+            	if len(msg.fields) == 4: #Assuming X,Y,Z,I format
+            	    msg.fields[3].name = "intensity"
+                outbag.write(new_topic, msg, msg.header.stamp if msg._has_header else t)
+            else: #Any other topics are kept
+                outbag.write(topic, msg, msg.header.stamp if msg._has_header else t)
+            
+            progress.update(instance)
+            instance += 1
+        
+        
+        progress.finish()
+    
+if __name__ == '__main__':
+    main()

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -225,6 +225,26 @@ subs :
         desc : Launches the driver for the selected RoboSense LiDAR sensor and publishes the pointcloud in rslidar_points.
         run  : roslaunch rslidar_pointcloud cloud_nodelet_16.launch
 
+      - name : Ouster OS1
+        desc : Launches the driver for the Ouster OS1 LiDAR and publishes the pointcloud as points_raw.
+        run  : roslaunch ouster_ros os1.launch
+        param: ouster_ros
+        gui  :
+          flags : [ SIGTERM, kill_children ]
+          lidar_address : 
+             user_category : 'Address'
+             flags: [ expand ]
+          pc_address  : 
+             flags: [ expand, nl ]
+          operation_mode :
+             user_category : 'Advanced'
+          pulse_mode : { prop: 0 }
+          window_rejection : { flags: [ nl ] }
+          mode_xyzir : 
+             prop  : 0
+             user_category : 'Misc.'
+          replay : { prop  : 0 }
+          
   - name : Other Sensors
     desc : Other Sensors desc sample
     subs :
@@ -458,6 +478,85 @@ params :
         dash : ''
         delim: ':='
         must : true
+        
+  - name  : ouster_ros
+    vars  :
+    - name : lidar_address
+      desc : OS1 LiDAR hostname or IP address
+      label: 'OS1 address:'
+      kind    : str
+      v       : 'localhost'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : pc_address
+      desc : Computer (PC) hostname or IP address
+      label: 'PC address:'
+      kind    : str
+      v       : '192.168.0.1'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name  : operation_mode
+      desc  : OS1 LiDAR operation mode (hor. res. and scan rate)
+      label : 'lidar operation mode'
+      kind  : menu
+      choices:
+      - 512x10
+      - 1024x10 (default)
+      - 2048x10
+      - 512x20
+      - 1024x20
+      descs :
+      - 512 points horizontal, 10Hz
+      - 1024 points horizontal, 10Hz
+      - 2048 points horizontal, 10Hz
+      - 512 points horizontal, 20Hz
+      - 1024 points horizontal, 20Hz
+      v     : 1
+      cmd_param:
+        dash     : ''
+        delim    : ':='
+    - name  : pulse_mode
+      desc  : OS1 LiDAR pulse width
+      label : 'pulse mode'
+      kind  : menu
+      choices:
+      - STANDARD (8ns, default)
+      - NARROW (4ns)
+      descs :
+      - For full range and specs
+      - For higher resolution, lower range
+      v     : 0
+      cmd_param:
+        dash     : ''
+        delim    : ':='
+    - name  : window_rejection
+      desc  : Window rejection enable, disable for short range operation
+      label : 'Window rejection'
+      kind      : checkbox
+      v         : True
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : mode_xyzir
+      desc  : Velodyne compatible pointcloud mode
+      label : 'Velodyne compatible mode?'
+      kind      : checkbox
+      v         : True
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : replay
+      desc  : For playing rosbag files of raw ouster data
+      label : 'Replay?'
+      kind      : checkbox
+      v         : False
+      cmd_param :
+        dash        : ''
+        delim       : ':='
 
   - name  : grasshopper3_params
     vars  :

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -230,11 +230,22 @@ subs :
         run  : roslaunch ouster_ros os1.launch
         param: ouster_ros
         gui  :
+          dialog_height : 400
           flags : [ SIGTERM, kill_children ]
           lidar_address : 
              user_category : 'Address'
              flags: [ expand ]
           pc_address  : 
+             flags: [ expand, nl ]
+          lidar_frame_name  : 
+             user_category : 'PointCloud'
+             flags: [ expand ]
+          lidar_topic_name  : 
+             flags: [ expand, nl ]
+          imu_frame_name  : 
+             user_category : 'IMU'
+             flags: [ expand ]
+          imu_topic_name  : 
              flags: [ expand, nl ]
           operation_mode :
              user_category : 'Advanced'
@@ -485,7 +496,7 @@ params :
       desc : OS1 LiDAR hostname or IP address
       label: 'OS1 address:'
       kind    : str
-      v       : 'localhost'
+      v       : '192.168.0.100'
       cmd_param :
         dash        : ''
         delim       : ':='
@@ -495,6 +506,42 @@ params :
       label: 'PC address:'
       kind    : str
       v       : '192.168.0.1'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : lidar_frame_name
+      desc : PointCloud frame name (use 'os1' for native Ouster, 'velodyne' for compatible mode)
+      label: 'Cloud frame:'
+      kind    : str
+      v       : 'velodyne'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : lidar_topic_name
+      desc : PointCloud topic name (use '/points' for native Ouster, '/points_raw' for compatible mode)
+      label: 'Cloud topic:'
+      kind    : str
+      v       : '/points_raw'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : imu_frame_name
+      desc : IMU frame name (use 'os1_imu' for native Ouster, 'imu' for general use)
+      label: 'IMU frame:'
+      kind    : str
+      v       : 'imu'
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+        must : True
+    - name : imu_topic_name
+      desc : IMU topic name (use 'imu' for native Ouster, '/imu_raw' for general use)
+      label: 'IMU topic:'
+      kind    : str
+      v       : 'imu'
       cmd_param :
         dash        : ''
         delim       : ':='
@@ -543,7 +590,7 @@ params :
         delim       : ':='
     - name  : mode_xyzir
       desc  : Velodyne compatible pointcloud mode
-      label : 'Velodyne compatible mode?'
+      label : 'Velodyne compatible pointcloud mode?'
       kind      : checkbox
       v         : True
       cmd_param :
@@ -551,7 +598,7 @@ params :
         delim       : ':='
     - name  : replay
       desc  : For playing rosbag files of raw ouster data
-      label : 'Replay?'
+      label : 'Play rawdata on rosbag?'
       kind      : checkbox
       v         : False
       cmd_param :

--- a/ros/src/util/packages/runtime_manager/scripts/simulation.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/simulation.yaml
@@ -9,15 +9,23 @@ buttons:
       - self.label_rosbag_play_bar
       panel : self.panel_rosbag_play
       start :
+        prop   : 1
         border : 20
         flags  : [ left ]
       repeat :
+        prop   : 1
         border : 20
         flags  : [ left ]
       clock :
+        prop   : 1
         border : 20
         flags  : [ left ]
+      other    :
+        prop   : 4
+        border : 40
+        flags  : [ right, no_category ]
       sim_time :
+        prop   : 0
         border : 20
         flags  : [ left, no_category ]
 
@@ -67,6 +75,14 @@ params :
       cmd_param :
         only_enable : True
         dash        : '--'
+    - name      : other
+      label     : 'Other flags:'
+      kind      : str
+      v         : '                        '
+      cmd_param :
+        must        : False
+        tail        : True
+        delim       : ''
     - name      : sim_time
       label     : Sim Time
       kind      : hide


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Added new node to the `autoware_bag_tools` to allow renaming the topic name and frame name of a pointcloud topic inside a BAG file, and to make sure the field name for the intensity channel is actually 'intensity'.

## Related PRs
None

## Todos
- [X] Tests
- [X] Documentation

## Steps to Test or Reproduce
1. Clone the branch `feature/pointcloud_renaming_in_bag`, and build Autoware the usual way.
2. Use any BAG file having `sensor_msgs/PointCloud2` type topics
3. Change the topic name to `/my_new_topic_name` as follows (the original name was `/points_raw`):
```
python pointcloud_renaming.py -i <INPUT-FILENAME.bag> -t "/points_raw" -n "/my_new_topic_name" -f "velodyne" -o <OUTPUT-FILENAME.bag>
```
4. Change the frame name to "my_new_frame_name" of any pointcloud topic as follows:
```
python pointcloud_renaming.py -i <INPUT-FILENAME.bag> -t "" -f "my_new_frame_name" -o <OUTPUT-FILENAME.bag>
```

For any execution, the program will show a progress bar as follows:
```
100% (4541 of 4541) |##################################| Elapsed Time: 0:00:11 Time:  0:00:11
```
In this case "4541" is the number of messages in the BAG file.