### PR TITLE
Update CMake requirement to 3.5

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/as/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(as)
 
 find_package(

--- a/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
+++ b/ros/src/actuation/vehicles/packages/ymc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ymc)
 
 set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")

--- a/ros/src/common/cmake/autoware_build_flags/CMakeLists.txt
+++ b/ros/src/common/cmake/autoware_build_flags/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_build_flags)
 
 find_package(catkin REQUIRED)

--- a/ros/src/common/libs/amathutils_lib/CMakeLists.txt
+++ b/ros/src/common/libs/amathutils_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 project(amathutils_lib) # autoware math utility
 find_package(catkin REQUIRED COMPONENTS
         autoware_build_flags

--- a/ros/src/common/libs/diagnostics_lib/diag_lib/CMakeLists.txt
+++ b/ros/src/common/libs/diagnostics_lib/diag_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(diag_lib)
 
 add_compile_options(-std=c++11)

--- a/ros/src/common/libs/diagnostics_lib/diag_msgs/CMakeLists.txt
+++ b/ros/src/common/libs/diagnostics_lib/diag_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(diag_msgs)
 
 

--- a/ros/src/common/libs/diagnostics_lib/fake_autoware_nodes/CMakeLists.txt
+++ b/ros/src/common/libs/diagnostics_lib/fake_autoware_nodes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(fake_autoware_nodes)
 
 add_compile_options(-std=c++11)

--- a/ros/src/common/libs/state_machine_lib/CMakeLists.txt
+++ b/ros/src/common/libs/state_machine_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(state_machine_lib)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/common/libvectormap/CMakeLists.txt
+++ b/ros/src/common/libvectormap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(libvectormap)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/fusion_tools/packages/pixel_cloud_fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/fusion_tools/packages/pixel_cloud_fusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(pixel_cloud_fusion)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/fusion_tools/packages/range_vision_fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/fusion_tools/packages/range_vision_fusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(range_vision_fusion)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_euclidean_cluster_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_euclidean_cluster_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_euclidean_cluster_detect)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_fake_perception)
 
 set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_naive_l_shape_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_naive_l_shape_detect)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_svm_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_svm_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_svm_detect)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_tracker/libs/fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/libs/fusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(fusion)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_euclidean_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_euclidean_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_euclidean_track)
 
 ## Find catkin macros and libraries

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_imm_ukf_pda_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_imm_ukf_pda_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(imm_ukf_pda_track)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_contour_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_contour_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_kf_contour_track)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_kf_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_kf_track)
 
 

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_pf_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/lidar_pf_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_pf_track)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/obj_fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/obj_fusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(obj_fusion)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/obj_reproj/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/obj_reproj/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(obj_reproj)
 
 FIND_PACKAGE(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/lidar_tracker/packages/range_fusion/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/lidar_tracker/packages/range_fusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(range_fusion)
 
 FIND_PACKAGE(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/trafficlight_recognizer/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/trafficlight_recognizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(trafficlight_recognizer)
 execute_process(
         COMMAND rosversion -d

--- a/ros/src/computing/perception/detection/vision_detector/libs/dpm_ttic/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/libs/dpm_ttic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(libdpm_ttic)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_darknet_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_darknet_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_darknet_detect)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_dpm_ttic_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_dpm_ttic_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_dpm_ttic_detect)
 
 include(FindPkgConfig)

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_lane_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_lane_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vision_lane_detect)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_segment_enet_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_segment_enet_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_segment_enet_detect)
 
 FIND_PACKAGE(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_ssd_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_ssd_detect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_ssd_detect)
 
 set(ROS_VERSION $ENV{ROS_DISTRO})

--- a/ros/src/computing/perception/detection/vision_tracker/libs/kf/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/libs/kf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kf_lib)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/vision_tracker/packages/vision_beyond_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/packages/vision_beyond_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_beyond_track)
 
 find_package(OpenCV REQUIRED)

--- a/ros/src/computing/perception/detection/vision_tracker/packages/vision_dummy_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/packages/vision_dummy_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_dummy_track)
 
 set(ROS_VERSION $ENV{ROS_DISTRO})

--- a/ros/src/computing/perception/detection/vision_tracker/packages/vision_kf_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/packages/vision_kf_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_kf_track)
 
 set(ROS_VERSION $ENV{ROS_DISTRO})

