### PR TITLE
[Fix] Link error at docker build

### DIFF
--- a/docker/generic/Dockerfile.kinetic
+++ b/docker/generic/Dockerfile.kinetic
@@ -112,10 +112,9 @@ RUN sudo rosdep init \
         && rosdep update \
         && echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
 
-# YOLO_V2
-RUN cd && git clone https://github.com/pjreddie/darknet.git
-RUN cd ~/darknet && git checkout 56d69e73aba37283ea7b9726b81afd2f79cd1134
-RUN cd ~/darknet/data && wget https://pjreddie.com/media/files/yolo.weights
+# Setting
+RUN sudo ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64/stubs/:$LD_LIBRARY_PATH"
 
 # Install Autoware
 RUN cd && mkdir /home/$USERNAME/Autoware


### PR DESCRIPTION
## Status
**PRODUCTION**

## Description
Fix `Unable to build docker image for v1.10.0 RC1` autowarefoundation/autoware_ai#490 

Since https://github.com/pjreddie/darknet is no longer required for building Autoware,
it is removed from the Dockerfile.

## Related PRs
- release/1.10.0

## Todos
- [x] Tests

## Steps to Test or Reproduce
```
$ cd Autoware/docker/generic
$ ./build.sh kinetic
```