### PR TITLE
Fix param type of deceleration_range

### DIFF
--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -1744,7 +1744,7 @@ params :
       label : Deceleration Range (m)
       min   : 0
       max   : 10
-      v     : 0
+      v     : 0.0
     - name  : threshold_points
       desc  : threshold_points desc sample
       label : Points Threshold


### PR DESCRIPTION
## Bug fix

### Fixed bug

When set `deceleration_range` parameter used in `velocity_set` , we can set only an int number from runtime_manager. The parameter is actually defined [here](https://github.com/autowarefoundation/autoware/blob/master/ros/src/msgs/autoware_config_msgs/msg/ConfigVelocitySet.msg) as float32.

### Fix applied

In yaml file for runtime_manager, the parameter is recognized as an int by writing 0 as the default value. If it is 0.0, it becomes float.

