### PR TITLE
[fix] rosbag_controller's split function

### DIFF
--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/autoware_rosbag_plugin.cpp
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/autoware_rosbag_plugin.cpp
@@ -165,7 +165,7 @@ void Autoware_Rosbag_Plugin::on_button_record_start_clicked()
 
   /* Caculate max split size */
   if (split_size != 0 && ui->checkBox_split_size->isChecked())
-    recoParam.max_size = ceil(split_size * 1048576 * 1024);
+    recoParam.max_size = uint64_t(split_size * 1048576 * 1024);
   else
     recoParam.max_size = 0;
 

--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/autoware_rosbag_plugin.cpp
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/autoware_rosbag_plugin.cpp
@@ -165,7 +165,7 @@ void Autoware_Rosbag_Plugin::on_button_record_start_clicked()
 
   /* Caculate max split size */
   if (split_size != 0 && ui->checkBox_split_size->isChecked())
-    recoParam.max_size = uint64_t(split_size * 1048576 * 1024);
+    recoParam.max_size = ceil(split_size * 1000 * 1000 * 1000);
   else
     recoParam.max_size = 0;
 
@@ -243,7 +243,7 @@ int Autoware_Rosbag_Plugin::recordReq( RecordParam &recoParam )
   ROS_INFO("%s L.%d -   chunk_size      [%d]", __FUNCTION__, __LINE__, recorder_opts_->chunk_size);
   ROS_INFO("%s L.%d -   limit           [%d]", __FUNCTION__, __LINE__, recorder_opts_->limit);
   ROS_INFO("%s L.%d -   split           [%d]", __FUNCTION__, __LINE__, recorder_opts_->split);
-  ROS_INFO("%s L.%d -   max_size        [%.2fGB]", __FUNCTION__, __LINE__, recorder_opts_->max_size / 1048576.0 / 1024.0);
+  ROS_INFO("%s L.%d -   max_size        [%.2fGB]", __FUNCTION__, __LINE__, recorder_opts_->max_size / 1000.0 / 1000.0 / 1000.0);
   ROS_INFO("%s L.%d -   max_duration    [%.1fmin]", __FUNCTION__, __LINE__, recorder_opts_->max_duration.toSec() / 60.0 );
   ROS_INFO("%s L.%d -   node            [%s]", __FUNCTION__, __LINE__, recorder_opts_->node.c_str() );
   ROS_INFO("%s L.%d -   min_space       [%d]", __FUNCTION__, __LINE__, recorder_opts_->min_space );

--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/autoware_rosbag_plugin.h
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/autoware_rosbag_plugin.h
@@ -69,7 +69,7 @@ public:
       std::string filename;
       std::vector<std::string> topics;
       int max_duration;
-      uint32_t max_size;
+      uint64_t max_size;
     } RecordParam;
 
 protected:

--- a/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.h
+++ b/ros/src/util/packages/autoware_rviz_plugins/rosbag_controller/src/core/recorder.h
@@ -118,7 +118,7 @@ struct ROSBAG_DECL RecorderOptions
     uint32_t        chunk_size;
     uint32_t        limit;
     bool            split;
-    uint32_t        max_size;
+    uint64_t        max_size;
     uint32_t        max_splits;
     ros::Duration   max_duration;
     std::string     node;


### PR DESCRIPTION
## Description
**Fix**
Fix the bug of max size for split function.

**Change & Reason**
Change unit of split size from gibibytes to gigabytes.
To make sure the input size is consistent with recorded data's sized shown by Ubuntu system.

