### PR TITLE
Removed the "function" key-words

### DIFF
--- a/docker/generic/run.sh
+++ b/docker/generic/run.sh
@@ -9,7 +9,7 @@ BASE_ONLY="false"
 PRE_RELEASE="off"
 AUTOWARE_GROUP_ID=15214
 
-function usage() {
+usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "    -b,--base-only               Run the base image only."
     echo "                                 Default:$BASE_ONLY"
@@ -25,7 +25,7 @@ function usage() {
 }
 
 # Convert a relative directory path to absolute
-function abspath() {
+abspath() {
     local path=$1
     if [ ! -d $path ]; then
 	exit 1


### PR DESCRIPTION
## Bug fix
When you run the `Autoware/docker/generic/run.sh` without `bash` command like the [documentation](https://github.com/autowarefoundation/autoware/wiki/Generic-x86-Docker#case-1-using-docker-hub-as-is) says  (`sudo sh run.sh`), you get the error: `run.sh: 12: run.sh: Syntax error: "(" unexpected`.
In the issue  autowarefoundation/autoware_ai#706  was explained that you must run it with bash command `bash run.sh`, but you can solve it in a better way:

### Fixed bug
The `function` keyword in the shell script is optional, as documented [here](http://www.gnu.org/software/bash/manual/bashref.html#Shell-Functions):

> 3.3 Shell Functions
> Shell functions are a way to group commands for later execution using a single name for the group. They are executed just like a "regular" command. When the name of a shell function is used as a simple command name, the list of commands associated with that function name is executed. Shell functions are executed in the current shell context; no new process is created to interpret them.
> 
> Functions are declared using this syntax:
> 
> name () compound-command [ redirections ]
> or
> 
> function name [()] compound-command [ redirections ]

### Fix applied
so I just removed the `function` keywords in the script `run.sh` and tested it in `zsh` and `bash` shell

### Motivation
Why edit the script `run.sh` instead edit the documentation?
- To don't make the previous videos/articles deprecated.