### PR TITLE
Fix Melodic Cross-Build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,14 +36,7 @@ variables:
     - cd ..
     - rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}
 
-.build_cross: &build_cross
-  stage: build
-  image: docker
-  services:
-    - docker:dind
-  variables:
-    ROS_DISTRO: kinetic
-    AUTOWARE_DOCKER_DATE: 20190521
+.build_cross_vars: &build_cross_vars
     AUTOWARE_HOME: $CI_PROJECT_DIR
     AUTOWARE_TARGET_ARCH: aarch64
     AUTOWARE_TARGET_PLATFORM: generic-aarch64
@@ -51,8 +44,9 @@ variables:
     AUTOWARE_INSTALL_PATH: $CI_PROJECT_DIR/ros/install-${AUTOWARE_TARGET_PLATFORM}
     AUTOWARE_TOOLCHAIN_FILE_PATH: $CI_PROJECT_DIR/ros/cross_toolchain.cmake
     AUTOWARE_SYSROOT: /sysroot/${AUTOWARE_TARGET_PLATFORM}
+
+.build_cross_script: &build_cross_script
   script:
-    # - ${AUTOWARE_HOME}/docker/crossbuild/build_cross_image.sh
     - 'docker run
           -e AUTOWARE_SYSROOT=${AUTOWARE_SYSROOT}
           --rm
@@ -155,14 +149,26 @@ build_melodic:
   coverage: /\s*lines.*:\s(\d+\.\d+\%\s\(\d+\sof\s\d+.*\))/
 
 build_kinetic_cross:
+  stage: build
+  image: docker
+  services:
+    - docker:dind
   variables:
-      ROS_DISTRO: kinetic
-  <<: *build_cross
+    ROS_DISTRO: kinetic
+    AUTOWARE_DOCKER_DATE: "20190521"
+    <<: *build_cross_vars
+  <<: *build_cross_script
 
 build_melodic_cross:
+  stage: build
+  image: docker
+  services:
+    - docker:dind
   variables:
-      ROS_DISTRO: melodic
-  <<: *build_cross
+    ROS_DISTRO: melodic
+    AUTOWARE_DOCKER_DATE: "20190306"
+    <<: *build_cross_vars
+  <<: *build_cross_script
 
 pages:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,7 @@ variables:
                     --merge-install
                     --build-base ${AUTOWARE_BUILD_PATH}
                     --install-base ${AUTOWARE_INSTALL_PATH}
+                    --packages-skip citysim
                     --cmake-args
                     -DPYTHON_EXECUTABLE=/usr/bin/python3
                     -DCMAKE_TOOLCHAIN_FILE=${AUTOWARE_TOOLCHAIN_FILE_PATH}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,7 +166,7 @@ build_melodic_cross:
     - docker:dind
   variables:
     ROS_DISTRO: melodic
-    AUTOWARE_DOCKER_DATE: "20190306"
+    AUTOWARE_DOCKER_DATE: "20190521"
     <<: *build_cross_vars
   <<: *build_cross_script
 

--- a/docker/crossbuild/Dockerfile.kinetic-crossbuild
+++ b/docker/crossbuild/Dockerfile.kinetic-crossbuild
@@ -7,9 +7,6 @@ ARG AUTOWARE_TARGET_ARCH
 
 COPY --from=bootstrap /usr/bin/qemu-${AUTOWARE_TARGET_ARCH}-static /usr/bin/qemu-${AUTOWARE_TARGET_ARCH}-static
 
-RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" | tee /etc/apt/sources.list.d/ros-latest.list
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     lsb-release \
@@ -47,7 +44,7 @@ COPY --from=sysroot /usr/share/pkgconfig ${AUTOWARE_SYSROOT}/usr/share/pkgconfig
 COPY --from=sysroot /opt ${AUTOWARE_SYSROOT}/opt
 COPY --from=sysroot /etc/alternatives ${AUTOWARE_SYSROOT}/etc/alternatives
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" | tee /etc/apt/sources.list.d/ros-latest.list
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cython \
     crossbuild-essential-arm64 \

