### PR TITLE
Remove robosense submodule (Fixes #2159)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "ros/src/sensing/drivers/lidar/packages/robosense"]
-	path = ros/src/sensing/drivers/lidar/packages/robosense
-	url = https://github.com/CPFL/robosense
-	branch = develop-curves-function
 [submodule "ros/src/msgs/lgsvl_msgs"]
 	path = ros/src/msgs/lgsvl_msgs
 	url = https://github.com/lgsvl/lgsvl_msgs.git


### PR DESCRIPTION
Remove robosense submodule to simplify branch/version management in support of switching to a vcs-based install.