### PR TITLE
lane_select: parameterize minimum_dt

### DIFF
--- a/ros/src/computing/planning/mission/packages/lane_planner/include/lane_select_core.h
+++ b/ros/src/computing/planning/mission/packages/lane_planner/include/lane_select_core.h
@@ -90,6 +90,7 @@ private:
   // parameter from runtime manager
   double distance_threshold_, lane_change_interval_, lane_change_target_ratio_, lane_change_target_minimum_,
       vlength_hermite_curve_;
+  int search_closest_waypoint_minimum_dt_;
 
   // topics
   geometry_msgs::PoseStamped current_pose_;
@@ -144,7 +145,7 @@ private:
 
 int32_t getClosestWaypointNumber(const autoware_msgs::Lane& current_lane, const geometry_msgs::Pose& current_pose,
                                  const geometry_msgs::Twist& current_velocity, const int32_t previous_number,
-                                 const double distance_threshold);
+                                 const double distance_threshold, const int search_closest_waypoint_minimum_dt);
 
 double getTwoDimensionalDistance(const geometry_msgs::Point& target1, const geometry_msgs::Point& target2);
 

--- a/ros/src/computing/planning/mission/packages/lane_planner/launch/lane_select.launch
+++ b/ros/src/computing/planning/mission/packages/lane_planner/launch/lane_select.launch
@@ -1,5 +1,8 @@
 <!-- -->
 <launch>
+	<arg name="search_closest_waypoint_minimum_dt" default="5" doc="Minimum number of lookahead waypoints when searching closest_waypoint"/>
 
-<node pkg="lane_planner" type="lane_select" name="lane_select" output="log"></node>
+	<node pkg="lane_planner" type="lane_select" name="lane_select" output="log">
+		<param name="search_closest_waypoint_minimum_dt" value="$(arg search_closest_waypoint_minimum_dt)" />
+	</node>
 </launch>

--- a/ros/src/util/packages/runtime_manager/scripts/computing.yaml
+++ b/ros/src/util/packages/runtime_manager/scripts/computing.yaml
@@ -2750,6 +2750,15 @@ params :
       min       : 1.0
       max       : 50
       v         : 10.0
+    - name      : search_closest_waypoint_minimum_dt
+      desc      : Minimum number of lookahead waypoints when searching closest_waypoint
+      label     : Search Closest Waypoint Minimum Lookahead Number
+      min       : 1
+      max       : 100
+      v         : 5
+      cmd_param:
+        dash  : ''
+        delim : ':='
 
   - name  : astar_navi_param
     vars  :


### PR DESCRIPTION
Signed-off-by:  Yamato ANDO yamato.ando@gmail.com

## Bug fix

### Fixed bug

https://github.com/autowarefoundation/autoware/blob/master/ros/src/computing/planning/mission/packages/lane_planner/nodes/lane_select/lane_select_core.cpp#L804

The minimum number of lookahead waypoints is too small (only the previous closest_waypoint+1) when searching closest_waypoint.
If the interval of the waypoint is narrow (ex. every 0.1m), the search may fail because the search range is too small.
It is better to be able to search further.

### Fix applied
I have parameterized the minimum number of lookahead waypoints,
the default value is 5 (up to the previous closest_waypoint+4).
Parameters can be changed from launch file or Autoware Runtime Manager.

![Screenshot from 2019-06-06 16-28-58](https://user-images.githubusercontent.com/13819566/59014725-3ea58a00-8878-11e9-8f47-84cf6cdde4d1.png)