--- a/docker/crossbuild/Dockerfile.kinetic-crossbuild-driveworks
+++ b/docker/crossbuild/Dockerfile.kinetic-crossbuild-driveworks
@@ -1,7 +1,7 @@
 ARG AUTOWARE_DOCKER_ARCH
 ARG AUTOWARE_TARGET_ARCH
 ARG AUTOWARE_TARGET_PLATFORM
-FROM autoware/build:${AUTOWARE_TARGET_PLATFORM}-kinetic-20190306
+FROM autoware/build:${AUTOWARE_TARGET_PLATFORM}-kinetic-20190521
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential
 COPY crossbuild/files/FindCUDA.cmake /usr/share/cmake-3.5/Modules/FindCUDA.cmake

--- a/docker/crossbuild/Dockerfile.melodic-crossbuild
+++ b/docker/crossbuild/Dockerfile.melodic-crossbuild
@@ -105,7 +105,4 @@ ENV CXX /usr/bin/${AUTOWARE_TARGET_ARCH}-linux-gnu-g++
 ENV AR /usr/bin/${AUTOWARE_TARGET_ARCH}-linux-gnu-ar
 ENV CPP /usr/bin/${AUTOWARE_TARGET_ARCH}-linux-gnu-cpp
 
-RUN ln -s ${AUTOWARE_SYSROOT}/opt/ros/melodic/include /opt/ros/melodic/include
-RUN ln -s ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/orocos_kdl /opt/ros/melodic/share/orocos_kdl
-
 CMD . /opt/ros/melodic/setup.sh && /bin/bash

--- a/docker/crossbuild/Dockerfile.melodic-crossbuild
+++ b/docker/crossbuild/Dockerfile.melodic-crossbuild
@@ -192,6 +192,8 @@ ENV AUTOWARE_SYSROOT /sysroot/${AUTOWARE_TARGET_PLATFORM}
 COPY --from=sysroot /lib ${AUTOWARE_SYSROOT}/lib
 COPY --from=sysroot /usr/include ${AUTOWARE_SYSROOT}/usr/include
 COPY --from=sysroot /usr/lib ${AUTOWARE_SYSROOT}/usr/lib
+COPY --from=sysroot /usr/share/OGRE ${AUTOWARE_SYSROOT}/usr/share/OGRE
+COPY --from=sysroot /usr/share/OpenCV ${AUTOWARE_SYSROOT}/usr/share/OpenCV
 COPY --from=sysroot /usr/share/pkgconfig ${AUTOWARE_SYSROOT}/usr/share/pkgconfig
 COPY --from=sysroot /opt ${AUTOWARE_SYSROOT}/opt
 COPY --from=sysroot /etc/alternatives ${AUTOWARE_SYSROOT}/etc/alternatives
@@ -212,6 +214,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-catkin
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/opt/ros/melodic/include#${AUTOWARE_SYSROOT}/opt/ros/melodic/include#g" {} \;
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/opt/ros/melodic/lib#${AUTOWARE_SYSROOT}/opt/ros/melodic/lib#g" {} \;
+RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/opt/ros/melodic/share#${AUTOWARE_SYSROOT}/opt/ros/melodic/share#g" {} \;
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/usr/include#${AUTOWARE_SYSROOT}/usr/include#g" {} \;
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/usr/lib#${AUTOWARE_SYSROOT}/usr/lib#g" {} \;
 RUN find ${AUTOWARE_SYSROOT}/usr/lib/cmake/ -name "*.cmake" -type f -exec sed -i -e "s#/usr/lib/${AUTOWARE_TARGET_ARCH}-linux-gnu#${AUTOWARE_SYSROOT}/usr/lib/${AUTOWARE_TARGET_ARCH}-linux-gnu#g" {} \;
