### PR TITLE
Fix/gazebo_simulator CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ build_cross:
     - docker:dind
   variables:
     ROS_DISTRO: kinetic
-    AUTOWARE_DOCKER_DATE: 20190102
+    AUTOWARE_DOCKER_DATE: 20190211
     AUTOWARE_HOME: $CI_PROJECT_DIR
     AUTOWARE_TARGET_ARCH: aarch64
     AUTOWARE_TARGET_PLATFORM: generic-aarch64
@@ -115,7 +115,7 @@ build_cross:
                   "
                   '
   retry: 1
-  
+
 pages:
   stage: deploy
   image: alpine

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,9 +8,6 @@
 	path = ros/src/sensing/drivers/lidar/packages/ouster
 	url = https://github.com/CPFL/ouster
 	branch = autoware_branch
-[submodule "ros/src/simulation/gazebo_simulator/vehicle/sensor_model/velodyne"]
-	path = ros/src/simulation/gazebo_simulator/vehicle/sensor_model/velodyne
-	url = https://bitbucket.org/DataspeedInc/velodyne_simulator.git
 [submodule "ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim"]
 	path = ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim
 	url = https://github.com/yukkysaito/osrf_citysim.git


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fixes CI #1930 
[Pipeline before squashing commits](https://gitlab.com/ServandoGS/Autoware/pipelines/47011315)
[Pipeline after squashing commits](https://gitlab.com/ServandoGS/Autoware/pipelines/47032613)

@yukkysaito The velodyne submodule is the one causing trouble, the packages can be installed directly as they are available as part of ROS