### PR TITLE
Make VectorMap::hasSubscribed public

### DIFF
--- a/ros/src/data/packages/vector_map/include/vector_map/vector_map.h
+++ b/ros/src/data/packages/vector_map/include/vector_map/vector_map.h
@@ -395,7 +395,6 @@ private:
   Handle<Fence, FenceArray> fence_;
   Handle<RailCrossing, RailCrossingArray> rail_crossing_;
 
-  bool hasSubscribed(category_t category) const;
   void registerSubscriber(ros::NodeHandle& nh, category_t category);
 
 public:
@@ -470,6 +469,8 @@ public:
   std::vector<Wall> findByFilter(const Filter<Wall>& filter) const;
   std::vector<Fence> findByFilter(const Filter<Fence>& filter) const;
   std::vector<RailCrossing> findByFilter(const Filter<RailCrossing>& filter) const;
+
+  bool hasSubscribed(category_t category) const;
 
   void registerCallback(const Callback<PointArray>& cb);
   void registerCallback(const Callback<VectorArray>& cb);


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
This pull request splits the change of vector_map from #1609,
and makes VectorMap::hasSubscribed public.
The other component can check if vectormap is loaded or not.

## Related PRs
- Feature/rebuild decision maker #1609

## Todos
- [x] Pass CI