@@ -221,9 +224,9 @@ RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/lib/pkgconfig/ -name "*.pc" -type f
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/lib/pkgconfig/ -name "*.pc" -type f -exec sed -i -e "s#-I/usr/include#-I${AUTOWARE_SYSROOT}/usr/include#g" {} \;
 RUN find ${AUTOWARE_SYSROOT}/ -name "*.pc" -type f -exec sed -i -e "s#prefix=/#prefix=${AUTOWARE_SYSROOT}/#g" {} \;
 RUN sed -i -e "s#/usr#${AUTOWARE_SYSROOT}/usr#g" ${AUTOWARE_SYSROOT}/usr/lib/${AUTOWARE_TARGET_ARCH}-linux-gnu/cmake/pcl/PCLConfig.cmake
-RUN sed -i -e "s#set(imported_location \"\${_qt5Widgets_install_prefix}/lib/${AUTOWARE_TARGET_ARCH}-linux-gnu/qt5/bin/uic\")#set(imported_location \"/usr/lib/x86_64-linux-gnu/qt5/bin/uic\")#g" \
+RUN sed -i -e "s#set(imported_location \"\${_qt5Widgets_install_prefix}/lib/qt5/bin/uic\")#set(imported_location \"/usr/lib/x86_64-linux-gnu/qt5/bin/uic\")#g" \
     ${AUTOWARE_SYSROOT}/usr/lib/${AUTOWARE_TARGET_ARCH}-linux-gnu/cmake/Qt5Widgets/Qt5WidgetsConfigExtras.cmake
-RUN sed -i -e "s#set(imported_location \"\${_qt5Core_install_prefix}/lib/${AUTOWARE_TARGET_ARCH}-linux-gnu/qt5/bin/#set(imported_location \"/usr/lib/x86_64-linux-gnu/qt5/bin/#g" \
+RUN sed -i -e "s#set(imported_location \"\${_qt5Core_install_prefix}/lib/qt5/bin/#set(imported_location \"/usr/lib/x86_64-linux-gnu/qt5/bin/#g" \
     ${AUTOWARE_SYSROOT}/usr/lib/${AUTOWARE_TARGET_ARCH}-linux-gnu/cmake/Qt5Core/Qt5CoreConfigExtras.cmake
 RUN sed -i -e "s#define ARMA_SUPERLU_INCLUDE_DIR /usr/include/superlu/#define ARMA_SUPERLU_INCLUDE_DIR ${AUTOWARE_SYSROOT}/usr/include/superlu/#g" \
     ${AUTOWARE_SYSROOT}/usr/include/armadillo_bits/config.hpp

--- a/docker/crossbuild/Dockerfile.melodic-crossbuild
+++ b/docker/crossbuild/Dockerfile.melodic-crossbuild
@@ -2,186 +2,47 @@ ARG AUTOWARE_DOCKER_ARCH
 ARG AUTOWARE_TARGET_ARCH
 FROM multiarch/alpine:${AUTOWARE_TARGET_ARCH}-latest-stable AS bootstrap
 
-FROM ${AUTOWARE_DOCKER_ARCH}/ubuntu:18.04 AS sysroot
+FROM ${AUTOWARE_DOCKER_ARCH}/ros:melodic-perception AS sysroot
 ARG AUTOWARE_TARGET_ARCH
 
 COPY --from=bootstrap /usr/bin/qemu-${AUTOWARE_TARGET_ARCH}-static /usr/bin/qemu-${AUTOWARE_TARGET_ARCH}-static
 
-RUN apt-get update
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg
 
-RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" | tee /etc/apt/sources.list.d/ros-latest.list
-RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
     curl \
     lsb-release \
     python-rosdep \
-    sudo
-
-# adwaita-icon-theme humanity-icon-theme and ubuntu-mono install the following as dependencies,
-# however when attempting to installing the former, dpkg fails due to an unknown error, so we
-# install the separately
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    fontconfig \
-    fontconfig-config \
-    fonts-dejavu-core \
+    sudo \
     gtk-update-icon-cache \
