### PR TITLE
Fix launch param name publish_objects in lidar_fake_perception.launch

### DIFF
--- a/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/launch/lidar_fake_perception.launch
+++ b/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/launch/lidar_fake_perception.launch
@@ -43,7 +43,7 @@
     <remap from="/fake_objects" to="$(arg fake_objects_topic)"/>
     <remap from="/fake_points" to="$(arg fake_points_topic)"/>
 
-    <param name="publish_object" value="$(arg publish_object)"/>
+    <param name="publish_objects" value="$(arg publish_objects)"/>
     <param name="publish_points" value="$(arg publish_points)"/>
     <param name="publish_rate" value="$(arg publish_rate)"/>
     <param name="object_length" value="$(arg object_length)"/>


### PR DESCRIPTION
## Bug fix

### Fixed bug
The launch file sets `publish_object`, while the node looks `publish_objects`.
https://github.com/autowarefoundation/autoware/blob/b734f194f9567953691be920378a8db3915592c8/ros/src/computing/perception/detection/lidar_detector/packages/lidar_fake_perception/nodes/lidar_fake_perception.cpp#L8

### Fix applied
Fix the typo above.