### PR TITLE
Use catkin_make_release to build Autoware

### DIFF
--- a/docker/generic/Dockerfile.kinetic
+++ b/docker/generic/Dockerfile.kinetic
@@ -120,7 +120,8 @@ RUN cd ~/darknet/data && wget https://pjreddie.com/media/files/yolo.weights
 # Install Autoware
 RUN cd && mkdir /home/$USERNAME/Autoware
 COPY --chown=autoware ./ /home/$USERNAME/Autoware/
-RUN /bin/bash -c 'source /opt/ros/kinetic/setup.bash; cd /home/$USERNAME/Autoware/ros/src; git submodule update --init --recursive; cd ../; ./colcon_release'
+# Use catkin_make_release for now until we migrate entirely to colcon
+RUN /bin/bash -c 'source /opt/ros/kinetic/setup.bash; cd /home/$USERNAME/Autoware/ros/src; git submodule update --init --recursive; catkin_init_workspace; cd ../; ./catkin_make_release'
 RUN echo "source /home/$USERNAME/Autoware/ros/devel/setup.bash" >> /home/$USERNAME/.bashrc
 
 # Setting


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Revert the colcon change in the Docker image

Connects to autowarefoundation/autoware#1851 