### PR TITLE
fix thread handling of node_status_publisher.

### DIFF
--- a/ros/src/system/autoware_health_checker/include/autoware_health_checker/node_status_publisher.h
+++ b/ros/src/system/autoware_health_checker/include/autoware_health_checker/node_status_publisher.h
@@ -108,6 +108,8 @@ private:
   void publishStatus();
   bool node_activated_;
   std::mutex mtx_;
+  boost::thread publish_thread_;
+  bool ros_ok_;
 };
 }
 #endif // NODE_STATUS_PUBLISHER_H_INCLUDED


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
This tries to solve autowarefoundation/autoware_ai#589.

autowarefoundation/autoware#2028 couldn't path the tests because of autoware_health_checker::NodeStatusPublisher.
I think its cause is that the thread is not dead during the test.