### PR TITLE
Fix/velodyne subtree CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ build_cross:
     - docker:dind
   variables:
     ROS_DISTRO: kinetic
-    AUTOWARE_DOCKER_DATE: 20190102
+    AUTOWARE_DOCKER_DATE: 20190211
     AUTOWARE_HOME: $CI_PROJECT_DIR
     AUTOWARE_TARGET_ARCH: aarch64
     AUTOWARE_TARGET_PLATFORM: generic-aarch64


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fixes CI #1966 
[Pipeline before squashing commits](https://gitlab.com/ServandoGS/Autoware/pipelines/47000090)
[Pipeline after squashing commits](https://gitlab.com/ServandoGS/Autoware/pipelines/47033653)