### PR TITLE
Add .repos file for setting up an Autoware workspace using vcs

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -31,7 +31,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/utilities.git
     version: master
-  autoware/visualisation:
+  autoware/visualization:
     type: git
     url: https://github.com/autowarefoundation/visualization.git
     version: master

--- a/autoware.repos
+++ b/autoware.repos
@@ -47,7 +47,3 @@ repositories:
     type: git
     url: https://github.com/CPFL/car_demo.git
     version: e364448fad421cb6244c9f828f978d8d877dcbf9
-  lgsvl/lgsvl_msgs:
-    type: git
-    url: https://github.com/lgsvl/lgsvl_msgs.git
-    version: da97879fb78e1df3b84a60572d90faa6aea4189b

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,0 +1,53 @@
+repositories:
+  autoware/autoware:
+    type: git
+    url: git@github.com:autowarefoundation/autoware.git
+    version: master
+  autoware/core_control:
+    type: git
+    url: git@github.com:autowarefoundation/core_control.git
+    version: master
+  autoware/core_perception:
+    type: git
+    url: git@github.com:autowarefoundation/core_perception.git
+    version: master
+  autoware/core_planning:
+    type: git
+    url: git@github.com:autowarefoundation/core_planning.git
+    version: master
+  autoware/documentation:
+    type: git
+    url: git@github.com:autowarefoundation/documentation.git
+    version: master
+  autoware/messages:
+    type: git
+    url: git@github.com:autowarefoundation/messages.git
+    version: master
+  autoware/simulation:
+    type: git
+    url: git@github.com:autowarefoundation/simulation.git
+    version: master
+  autoware/utilities:
+    type: git
+    url: git@github.com:autowarefoundation/utilities.git
+    version: master
+  autoware/visualisation:
+    type: git
+    url: git@github.com:autowarefoundation/visualisation.git
+    version: master
+  drivers:
+    type: git
+    url: git@github.com:autowarefoundation/drivers.git
+    version: master
+  citysim:
+    type: git
+    url: git@github.com:CPFL/osrf_citysim.git
+    version: 53b8483d098999298498854f3795a9f01c5e8828
+  car_demo:
+    type: git
+    url: git@github.com:CPFL/car_demo.git
+    version: e364448fad421cb6244c9f828f978d8d877dcbf9
+  lgsvl/lgsvl_msgs:
+    type: git
+    url: git@github.com:lgsvl/lgsvl_msgs.git
+    version: da97879fb78e1df3b84a60572d90faa6aea4189b

--- a/autoware.repos
+++ b/autoware.repos
@@ -33,7 +33,7 @@ repositories:
     version: master
   autoware/visualisation:
     type: git
-    url: https://github.com/autowarefoundation/visualisation.git
+    url: https://github.com/autowarefoundation/visualization.git
     version: master
   drivers:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,53 +1,53 @@
 repositories:
   autoware/autoware:
     type: git
-    url: git@github.com:autowarefoundation/autoware.git
+    url: https://github.com/autowarefoundation/autoware.git
     version: master
   autoware/core_control:
     type: git
-    url: git@github.com:autowarefoundation/core_control.git
+    url: https://github.com/autowarefoundation/core_control.git
     version: master
   autoware/core_perception:
     type: git
-    url: git@github.com:autowarefoundation/core_perception.git
+    url: https://github.com/autowarefoundation/core_perception.git
     version: master
   autoware/core_planning:
     type: git
-    url: git@github.com:autowarefoundation/core_planning.git
+    url: https://github.com/autowarefoundation/core_planning.git
     version: master
   autoware/documentation:
     type: git
-    url: git@github.com:autowarefoundation/documentation.git
+    url: https://github.com/autowarefoundation/documentation.git
     version: master
   autoware/messages:
     type: git
-    url: git@github.com:autowarefoundation/messages.git
+    url: https://github.com/autowarefoundation/messages.git
     version: master
   autoware/simulation:
     type: git
-    url: git@github.com:autowarefoundation/simulation.git
+    url: https://github.com/autowarefoundation/simulation.git
     version: master
   autoware/utilities:
     type: git
-    url: git@github.com:autowarefoundation/utilities.git
+    url: https://github.com/autowarefoundation/utilities.git
     version: master
   autoware/visualisation:
     type: git
-    url: git@github.com:autowarefoundation/visualisation.git
+    url: https://github.com/autowarefoundation/visualisation.git
     version: master
   drivers:
     type: git
-    url: git@github.com:autowarefoundation/drivers.git
+    url: https://github.com/autowarefoundation/drivers.git
     version: master
   citysim:
     type: git
-    url: git@github.com:CPFL/osrf_citysim.git
+    url: https://github.com/CPFL/osrf_citysim.git
     version: 53b8483d098999298498854f3795a9f01c5e8828
   car_demo:
     type: git
-    url: git@github.com:CPFL/car_demo.git
+    url: https://github.com/CPFL/car_demo.git
     version: e364448fad421cb6244c9f828f978d8d877dcbf9
   lgsvl/lgsvl_msgs:
     type: git
-    url: git@github.com:lgsvl/lgsvl_msgs.git
+    url: https://github.com/lgsvl/lgsvl_msgs.git
     version: da97879fb78e1df3b84a60572d90faa6aea4189b


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Use the [`vcs` tool](https://github.com/dirk-thomas/vcstool) to set up an Autoware workspace when building from source.

### Implementation description

This provides the `autoware.repos` file, which is a description of the repositories and versions that need to be checked out into a workspace to build Autoware from source.

This version of the file is for the `master` branch of Autoware. Versions can be made in tags of this repository to provide different versions, such as the 1.12 release.