### PR TITLE
Remove citysim submodule (Fixes #2156)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,9 +9,6 @@
 	path = ros/src/sensing/drivers/lidar/packages/ouster
 	url = https://github.com/CPFL/ouster
 	branch = autoware_branch
-[submodule "ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim"]
-	path = ros/src/simulation/gazebo_simulator/worlds/external/osrf_citysim
-	url = https://github.com/CPFL/osrf_citysim.git
 [submodule "ros/src/simulation/gazebo_simulator/worlds/external/car_demo"]
 	path = ros/src/simulation/gazebo_simulator/worlds/external/car_demo
 	url = https://github.com/CPFL/car_demo.git


### PR DESCRIPTION
Remove citysim submodule to simplify branch/version management in support of switching to a vcs-based install.