### PR TITLE
Add support guidelines link to issue template

### DIFF
--- a/docs/issue-template.md
+++ b/docs/issue-template.md
@@ -1,3 +1,6 @@
+
+Before filling out a bug report or feature request, please be sure to read the [support guidelines](https://github.com/CPFL/Autoware/wiki/Support-guidelines).
+
 Fill-out only one section depending on whether you are reporting a bug or a new feature.
 
 # Bug


### PR DESCRIPTION
Add a link to the support guidelines page on the wiki to the bug report/feature request template so that users are directed to the correct place when necessary.