### PR TITLE
Remove ds4 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,6 +15,3 @@
 [submodule "ros/src/simulation/gazebo_simulator/worlds/external/car_demo"]
 	path = ros/src/simulation/gazebo_simulator/worlds/external/car_demo
 	url = https://github.com/CPFL/car_demo.git
-[submodule "ros/src/util/packages/ds4"]
-	path = ros/src/util/packages/ds4
-	url = https://github.com/tier4/ds4


### PR DESCRIPTION
Remove ds4 submodule to simplify branch/version management in support of switching to a vcs-based install.