### PR TITLE
[fix] not predicting objects at x<=0 or y<=0

### DIFF
--- a/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/include/naive_motion_predict.h
+++ b/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/include/naive_motion_predict.h
@@ -54,6 +54,7 @@ private:
   double interval_sec_;
   int num_prediction_;
   double sensor_height_;
+  double filter_out_close_object_threshold_;
 
   void objectsCallback(const autoware_msgs::DetectedObjectArray& input);
 

--- a/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/launch/naive_motion_predict.launch
+++ b/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/launch/naive_motion_predict.launch
@@ -3,12 +3,14 @@
     <arg name="interval_sec" default="0.1"/>
     <arg name="num_prediction" default="10"/>
     <arg name="sensor_height" default="2.0"/>
+    <arg name="filter_out_close_object_threshold" default="0.1"/>
     <arg name="input_topic" default="/detection/objects"/>
 
     <node pkg="naive_motion_predict" type="naive_motion_predict" name="naive_motion_predict">
         <param name="interval_sec" value="$(arg interval_sec)"/>
         <param name="num_prediction" value="$(arg num_prediction)"/>
         <param name="sensor_height" value="$(arg sensor_height)"/>
+        <param name="filter_out_close_object_threshold" value="$(arg filter_out_close_object_threshold)"/>
     </node>
 
     <remap from="/detection/objects" to="$(arg input_topic)"/>

--- a/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/launch/naive_motion_predict.launch
+++ b/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/launch/naive_motion_predict.launch
@@ -3,7 +3,7 @@
     <arg name="interval_sec" default="0.1"/>
     <arg name="num_prediction" default="10"/>
     <arg name="sensor_height" default="2.0"/>
-    <arg name="filter_out_close_object_threshold" default="0.1"/>
+    <arg name="filter_out_close_object_threshold" default="1.5"/>
     <arg name="input_topic" default="/detection/objects"/>
 
     <node pkg="naive_motion_predict" type="naive_motion_predict" name="naive_motion_predict">

--- a/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/nodes/naive_motion_predict/naive_motion_predict.cpp
+++ b/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/nodes/naive_motion_predict/naive_motion_predict.cpp
@@ -24,7 +24,7 @@ NaiveMotionPredict::NaiveMotionPredict() :
   private_nh_.param<double>("interval_sec", interval_sec_, 0.1);
   private_nh_.param<int>("num_prediction", num_prediction_, 10);
   private_nh_.param<double>("sensor_height_", sensor_height_, 2.0);
-  private_nh_.param<double>("filter_out_close_object_threshold", filter_out_close_object_threshold_, 0.1);
+  private_nh_.param<double>("filter_out_close_object_threshold", filter_out_close_object_threshold_, 1.5);
 
   predicted_objects_pub_ = nh_.advertise<autoware_msgs::DetectedObjectArray>("/prediction/motion_predictor/objects", 1);
   predicted_paths_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/prediction/motion_predictor/path_markers", 1);

--- a/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/nodes/naive_motion_predict/naive_motion_predict.cpp
+++ b/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/nodes/naive_motion_predict/naive_motion_predict.cpp
@@ -24,6 +24,7 @@ NaiveMotionPredict::NaiveMotionPredict() :
   private_nh_.param<double>("interval_sec", interval_sec_, 0.1);
   private_nh_.param<int>("num_prediction", num_prediction_, 10);
   private_nh_.param<double>("sensor_height_", sensor_height_, 2.0);
+  private_nh_.param<double>("filter_out_close_object_threshold", filter_out_close_object_threshold_, 0.1);
 
   predicted_objects_pub_ = nh_.advertise<autoware_msgs::DetectedObjectArray>("/prediction/motion_predictor/objects", 1);
   predicted_paths_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/prediction/motion_predictor/path_markers", 1);
@@ -207,6 +208,8 @@ void NaiveMotionPredict::objectsCallback(const autoware_msgs::DetectedObjectArra
 
 bool NaiveMotionPredict::isObjectValid(const autoware_msgs::DetectedObject &in_object)
 {
+  double distance = std::sqrt(std::pow(in_object.pose.position.x,2)+
+                              std::pow(in_object.pose.position.y,2));
   if (!in_object.valid ||
       std::isnan(in_object.pose.orientation.x) ||
       std::isnan(in_object.pose.orientation.y) ||
@@ -215,6 +218,7 @@ bool NaiveMotionPredict::isObjectValid(const autoware_msgs::DetectedObject &in_o
       std::isnan(in_object.pose.position.x) ||
       std::isnan(in_object.pose.position.y) ||
       std::isnan(in_object.pose.position.z) ||
+      (distance <=  filter_out_close_object_threshold_)||
       (in_object.dimensions.x <= 0) ||
       (in_object.dimensions.y <= 0) ||
       (in_object.dimensions.z <= 0)

--- a/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/nodes/naive_motion_predict/naive_motion_predict.cpp
+++ b/ros/src/computing/perception/prediction/motion_predictor/packages/naive_motion_predict/nodes/naive_motion_predict/naive_motion_predict.cpp
@@ -215,8 +215,6 @@ bool NaiveMotionPredict::isObjectValid(const autoware_msgs::DetectedObject &in_o
       std::isnan(in_object.pose.position.x) ||
       std::isnan(in_object.pose.position.y) ||
       std::isnan(in_object.pose.position.z) ||
-      (in_object.pose.position.x <= 0) ||
-      (in_object.pose.position.y <= 0) ||
       (in_object.dimensions.x <= 0) ||
       (in_object.dimensions.y <= 0) ||
       (in_object.dimensions.z <= 0)

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -5327,7 +5327,7 @@ params :
       label : filter_out_close_object_threshold
       min     : 0.0
       max     : 10.0
-      v       : 0.1
+      v       : 1.5
       cmd_param :
         dash      : ''
         delim     : ':='

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -5322,6 +5322,15 @@ params :
       cmd_param :
         dash      : ''
         delim     : ':='
+    - name  : filter_out_close_object_threshold
+      desc  : Filtering out an object whithin this threshold
+      label : filter_out_close_object_threshold
+      min     : 0.0
+      max     : 10.0
+      v       : 0.1
+      cmd_param :
+        dash      : ''
+        delim     : ':='
 
   - name  : costmap_generator_param
     vars  :


### PR DESCRIPTION
## Status
**DEVELOPMENT**

## Description
Modify evaluation method for invalidity so that object at x<=0 or y<= 0 would be predicted. 


## Related issue
autowarefoundation/autoware_ai#618 

## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce

```
roslaunch naive_motion_predict naive_motion_predict.launch
```
Objects at x<=0 or y=0 are predicted.
You can check resulst by subscribing to `/prediction/motion_predict//prediction/motion_predictor/path_markers`