### PR TITLE
Fix/emergency handler

### DIFF
--- a/ros/src/system/autoware_health_checker/CMakeLists.txt
+++ b/ros/src/system/autoware_health_checker/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES node_status_publisher
+  LIBRARIES node_status_publisher system_status_subscriber
   CATKIN_DEPENDS autoware_system_msgs roscpp
 #  DEPENDS system_lib
 )

--- a/ros/src/system/emergency_handler/CMakeLists.txt
+++ b/ros/src/system/emergency_handler/CMakeLists.txt
@@ -33,7 +33,6 @@ add_dependencies(system_status_filter ${catkin_EXPORTED_TARGETS})
 
 add_library(emergency_handler lib/libemergency_handler.cpp)
 target_link_libraries(emergency_handler
-  system_status_subscriber
   system_status_filter
   ${catkin_LIBRARIES}
 )


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
@yn-mrse the _system_status_subscriber_ library was not being exported as part of _autoware_health_checker_. Since _autoware_health_checker_ is part of the `find_package` instruction the library is included in _${catkin_LIBRARIES}_

## Related PRs
#1987 