### PR TITLE
fix rosbag_controller license

### DIFF
--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.cpp
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.cpp
@@ -12,7 +12,7 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
+**********************************************************************
 * Software License Agreement (BSD License)
 *
 *  Copyright (c) 2008, Willow Garage, Inc.
@@ -44,7 +44,7 @@
 *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
-********************************************************************/
+*********************************************************************/
 
 #include "recorder.h"
 

--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.cpp
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.cpp
@@ -1,4 +1,18 @@
 /*********************************************************************
+* Copyright 2015-2019 Autoware Foundation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
 * Software License Agreement (BSD License)
 *
 *  Copyright (c) 2008, Willow Garage, Inc.

--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.h
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.h
@@ -12,7 +12,7 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
+**********************************************************************
 * Software License Agreement (BSD License)
 *
 *  Copyright (c) 2008, Willow Garage, Inc.

--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.h
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.h
@@ -1,4 +1,18 @@
 /*********************************************************************
+* Copyright 2015-2019 Autoware Foundation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
 * Software License Agreement (BSD License)
 *
 *  Copyright (c) 2008, Willow Garage, Inc.


### PR DESCRIPTION
## Description
Fix the  license violations

https://github.com/CPFL/Autoware/blob/develop/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.cpp
copied from
https://github.com/ros/ros_comm/blob/kinetic-devel/tools/rosbag/src/recorder.cpp

https://github.com/CPFL/Autoware/blob/develop/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.h
copied from
https://github.com/ros/ros_comm/blob/kinetic-devel/tools/rosbag/include/rosbag/recorder.h

Not 100% copy, I add some other functions to support rest codes. 

Apache license is now appended before original BSD Licenses for two files mentioned before. 