--- a/ros/src/computing/perception/detection/vision_tracker/packages/vision_klt_track/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_tracker/packages/vision_klt_track/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(vision_klt_track)
 
 set(ROS_VERSION $ENV{ROS_DISTRO})

--- a/ros/src/computing/perception/detection/visualizers/packages/detected_objects_visualizer/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/visualizers/packages/detected_objects_visualizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(detected_objects_visualizer)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/visualizers/packages/integrated_viewer/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/visualizers/packages/integrated_viewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.5)
 project(integrated_viewer)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/detection/visualizers/packages/viewers/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/visualizers/packages/viewers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(viewers)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/localization/lib/gnss/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/lib/gnss/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(gnss)
 
 find_package(catkin REQUIRED COMPONENTS roscpp)

--- a/ros/src/computing/perception/localization/lib/ndt_cpu/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/lib/ndt_cpu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ndt_cpu)
 
 find_package(catkin REQUIRED)

--- a/ros/src/computing/perception/localization/lib/ndt_gpu/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/lib/ndt_gpu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ndt_gpu)
 
 find_package(catkin REQUIRED)

--- a/ros/src/computing/perception/localization/lib/ndt_tku/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/lib/ndt_tku/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ndt_tku)
 
 ###################################

--- a/ros/src/computing/perception/localization/lib/pcl_omp_registration/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/lib/pcl_omp_registration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(pcl_omp_registration)
 
 find_package(catkin REQUIRED COMPONENTS)

--- a/ros/src/computing/perception/localization/packages/autoware_connector/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/autoware_connector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_connector)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/localization/packages/gnss_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/gnss_localizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(gnss_localizer)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/localization/packages/lidar_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/lidar_localizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_localizer)
 
 find_package(PCL REQUIRED)

--- a/ros/src/computing/perception/localization/packages/orb_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/orb_localizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(orb_localizer)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/perception/localization/packages/orb_localizer/Thirdparty/DBoW2/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/orb_localizer/Thirdparty/DBoW2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(DBoW2)
 
 find_package (OpenCV REQUIRED)

--- a/ros/src/computing/perception/localization/packages/orb_localizer/Thirdparty/g2o/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/orb_localizer/Thirdparty/g2o/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 project(g2o)
 

--- a/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/CMakeLists.txt
+++ b/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(naive_motion_predict)
 
 include(FindPkgConfig)

--- a/ros/src/computing/perception/semantics/packages/object_map/CMakeLists.txt
+++ b/ros/src/computing/perception/semantics/packages/object_map/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(object_map)
 

--- a/ros/src/computing/perception/semantics/packages/road_occupancy_processor/CMakeLists.txt
+++ b/ros/src/computing/perception/semantics/packages/road_occupancy_processor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(road_occupancy_processor)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/common/lib/openplanner/op_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_planner)
 
 # Get a ros version

--- a/ros/src/computing/planning/common/lib/openplanner/op_ros_helpers/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_ros_helpers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_ros_helpers)
 set(ROS_VERSION $ENV{ROS_DISTRO})
 

--- a/ros/src/computing/planning/common/lib/openplanner/op_simu/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_simu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_simu)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/ros/src/computing/planning/common/lib/openplanner/op_utility/CMakeLists.txt
+++ b/ros/src/computing/planning/common/lib/openplanner/op_utility/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_utility)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/ros/src/computing/planning/decision/packages/decision_maker/CMakeLists.txt
+++ b/ros/src/computing/planning/decision/packages/decision_maker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(decision_maker)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/ros/src/computing/planning/mission/packages/freespace_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/freespace_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(freespace_planner)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/mission/packages/lane_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/lane_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(lane_planner)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/mission/packages/op_global_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/op_global_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_global_planner)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/mission/packages/way_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/mission/packages/way_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(way_planner)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/motion/packages/astar_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/astar_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(astar_planner)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/motion/packages/dp_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/dp_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(dp_planner)
 set(ROS_VERSION $ENV{ROS_DISTRO})
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/motion/packages/ff_waypoint_follower/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/ff_waypoint_follower/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ff_waypoint_follower)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/motion/packages/lattice_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/lattice_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(lattice_planner)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/motion/packages/op_local_planner/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_local_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_local_planner)
 set(ROS_VERSION $ENV{ROS_DISTRO})
 

