### PR TITLE
Update twist_filter.cpp

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/twist_filter/twist_filter.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/twist_filter/twist_filter.cpp
@@ -52,7 +52,7 @@ void TwistCmdCallback(const geometry_msgs::TwistStampedConstPtr &msg)
     return;
   }
 
-  double max_v = g_lateral_accel_limit / omega;
+  double max_v = g_lateral_accel_limit / fabs(omega);
 
   geometry_msgs::TwistStamped tp;
   tp.header = msg->header;


### PR DESCRIPTION
Fix negative max_v values for negative omega.

## Status
**PRODUCTION / DEVELOPMENT**

## Description
The max_v values is negative on right turns since omega is negative.

## Steps to Test or Reproduce
1. Build Autoware with as_interface (branch: feature/demo_astuff) and AS Speed and Steering Control (closed source - Autonomoustuff)
2. Generate waypoints with right turns and test waypoint following - hard stops on turn for negative omega (negative velocity values get cut off at 0 when going through the as_interface)

```
```
The car should hard stop at right turns.

@aohsato @shinpei0208 