### PR TITLE
Remove ouster submodule (Fixes #2158)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,10 +5,6 @@
 [submodule "ros/src/msgs/lgsvl_msgs"]
 	path = ros/src/msgs/lgsvl_msgs
 	url = https://github.com/lgsvl/lgsvl_msgs.git
-[submodule "ros/src/sensing/drivers/lidar/packages/ouster"]
-	path = ros/src/sensing/drivers/lidar/packages/ouster
-	url = https://github.com/CPFL/ouster
-	branch = autoware_branch
 [submodule "ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim"]
 	path = ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim
 	url = https://github.com/CPFL/osrf_citysim.git


### PR DESCRIPTION
Remove ouster submodule to simplify branch/version management in support of switching to a vcs-based install.