--- a/ros/src/computing/planning/motion/packages/op_simulation_package/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_simulation_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_simulation_package)
 execute_process(
   COMMAND rosversion -d

--- a/ros/src/computing/planning/motion/packages/op_utilities/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/op_utilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(op_utilities)
 
 find_package(catkin REQUIRED COMPONENTS		

--- a/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(waypoint_follower)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/motion/packages/waypoint_maker/CMakeLists.txt
+++ b/ros/src/computing/planning/motion/packages/waypoint_maker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(waypoint_maker)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/computing/planning/state/state_machine/CMakeLists.txt
+++ b/ros/src/computing/planning/state/state_machine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(state_machine)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/data/packages/map_file/CMakeLists.txt
+++ b/ros/src/data/packages/map_file/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(map_file)
 
 include(FindPkgConfig)

--- a/ros/src/data/packages/obj_db/CMakeLists.txt
+++ b/ros/src/data/packages/obj_db/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(obj_db)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/data/packages/pos_db/CMakeLists.txt
+++ b/ros/src/data/packages/pos_db/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(pos_db)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/data/packages/vector_map/CMakeLists.txt
+++ b/ros/src/data/packages/vector_map/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vector_map)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/data/packages/vector_map_msgs/CMakeLists.txt
+++ b/ros/src/data/packages/vector_map_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vector_map_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/data/packages/vector_map_server/CMakeLists.txt
+++ b/ros/src/data/packages/vector_map_server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vector_map_server)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/driveworks/packages/autoware_driveworks_gmsl_interface/CMakeLists.txt
+++ b/ros/src/driveworks/packages/autoware_driveworks_gmsl_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_driveworks_gmsl_interface)
 
 find_package(CUDA)

--- a/ros/src/driveworks/packages/autoware_driveworks_interface/CMakeLists.txt
+++ b/ros/src/driveworks/packages/autoware_driveworks_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_driveworks_interface)
 
 set(CMAKE_CXX_FLAGS "-O2 -s  -Wno-error=unused-parameter")

--- a/ros/src/msgs/autoware_can_msgs/CMakeLists.txt
+++ b/ros/src/msgs/autoware_can_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_can_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/msgs/autoware_config_msgs/CMakeLists.txt
+++ b/ros/src/msgs/autoware_config_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_config_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/msgs/autoware_msgs/CMakeLists.txt
+++ b/ros/src/msgs/autoware_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/msgs/dbw_mkz_msgs/CMakeLists.txt
+++ b/ros/src/msgs/dbw_mkz_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(dbw_mkz_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/camera/packages/baumer/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/baumer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vlg22c_cam)
 
 find_package(catkin REQUIRED COMPONENTS 

--- a/ros/src/sensing/drivers/camera/packages/hexacam/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/hexacam/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(hexacam)
 
 ## Find catkin macros and libraries

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(autoware_pointgrey_drivers)
 

--- a/ros/src/sensing/drivers/camera/packages/vectacam/CMakeLists.txt
+++ b/ros/src/sensing/drivers/camera/packages/vectacam/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vectacam)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/can/packages/kvaser/CMakeLists.txt
+++ b/ros/src/sensing/drivers/can/packages/kvaser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kvaser)
 
 ## Find catkin macros and libraries

--- a/ros/src/sensing/drivers/gnss/packages/garmin/CMakeLists.txt
+++ b/ros/src/sensing/drivers/gnss/packages/garmin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(garmin)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x") #or

--- a/ros/src/sensing/drivers/gnss/packages/javad_navsat_driver/CMakeLists.txt
+++ b/ros/src/sensing/drivers/gnss/packages/javad_navsat_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(javad_navsat_driver)
 
 find_package(catkin REQUIRED COMPONENTS roslint)

--- a/ros/src/sensing/drivers/gnss/packages/nmea_navsat/CMakeLists.txt
+++ b/ros/src/sensing/drivers/gnss/packages/nmea_navsat/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(nmea_navsat)
 
 find_package(catkin REQUIRED 

--- a/ros/src/sensing/drivers/imu/packages/analog_devices/CMakeLists.txt
+++ b/ros/src/sensing/drivers/imu/packages/analog_devices/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(adi_driver)
 
 find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs roslint)

