### PR TITLE
Fix gazebo not found in colcon_release_cross

### DIFF
--- a/ros/colcon_release_cross
+++ b/ros/colcon_release_cross
@@ -52,7 +52,7 @@ END
     echo "Using toolchain file: '${AUTOWARE_TOOLCHAIN_FILE_PATH}''"
     AUTOWARE_SYSROOT=/sysroot/${AUTOWARE_TARGET_PLATFORM}
 
-    AUTOWARE_DOCKER_DATE=20190102
+    AUTOWARE_DOCKER_DATE=20190211
 
     docker container run \
         -it \


### PR DESCRIPTION
## Bug fix

### Fixed bug
colcon_release_cross fails at 2fbad6d64f9d71e4b1b5e1de9008ca63f3b44fa1.

```
$ cd Autoware/ros
$ git checkout 2fbad6d64f9d71e4b1b5e1de9008ca63f3b44fa1
$ ./colcon_release_cross synquacer
...
Starting >>> waypoint_follower
[69.564s] ERROR:asyncio:Task exception was never retrieved                                                                                                                                                                                                                                                                                                                            
future: <Task finished coro=<_wait_and_close_fds() done, defined at /usr/lib/python3/dist-packages/colcon_core/subprocess.py:253> exception=RuntimeError('cannot reuse already awaited coroutine',)>
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
RuntimeError: cannot reuse already awaited coroutine
--- stderr: citysim                                                                                                                                                                                                                                                                                                                                                          
CMake Error at CMakeLists.txt:27 (find_package):
  By not providing "Findgazebo.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "gazebo", but
  CMake did not find one.

  Could not find a package configuration file provided by "gazebo" with any
  of the following names:

    gazeboConfig.cmake
    gazebo-config.cmake

  Add the installation prefix of "gazebo" to CMAKE_PREFIX_PATH or set
  "gazebo_DIR" to a directory containing one of the above files.  If "gazebo"
  provides a separate development package or SDK, be sure it has been
  installed.
...
```

### Fix applied
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

Use the docker image  which is used in GitLab CI.
https://github.com/autowarefoundation/autoware/blob/2fbad6d64f9d71e4b1b5e1de9008ca63f3b44fa1/.gitlab-ci.yml#L87