### PR TITLE
[fix melodic] Add missing numeric header on lidar_detector

### DIFF
--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_apollo_cnn_seg_detect/include/cnn_segmentation.h
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_apollo_cnn_seg_detect/include/cnn_segmentation.h
@@ -17,6 +17,7 @@
 #define CNN_SEGMENTATION_H
 
 #include <chrono>
+#include <numeric>
 
 #include <ros/ros.h>
 


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fixes autowarefoundation/autoware_ai#595  on autowarefoundation/autoware#2032 
CUDA based node. 

Replaces autowarefoundation/autoware#2085