### PR TITLE
Remove car_demo submodule (Fixes #2160)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,9 +12,6 @@
 [submodule "ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim"]
 	path = ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim
 	url = https://github.com/CPFL/osrf_citysim.git
-[submodule "ros/src/simulation/gazebo_simulator/worlds/external/car_demo"]
-	path = ros/src/simulation/gazebo_simulator/worlds/external/car_demo
-	url = https://github.com/CPFL/car_demo.git
 [submodule "ros/src/util/packages/ds4"]
 	path = ros/src/util/packages/ds4
 	url = https://github.com/tier4/ds4


### PR DESCRIPTION
Remove car_demo submodule to simplify branch/version management in support of switching to a vcs-based install.