### PR TITLE
Fix/gazebo simulator CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,7 +99,7 @@ build_cross:
           --rm
           -v ${AUTOWARE_HOME}:${AUTOWARE_HOME}
           -w ${AUTOWARE_HOME}/ros
-          autoware/build:${AUTOWARE_TARGET_PLATFORM}-kinetic-${AUTOWARE_DOCKER_DATE}
+          autoware/build:devel-${AUTOWARE_TARGET_PLATFORM}-kinetic
           bash
             -c "
                 source ${AUTOWARE_SYSROOT}/opt/ros/kinetic/setup.bash &&

--- a/ros/src/simulation/gazebo_simulator/vehicle/vehicle_model/CMakeLists.txt
+++ b/ros/src/simulation/gazebo_simulator/vehicle/vehicle_model/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(catkin REQUIRED
   imu_description
   velodyne_description
   velodyne_gazebo_plugins
-  velodyne_simulator
 )
 
 catkin_package(
@@ -27,7 +26,6 @@ catkin_package(
     imu_description
     velodyne_description
     velodyne_gazebo_plugins
-    velodyne_simulator
 )
 
 install(DIRECTORY mesh


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
The metapackage _velodyne_simulator_ should not be included as a dependency.
Pipeline: [https://gitlab.com/ServandoGS/Autoware/pipelines/47501619](https://gitlab.com/ServandoGS/Autoware/pipelines/47501619)

## Related PRs
#1930 