### PR TITLE
[Fix] Add grid_map_vizualization to run_depend

### DIFF
--- a/ros/src/computing/perception/semantics/packages/object_map/package.xml
+++ b/ros/src/computing/perception/semantics/packages/object_map/package.xml
@@ -33,6 +33,7 @@
     <run_depend>grid_map_ros</run_depend>
     <run_depend>grid_map_cv</run_depend>
     <run_depend>grid_map_msgs</run_depend>
+    <run_depend>grid_map_visualization</run_depend>
     <run_depend>autoware_msgs</run_depend>
     <run_depend>vector_map</run_depend>
     <run_depend>libqt5-core</run_depend>


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Fix autowarefoundation/autoware_ai#422 

## Steps to Test or Reproduce
```
cd Autoware/ros
rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
roslaunch object_map grid_map_filter.launch
```