### PR TITLE
[Fix] rosbag split size in runtime manager

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
+++ b/ros/src/util/packages/runtime_manager/scripts/runtime_manager_dialog.py
@@ -3003,7 +3003,7 @@ class MyDialogROSbagRecord(rtmgr.MyDialogROSbagRecord):
 			mb = 0
 		if mb <= 0:
 			tc.SetValue('')
-		return [ '--size=' + str(int(mb * 1024 * 1024)) ] if mb > 0 else []
+		return [ '--size=' + str(int(mb)) ] if mb > 0 else []
 
 def set_size_gdic(dlg, gdic={}):
 	(w, h) = dlg.GetSize()


### PR DESCRIPTION
## Status
** DEVELOPMENT**

## Description
Fix on Issue autowarefoundation/autoware_ai#478 
The option --size for `rosbag record` is already in MB, but was treated as Byte in source code.
(see `rosbag record --help`)

## Related PRs
List related PRs against other branches:

## Steps to Test or Reproduce
  1. run runtime manager i.e. `./Autoware/ros/run`
  2. click ROSBAG button
  3. select topic
  4. tick split checkbox
  5. specify size in MB
  6. click START
Recorded bag file should be split up into specified size.