--- a/ros/src/sensing/drivers/imu/packages/memsic/CMakeLists.txt
+++ b/ros/src/sensing/drivers/imu/packages/memsic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(memsic_imu)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/imu/packages/microstrain/CMakeLists.txt
+++ b/ros/src/sensing/drivers/imu/packages/microstrain/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(microstrain_driver)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/imu/packages/xsens/src/custom_msgs/CMakeLists.txt
+++ b/ros/src/sensing/drivers/imu/packages/xsens/src/custom_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(custom_msgs)
 
 ## Find catkin macros and libraries

--- a/ros/src/sensing/drivers/imu/packages/xsens/src/xsens_driver/CMakeLists.txt
+++ b/ros/src/sensing/drivers/imu/packages/xsens/src/xsens_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xsens_driver)
 
 ## Find catkin macros and libraries

--- a/ros/src/sensing/drivers/lidar/packages/hokuyo/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/hokuyo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(hokuyo)
 
 ## Find catkin and any catkin packages

--- a/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_description/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sick_ldmrs_description)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_driver/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sick_ldmrs_driver)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_driver/src/driver/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_driver/src/driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 project(LIBSICK_LDMRS)
 
 set(SICK_LDMRS_MAJOR_VERSION 0)

--- a/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_laser/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_laser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sick_ldmrs_laser)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_msgs/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sick_ldmrs_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_tools/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/sick/ldmrs/sick_ldmrs_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sick_ldmrs_tools)
 
 ## Find catkin macros and libraries

--- a/ros/src/sensing/drivers/lidar/packages/sick/lms5xx/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/sick/lms5xx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sick_lms5xx)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(velodyne)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_driver/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(velodyne_driver)
 
 set(${PROJECT_NAME}_CATKIN_DEPS 

--- a/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_laserscan/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_laserscan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(velodyne_laserscan)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_msgs/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(velodyne_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)

--- a/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_pointcloud/CMakeLists.txt
+++ b/ros/src/sensing/drivers/lidar/packages/velodyne/velodyne_pointcloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(velodyne_pointcloud)
 
 set(${PROJECT_NAME}_CATKIN_DEPS

--- a/ros/src/sensing/filters/packages/image_processor/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/image_processor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(image_processor)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/filters/packages/points_downsampler/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/points_downsampler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(points_downsampler)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/filters/packages/points_preprocessor/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/points_preprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(points_preprocessor)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_camera_lidar_calibrator)
 
 include(FindPkgConfig)

--- a/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/calibration_camera_lidar/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(calibration_camera_lidar)
 set(ROS_VERSION $ENV{ROS_DISTRO})
 

--- a/ros/src/sensing/fusion/packages/multi_lidar_calibrator/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/multi_lidar_calibrator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(multi_lidar_calibrator)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/points2image/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(points2image)
 
 include(FindPkgConfig)

--- a/ros/src/sensing/fusion/packages/scan2image/CMakeLists.txt
+++ b/ros/src/sensing/fusion/packages/scan2image/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(scan2image)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/sensing/polygon/packages/points2polygon/CMakeLists.txt
+++ b/ros/src/sensing/polygon/packages/points2polygon/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(points2polygon)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/socket/packages/mqtt_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/mqtt_socket/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(mqtt_socket)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/socket/packages/oculus_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/oculus_socket/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(oculus_socket)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/socket/packages/tablet_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/tablet_socket/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(tablet_socket)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/socket/packages/tablet_socket_msgs/CMakeLists.txt
+++ b/ros/src/socket/packages/tablet_socket_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(tablet_socket_msgs)
 
 ## Find catkin macros and libraries

--- a/ros/src/socket/packages/udon_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/udon_socket/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(udon_socket)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/socket/packages/vehicle_socket/CMakeLists.txt
+++ b/ros/src/socket/packages/vehicle_socket/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(vehicle_socket)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/system/gazebo/catvehicle/CMakeLists.txt
+++ b/ros/src/system/gazebo/catvehicle/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(catvehicle)
 set(ROS_VERSION $ENV{ROS_DISTRO})
 

--- a/ros/src/system/gazebo/laser_scan_converter/CMakeLists.txt
+++ b/ros/src/system/gazebo/laser_scan_converter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(laser_scan_converter)
 
 ## Find catkin macros and libraries

--- a/ros/src/system/gazebo/point_cloud_converter/CMakeLists.txt
+++ b/ros/src/system/gazebo/point_cloud_converter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(point_cloud_converter)
 
 ## Find catkin macros and libraries

--- a/ros/src/system/gazebo/twist_cmd_converter/CMakeLists.txt
+++ b/ros/src/system/gazebo/twist_cmd_converter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(twist_cmd_converter)
 
 ## Find catkin macros and libraries

--- a/ros/src/system/sync/CMakeLists.txt
+++ b/ros/src/system/sync/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(synchronization)
 
 ## Find catkin macros and libraries

--- a/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/fastvirtualscan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(fastvirtualscan)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/util/packages/RobotSDK/glviewer/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/glviewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(glviewer)
 
 include(FindPkgConfig)

--- a/ros/src/util/packages/RobotSDK/rosinterface/CMakeLists.txt
+++ b/ros/src/util/packages/RobotSDK/rosinterface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(rosinterface)
 
 include(FindPkgConfig)

--- a/ros/src/util/packages/autoware_bag_tools/CMakeLists.txt
+++ b/ros/src/util/packages/autoware_bag_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_bag_tools)
 
 find_package(catkin REQUIRED COMPONENTS rospy rosbag nmea_msgs roslib)

