### PR TITLE
[feature] Initial integration of Boson FLIR ADK camera driver for Autoware

### DIFF
--- a/ros/src/sensing/drivers/camera/packages/pointgrey/README.md
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/README.md
@@ -46,3 +46,29 @@ Sensing Tab -> Cameras -> PointGrey Ladybug5
 
 * The FlyCapture SDK must be obtained from Point Grey's website.\
 <https://www.ptgrey.com/flycapture-sdk>
+
+
+## FLIR ADK
+
+Execute from `Autoware/ros` base path.
+
+1. `rosdep update`
+1. `rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO` 
+1. `./catkin_make_release`
+1. `./run`
+1. Connect your camera
+1. Confirm the camera has been detected using `v4l2-ctl --list-devices`
+1. Select from *Sensing* tab / *Cameras* -> FLIR ADK
+1. Press the `[config]` button and write the device name reported by `v4l2-ctl --list-devices`.
+1. Click the *FLIR ADK* checkbox
+1. Open Rviz and add image topic `/flir_adk/camera/image_raw`
+
+### Parameters available
+
+|Parameter| Type| Description|
+----------|-----|--------
+|`DEVICE`|*string* |Name of the system device in the form `/dev/videoX`. Obtain the correct name using `v4l2-ctl --list-devices`.|
+|`FPS`|*integer*|Frame per second. Default 30. |
+|`WIDTH`|*integer*|Image width of the stream (Default 640).|
+|`HEIGHT`|*integer*|Image height of the camera (Default 512).|
+|`NS`|*string*|Namespace to add as prefix. Default `flir_adk`.|

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/package.xml
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/package.xml
@@ -4,20 +4,27 @@
   <version>1.9.1</version>
   <description>The autoware_pointgrey_drivers package</description>
   <maintainer email="kondoh@axe-inc.co.jp">Masao KONDOH</maintainer>
-  <maintainer email="abrahammonrroy@yahoo.com">Masao KONDOH</maintainer>
+  <maintainer email="abrahammonrroy@yahoo.com">Abraham Monrroy</maintainer>
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>autoware_build_flags</buildtool_depend>
+
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>cv_bridge</build_depend>
+
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>message_generation</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>cv_bridge</run_depend>
+
+  <run_depend>v4l-utils</run_depend>
+  <run_depend>gstreamer0.10-plugins-good</run_depend>
+  <run_depend>gscam</run_depend>
+
   <export>
   </export>
 </package>

--- a/ros/src/sensing/drivers/camera/packages/pointgrey/scripts/flir_adk.launch
+++ b/ros/src/sensing/drivers/camera/packages/pointgrey/scripts/flir_adk.launch
@@ -1,0 +1,16 @@
+<launch>
+  <arg name="DEVICE" default="/dev/video0"/> <!--change this to the correct video device -->
+  <arg name="FPS" default="30"/>
+  <arg name="WIDTH" default="640"/>
+  <arg name="HEIGHT" default="512"/>
+  <arg name="NS" default="flir_adk"/>
+
+  <node ns="$(arg NS)" name="flir_adk_01" pkg="gscam" type="gscam" output="screen">
+    <param name="camera_name" value="flir"/>
+    <param name="gscam_config"
+           value="v4l2src device=$(arg DEVICE) ! video/x-raw-yuv,framerate=$(arg FPS)/1,width=$(arg WIDTH),height=$(arg HEIGHT) ! ffmpegcolorspace "/>
+    <param name="frame_id" value="$(arg NS)"/>
+    <param name="sync_sink" value="true"/>
+    <remap from="/$(arg NS)/camera/camera_info" to="not_camera_info"/> <!-- Ignore original camera_info topic -->
+  </node>
+</launch>

--- a/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/sensing.yaml
@@ -32,6 +32,12 @@ subs :
         probe:
         run  : roslaunch pointgrey_camera_driver camera.launch
 
+      - name : FLIR ADK
+        desc : Driver for Boson FLIR Thermal camera
+        probe:
+        run  : roslaunch autoware_pointgrey_drivers flir_adk.launch
+        param: fliradk_params
+
       - name : PointGrey LadyBug 5
         desc : PointGrey LadyBug 5 desc sample
         probe:
@@ -1646,6 +1652,48 @@ params :
       min   : -3.14157
       max   : 3.14157
       v     : 0
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+
+  - name  : fliradk_params
+    vars  :
+    - name  : DEVICE
+      label : Device
+      desc  : System Device name /dev/videoX
+      kind  : str
+      v     : /dev/video0
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : FPS
+      label : FPS
+      desc  : FPS Acquisition (Default 30)
+      min   : 1
+      max   : 100
+      v     : 30
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : WIDTH
+      label : Width
+      desc  : Image Width (Default 640)
+      v     : 640
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : HEIGHT
+      label : Height
+      desc  : Image Height (Default 512)
+      v     : 512
+      cmd_param :
+        dash        : ''
+        delim       : ':='
+    - name  : NS
+      label : Frame
+      desc  : Camera Frame to register in TF (Default flir_adk)
+      kind  : str
+      v     : flir_adk
       cmd_param :
         dash        : ''
         delim       : ':='


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Implements autowarefoundation/autoware_ai#471 

## Steps to Test or Reproduce
Execute:
1. `rosdep update`
1. `rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO` 
1. `./catkin_make_release`
1. `./run`
1. Connect your camera
1. Confirm the camera has been detected using `v4l2-ctl --list-devices`
1. Select from *Sensing* tab / *Cameras* -> FLIR ADK
1. Press the `[config]` button and write the device name reported by `v4l2-ctl --list-devices`.
1. Click the *FLIR ADK* checkbox
1. Open Rviz and add image topic `/flir_adk/camera/image_raw`