-    hicolor-icon-theme \
-    libbsd0 \
-    libcairo2 \
-    libcroco3 \
-    libdatrie1 \
-    libfontconfig1 \
-    libfreetype6 \
-    libgdk-pixbuf2.0-0 \
-    libgdk-pixbuf2.0-common \
     libglib2.0-0 \
-    libgraphite2-3 \
-    libharfbuzz0b \
-    libicu60 \
-    libjbig0 \
-    libjpeg-turbo8 \
-    libjpeg8 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libpangoft2-1.0-0 \
-    libpixman-1-0 \
-    libpng16-16 \
-    librsvg2-2 \
-    librsvg2-common \
-    libthai-data \
-    libthai0 \
-    libtiff5 \
-    libx11-6 \
-    libx11-data \
-    libxau6 \
-    libxcb-render0 \
-    libxcb-shm0 \
-    libxcb1 \
-    libxdmcp6 \
-    libxext6 \
-    libxml2 \
-    libxrender1 \
-    multiarch-support \
-    shared-mime-info \
-    ucf
+    libglib2.0-bin \
+    libglib2.0-dev \
+    libglib2.0-dev-bin \
+    libpng-dev \
+    libpng-dev libpng-tools \
+    libpng-tools \
+    libpng16-16
 
-# Install these adwaita-icon-theme humanity-icon-theme and ubuntu-mono separately to avoid
-# dpkg errors
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    adwaita-icon-theme \
-    humanity-icon-theme \
-    ubuntu-mono
+# Install ROS packages used by Autoware
+COPY ./dependencies /tmp/dependencies
+RUN apt-get update && \
+    sed "s/\$ROS_DISTRO/$ROS_DISTRO/g" "/tmp/dependencies" | xargs apt-get install -y
 
 # Autoware dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    cython \
-    freeglut3-dev \
-    gstreamer1.0-plugins-good \
+RUN apt-get install -y --no-install-recommends \
     libarmadillo-dev \
-    libcurl4-openssl-dev \
-    libeigen3-dev \
     libgflags-dev \
-    libgl1-mesa-dev \
     libglew-dev \
-    libglu1-mesa-dev \
     libgoogle-glog-dev \
-    libgstreamer-plugins-good1.0-0 \
-    libgtest-dev \
     libnlopt-dev \
     libopencv-dev \
-    libpcap0.8-dev \
-    libpcl-dev \
-    libqt5core5a \
-    libqt5gui5 \
-    libqt5opengl5 \
-    libqt5opengl5-dev \
-    libqt5widgets5 \
     libssh2-1 \
-    libtinyxml-dev \
-    libx11-dev \
-    libxi-dev \
-    libxml2-dev \
-    libxmu-dev \
-    libyaml-cpp-dev \
     python-flask \
-    python-scipy \
-    python-serial \
-    python-skimage \
-    qtbase5-dev \
-    ros-melodic-angles \
-    ros-melodic-automotive-platform-msgs \
-    ros-melodic-camera-info-manager \
-    ros-melodic-catkin \
-    ros-melodic-cmake-modules \
-    ros-melodic-cv-bridge \
-    ros-melodic-diagnostic-aggregator \
-    ros-melodic-diagnostic-msgs \
-    ros-melodic-diagnostic-updater \
-    ros-melodic-dynamic-reconfigure \
-    ros-melodic-eigen-conversions \
-    ros-melodic-filters \
-    ros-melodic-geometry-msgs \
-    ros-melodic-gps-common \
-    ros-melodic-grid-map-cv \
-    ros-melodic-grid-map-msgs \
-    ros-melodic-grid-map-ros \
-    ros-melodic-gscam \
-    ros-melodic-image-geometry \
-    ros-melodic-image-transport \
-    ros-melodic-imu-filter-madgwick \
-    ros-melodic-imu-tools \
-    ros-melodic-jsk-footstep-msgs \
-    ros-melodic-jsk-gui-msgs \
-    ros-melodic-jsk-hark-msgs \
-    ros-melodic-jsk-recognition-msgs \
-    ros-melodic-jsk-rviz-plugins \
     ros-melodic-jsk-tools \
