### PR TITLE
Remove lgsvl_msgs submodule (Fixes #2157)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,9 +2,6 @@
 	path = ros/src/sensing/drivers/lidar/packages/robosense
 	url = https://github.com/CPFL/robosense
 	branch = develop-curves-function
-[submodule "ros/src/msgs/lgsvl_msgs"]
-	path = ros/src/msgs/lgsvl_msgs
-	url = https://github.com/lgsvl/lgsvl_msgs.git
 [submodule "ros/src/sensing/drivers/lidar/packages/ouster"]
 	path = ros/src/sensing/drivers/lidar/packages/ouster
 	url = https://github.com/CPFL/ouster


### PR DESCRIPTION
Remove lgsvl_msgs submodule to simplify branch/version management in support of switching to a vcs-based install.