--- a/ros/src/util/packages/autoware_rviz_plugins/CMakeLists.txt
+++ b/ros/src/util/packages/autoware_rviz_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_rviz_plugins)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/util/packages/data_preprocessor/CMakeLists.txt
+++ b/ros/src/util/packages/data_preprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(data_preprocessor)
 
 set(CMAKE_CXX_FLAGS "-std=c++0x -O2 -Wall ${CMAKE_CXX_FLAGS}")

--- a/ros/src/util/packages/fake_drivers/CMakeLists.txt
+++ b/ros/src/util/packages/fake_drivers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(fake_drivers)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/util/packages/graph_tools/CMakeLists.txt
+++ b/ros/src/util/packages/graph_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(graph_tools)
 
 find_package(catkin REQUIRED)

--- a/ros/src/util/packages/kitti_pkg/kitti_box_publisher/CMakeLists.txt
+++ b/ros/src/util/packages/kitti_pkg/kitti_box_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kitti_box_publisher)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/util/packages/kitti_pkg/kitti_launch/CMakeLists.txt
+++ b/ros/src/util/packages/kitti_pkg/kitti_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kitti_launch)
 
 find_package(catkin REQUIRED)

--- a/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
+++ b/ros/src/util/packages/kitti_pkg/kitti_player/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kitti_player)
 
 SET(CMAKE_CXX_FLAGS "-O3")

--- a/ros/src/util/packages/log_tools/CMakeLists.txt
+++ b/ros/src/util/packages/log_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(log_tools)
 
 add_compile_options(-std=c++11)

--- a/ros/src/util/packages/map_tf_generator/CMakeLists.txt
+++ b/ros/src/util/packages/map_tf_generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(map_tf_generator)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/ros/src/util/packages/map_tools/CMakeLists.txt
+++ b/ros/src/util/packages/map_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(map_tools)
 
 find_package(PCL REQUIRED)

--- a/ros/src/util/packages/marker_downsampler/CMakeLists.txt
+++ b/ros/src/util/packages/marker_downsampler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(marker_downsampler)
 
 ## Find catkin macros and libraries

--- a/ros/src/util/packages/model_publisher/CMakeLists.txt
+++ b/ros/src/util/packages/model_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(model_publisher)
 
 ## Find catkin macros and libraries

--- a/ros/src/util/packages/pc2_downsampler/CMakeLists.txt
+++ b/ros/src/util/packages/pc2_downsampler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(pc2_downsampler)
 
 ## Find catkin macros and libraries

--- a/ros/src/util/packages/requirements_version_checker/CMakeLists.txt
+++ b/ros/src/util/packages/requirements_version_checker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(requirements_version_checker)
 
 find_package(OpenCV REQUIRED)

--- a/ros/src/util/packages/runtime_manager/CMakeLists.txt
+++ b/ros/src/util/packages/runtime_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(runtime_manager)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ros/src/util/packages/sample_data/CMakeLists.txt
+++ b/ros/src/util/packages/sample_data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sample_data)
 
 include(FindPkgConfig)

--- a/ros/src/util/packages/sound_player/CMakeLists.txt
+++ b/ros/src/util/packages/sound_player/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(sound_player)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
This pull request updates the CMake minimum version to 3.5 to all packages. Since we no longer support Ubuntu 14.04, we can use the version that Ubuntu 16.04 ships with.