-    ros-melodic-jsk-topic-tools \
-    ros-melodic-message-filters \
-    ros-melodic-message-generation \
-    ros-melodic-message-runtime \
-    ros-melodic-nav-msgs \
-    ros-melodic-nlopt \
-    ros-melodic-nmea-msgs \
-    ros-melodic-nodelet \
-    ros-melodic-pcl-conversions \
-    ros-melodic-pcl-msgs \
-    ros-melodic-pcl-ros \
-    ros-melodic-people-msgs \
-    ros-melodic-pluginlib \
-    ros-melodic-posedetection-msgs \
-    ros-melodic-robot-state-publisher \
-    ros-melodic-rosbridge-server \
-    ros-melodic-rosconsole \
-    ros-melodic-roscpp \
-    ros-melodic-roslaunch \
-    ros-melodic-roslib \
-    ros-melodic-roslint \
-    ros-melodic-rospy \
-    ros-melodic-rostest \
-    ros-melodic-rosunit \
-    ros-melodic-rqt-plot \
-    ros-melodic-rviz \
-    ros-melodic-sensor-msgs \
-    ros-melodic-shape-msgs \
-    ros-melodic-sound-play \
-    ros-melodic-std-msgs \
-    ros-melodic-std-srvs \
-    ros-melodic-stereo-msgs \
-    ros-melodic-tf \
-    ros-melodic-tf-conversions \
-    ros-melodic-tf2 \
-    ros-melodic-tf2-geometry-msgs \
-    ros-melodic-tf2-ros \
-    ros-melodic-urdfdom-py \
-    ros-melodic-view-controller-msgs \
-    ros-melodic-visualization-msgs \
-    ros-melodic-xacro \
-    v4l-utils
+    ros-melodic-nlopt && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN find / -depth -xdev -type l -lname '/*' -exec sh -c 'linkpath="$(readlink {})" && rm -f {} && ln -frsv "$linkpath" "{}"' \;
 
@@ -243,4 +104,8 @@ ENV CC /usr/bin/${AUTOWARE_TARGET_ARCH}-linux-gnu-gcc
 ENV CXX /usr/bin/${AUTOWARE_TARGET_ARCH}-linux-gnu-g++
 ENV AR /usr/bin/${AUTOWARE_TARGET_ARCH}-linux-gnu-ar
 ENV CPP /usr/bin/${AUTOWARE_TARGET_ARCH}-linux-gnu-cpp
+
+RUN ln -s ${AUTOWARE_SYSROOT}/opt/ros/melodic/include /opt/ros/melodic/include
+RUN ln -s ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/orocos_kdl /opt/ros/melodic/share/orocos_kdl
+
 CMD . /opt/ros/melodic/setup.sh && /bin/bash

--- a/docker/crossbuild/Dockerfile.melodic-crossbuild
+++ b/docker/crossbuild/Dockerfile.melodic-crossbuild
@@ -58,13 +58,16 @@ COPY --from=sysroot /usr/share/OpenCV ${AUTOWARE_SYSROOT}/usr/share/OpenCV
 COPY --from=sysroot /usr/share/pkgconfig ${AUTOWARE_SYSROOT}/usr/share/pkgconfig
 COPY --from=sysroot /opt ${AUTOWARE_SYSROOT}/opt
 COPY --from=sysroot /etc/alternatives ${AUTOWARE_SYSROOT}/etc/alternatives
+
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     tzdata
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg
+
 RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" | tee /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cython \
     crossbuild-essential-arm64 \
@@ -73,6 +76,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     qt5-qmake \
     qtbase5-dev-tools \
     ros-melodic-catkin
