### PR TITLE
[Fix] camera lidar calibator

### DIFF
--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/launch/camera_lidar_calibration.launch
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/launch/camera_lidar_calibration.launch
@@ -12,7 +12,7 @@ roslaunch autoware_camera_lidar_calibrator camera_lidar_calibration.launch intri
 
     <node if="$(arg compressed_stream)" name="decompress" type="republish" pkg="image_transport" output="screen" args="compressed in:=/$(arg camera_id)/$(arg image_src) raw out:=/$(arg camera_id)/$(arg image_src)" />
 
-    <node pkg="calibration_camera_lidar" type="calibration_publisher" name="calibration_publisher" ns="$(arg camera_id)">
+    <node pkg="calibration_publisher" type="calibration_publisher" name="calibration_publisher" ns="$(arg camera_id)">
         <param name="register_lidar2camera_tf" type="bool" value="false"/>
         <param name="publish_extrinsic_mat" type="bool" value="false"/>
         <param name="publish_camera_info" type="bool" value="true"/>

--- a/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/package.xml
+++ b/ros/src/sensing/fusion/packages/autoware_camera_lidar_calibrator/package.xml
@@ -32,6 +32,7 @@
 
     <build_depend>qtbase5-dev</build_depend>
     <exec_depend>libqt5-core</exec_depend>
+    <exec_depend>image_view2</exec_depend>
 
     <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
## Status
** DEVELOPMENT**

## Description
- Fix package name in launch file
- Add `image_view2` to dependency

Described in autowarefoundation/autoware_ai#518 

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
$ cd Autoware/ros
$ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
$ ./catkin_make_release
$ roslaunch autoware_camera_lidar_calibrator camera_lidar_calibration.launch intrinsics_file:=/PATH/TO/YYYYmmdd_HHMM_autoware_camera_calibration.yaml image_src:=/image
```