### PR TITLE
Fix Melodic Builds (All of Them)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,9 +15,7 @@ variables:
     - apt-get update
     # Use UTC for tzdata
     - DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
-    - apt-get install -y gnupg2
-    - apt-get install -y lsb-release
-    - apt-get install -y gcc g++
+    - apt-get install -y gnupg2 lsb-release gcc g++
     - sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
     - apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
     - apt-get update
@@ -72,7 +70,7 @@ variables:
 
 build_kinetic:
   stage: build
-  image: ubuntu:xenial
+  image: ros:kinetic-perception
   variables:
     ROS_DISTRO: kinetic
   <<: *build_common
@@ -114,7 +112,7 @@ build_kinetic:
 
 build_melodic:
   stage: build
-  image: ubuntu:bionic
+  image: ros:melodic-perception
   variables:
     ROS_DISTRO: melodic
   <<: *build_common

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ variables:
     # Update setuptools from PyPI because the version Ubuntu ships with is too old
     - pip3 install -U setuptools
     - source /opt/ros/${ROS_DISTRO}/setup.bash
-    - rosdep init
     - rosdep update
     - cd ros/src
     - wstool init

--- a/docker/crossbuild/Dockerfile.melodic-crossbuild-driveworks
+++ b/docker/crossbuild/Dockerfile.melodic-crossbuild-driveworks
@@ -1,7 +1,7 @@
 ARG AUTOWARE_DOCKER_ARCH
 ARG AUTOWARE_TARGET_ARCH
 ARG AUTOWARE_TARGET_PLATFORM
-FROM autoware/build:${AUTOWARE_TARGET_PLATFORM}-melodic-20190306
+FROM autoware/build:${AUTOWARE_TARGET_PLATFORM}-melodic-20190521
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential
 COPY crossbuild/files/FindCUDA.cmake /usr/share/cmake-3.10/Modules/FindCUDA.cmake


### PR DESCRIPTION
Should fix all Melodic and Kinetic builds on the Melodic branch (mostly through `citysim` update). Uses official `ros` Dockerhub images. Updates build date for Melodic driveworks Dockerfile.