### PR TITLE
[Fix] geo_pos_conv class member variable not initialized

### DIFF
--- a/ros/src/computing/perception/localization/lib/gnss/include/gnss/geo_pos_conv.hpp
+++ b/ros/src/computing/perception/localization/lib/gnss/include/gnss/geo_pos_conv.hpp
@@ -12,15 +12,16 @@ private:
 	double m_lat;  //latitude
 	double m_lon; //longitude
 	double m_h;
-  
+
 	double m_PLato;        //plane lat
 	double m_PLo;          //plane lon
 
 public:
+	geo_pos_conv();
 	double x() const;
 	double y() const;
 	double z() const;
-  
+
 	void set_plane(double lat,   double lon);
 	void set_plane(int num);
 	void set_xyz(double cx,   double cy,   double cz);

--- a/ros/src/computing/perception/localization/lib/gnss/src/geo_pos_conv.cpp
+++ b/ros/src/computing/perception/localization/lib/gnss/src/geo_pos_conv.cpp
@@ -16,6 +16,18 @@
 
 #include <gnss/geo_pos_conv.hpp>
 
+geo_pos_conv::geo_pos_conv()
+    : m_x(0)
+    , m_y(0)
+    , m_z(0)
+    , m_lat(0)
+    , m_lon(0)
+    , m_h(0)
+    , m_PLato(0)
+    , m_PLo(0)
+{
+}
+
 double geo_pos_conv::x() const
 {
   return m_x;


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
autowarefoundation/autoware_ai#517 

## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce

1. rosbag play moriyama.bag

1. launch nmea2tfpose

1. launch ndt_matching