### PR TITLE
Fix deceleration value bug in following state

### DIFF
--- a/ros/src/computing/planning/common/lib/openplanner/op_planner/src/DecisionMaker.cpp
+++ b/ros/src/computing/planning/common/lib/openplanner/op_planner/src/DecisionMaker.cpp
@@ -381,7 +381,7 @@ void DecisionMaker::InitBehaviorStates()
 
 		double deceleration_critical = 0;
 		double inv_time = 2.0*((beh.followDistance- (critical_long_front_distance+m_params.additionalBrakingDistance))-CurrStatus.speed);
-		if(inv_time == 0)
+		if(inv_time <= 0)
 			deceleration_critical = m_CarInfo.max_deceleration;
 		else
 			deceleration_critical = CurrStatus.speed*CurrStatus.speed/inv_time;


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
inv_time will be negatived when forward object too close, but deceleration_critical will be smaller than max_deceleration, that makes vehiche hard to stop .