+
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/opt/ros/melodic/include#${AUTOWARE_SYSROOT}/opt/ros/melodic/include#g" {} \;
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/opt/ros/melodic/lib#${AUTOWARE_SYSROOT}/opt/ros/melodic/lib#g" {} \;
 RUN find ${AUTOWARE_SYSROOT}/opt/ros/melodic/share/ -name "*.cmake" -type f -exec sed -i -e "s#/opt/ros/melodic/share#${AUTOWARE_SYSROOT}/opt/ros/melodic/share#g" {} \;

--- a/docker/crossbuild/Dockerfile.melodic-crossbuild-driveworks
+++ b/docker/crossbuild/Dockerfile.melodic-crossbuild-driveworks
@@ -4,5 +4,5 @@ ARG AUTOWARE_TARGET_PLATFORM
 FROM autoware/build:${AUTOWARE_TARGET_PLATFORM}-melodic-20190306
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential
-COPY files/FindCUDA.cmake /usr/share/cmake-3.10/Modules/FindCUDA.cmake
+COPY crossbuild/files/FindCUDA.cmake /usr/share/cmake-3.10/Modules/FindCUDA.cmake
 CMD . /opt/ros/melodic/setup.sh && /bin/bash

--- a/docker/dependencies
+++ b/docker/dependencies
@@ -23,7 +23,6 @@ ros-$ROS_DISTRO-pacmod-msgs
 ros-$ROS_DISTRO-position-controllers
 ros-$ROS_DISTRO-rosbridge-server
 ros-$ROS_DISTRO-sound-play
-ros-$ROS_DISTRO-tf-conversions
 ros-$ROS_DISTRO-transmission-interface
 ros-$ROS_DISTRO-velocity-controllers
 ros-$ROS_DISTRO-velodyne

--- a/docker/dependencies
+++ b/docker/dependencies
@@ -23,6 +23,7 @@ ros-$ROS_DISTRO-pacmod-msgs
 ros-$ROS_DISTRO-position-controllers
 ros-$ROS_DISTRO-rosbridge-server
 ros-$ROS_DISTRO-sound-play
+ros-$ROS_DISTRO-tf-conversions
 ros-$ROS_DISTRO-transmission-interface
 ros-$ROS_DISTRO-velocity-controllers
 ros-$ROS_DISTRO-velodyne

--- a/ros/colcon_release_cross
+++ b/ros/colcon_release_cross
@@ -53,7 +53,7 @@ END
     echo "Using toolchain file: '${AUTOWARE_TOOLCHAIN_FILE_PATH}''"
     AUTOWARE_SYSROOT=/sysroot/${AUTOWARE_TARGET_PLATFORM}
 
-    AUTOWARE_DOCKER_DATE=20190306
+    AUTOWARE_DOCKER_DATE=20190521
 
     docker container run \
         -it \


### PR DESCRIPTION
This PR fixes the following issues:

- Gitlab CI script was building both cross-build targets (Kinetic and Melodic) on the Kinetic Docker image.
- Gitlab CI script did not allow different build dates for Kinetic and Melodic.
- Fixes errors with CMake, OGRE, OpenCV, and orocos_kdl in the Docker.melodic-crossbuild image.

This PR adds the following new features:

- Kinetic and Melodic cross-build targets for CI now use the official arm64v8/ros images as their bases. This speeds up build time significantly.
- Many unnecessary calls to `apt-get update` were removed.
- Many redundant system dependencies were removed.
- All ROS dependencies now reside in the autoware/docker/dependencies file.

Known issues with this PR:

- The `citysim` package is temporarily removed from cross-building due to a CMake issue in the cross-build environment that only affects this package. It's a complex problem involving old CMake code and `pthreads` in cross-build environments so I figured it wasn't worth the hassle right now due to discussion in autowarefoundation/autoware_ai#634.
- This PR fixes the cross-build images and CI. The bash scripts for `generic` image builds and the `colcon_release_cross.sh` script still have issues.