### PR TITLE
Update gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,6 @@ variables:
     - wstool init
     - test -f "${ROSINSTALL_FILE}" && wstool merge "${ROSINSTALL_FILE}"
     - wstool up
-    - cd ..
     - rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} 
     
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,12 +21,15 @@ variables:
     - apt-get install -y dpkg
     - apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-${ROS_DISTRO}-catkin
     - apt-get install -y python3-pip python3-setuptools
+    - apt-get install -y python3-vcstool
     # Update setuptools from PyPI because the version Ubuntu ships with is too old
     - pip3 install -U setuptools
     - source /opt/ros/${ROS_DISTRO}/setup.bash
     - rosdep init
     - rosdep update
-    - cd ros/src
+    - mkdir -p $CI_PROJECT_DIR/../autoware.ai/src
+    - cd $CI_PROJECT_DIR/../autoware.ai
+    - vcs import src < $CI_PROJECT_DIR/autoware.repos
     - wstool init
     - test -f "${ROSINSTALL_FILE}" && wstool merge "${ROSINSTALL_FILE}"
     - wstool up


### PR DESCRIPTION
<!--
For support requests, general questions and design discussion, please ask on the Autoware Discourse category: https://discourse.ros.org/c/autoware
Not sure if this is the right repository? Open an issue on https://github.com/autowarefoundation/autoware/issues
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug
<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

The gitlab CI loop is not using the new `.repos` file.

### Fix applied
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->
The gitlab-ci.yml  has been updated to use the new `.repos` file. It creates a build `autoware.ai` folder to build and run tests inside. 

This implementation needs to be updated in the future when the new repositories are populated with the appropriate packages.