### PR TITLE
docs: fix links to autoware.ai wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Autoware.AI](docs/images/Autoware.AI-Logo-Typo-right.png)](https://github.com/Autoware-AI/autoware.ai)
+[![Autoware.AI](docs/images/Autoware.AI-Logo-Typo-right.png)](https://github.com/autowarefoundation/autoware.ai)
 
 ## Announcement on End-of-Life on Autoware.AI and Transition to ROS2
 As some of the users may know, the Autoware Foundation is currently developing [Autoware Core/Universe](https://github.com/autowarefoundation/autoware), which is ROS2 version of Autoware. In order to focus our resources, the Technical Steering Committee has decided on the end-of-life date for Autoware.AI by the end of 2022 as [announced in 2020](https://discourse.ros.org/t/end-of-life-dates-for-autoware-ai/13750).
@@ -8,25 +8,25 @@ After the end-of-life, no releases will be made and no merge requests accepted. 
 **Please be aware that we do NOT stop development of Autoware**, and we are just transitioning to ROS2 based Autoware for future development. We encourage any current and future contributors to consider using/contributing to Autoware Core/Universe rather than Autoware.AI.
 
 ---
-![Native CI workflow](https://github.com/Autoware-AI/autoware.ai/workflows/Native%20CI%20workflow/badge.svg) ![CUDA CI workflow](https://github.com/Autoware-AI/autoware.ai/workflows/CUDA%20CI%20workflow/badge.svg) ![Cross CI workflow](https://github.com/Autoware-AI/autoware.ai/workflows/Cross%20CI%20workflow/badge.svg)
+![Native CI workflow](https://github.com/autowarefoundation/autoware.ai/workflows/Native%20CI%20workflow/badge.svg) ![CUDA CI workflow](https://github.com/autowarefoundation/autoware.ai/workflows/CUDA%20CI%20workflow/badge.svg) ![Cross CI workflow](https://github.com/autowarefoundation/autoware.ai/workflows/Cross%20CI%20workflow/badge.svg)
 
 ## What Is Autoware
 
 [Autoware](https://www.autoware.org) is the world's first "all-in-one" open-source software for self-driving vehicles. The capabilities of Autoware are primarily well-suited for urban cities, but highways, freeways, mesomountaineous regions, and geofenced areas can be also covered. The code base of Autoware is protected by the Apache 2 License. Please use it at your own discretion. For safe use, we provide a ROSBAG-based simulation environment for those who do not own real autonomous vehicles. If you plan to use Autoware with real autonomous vehicles, **please formulate safety measures and assessment of risk before field testing.**
 
-You may refer to [Autoware Wiki](https://github.com/Autoware-AI/autoware.ai/wiki/home) for **Users Guide** and **Developers Guide**.
+You may refer to [Autoware Wiki](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/home) for **Users Guide** and **Developers Guide**.
 
 
 [![Autoware
-Overview](docs/images/autoware_overview.png)](https://github.com/Autoware-AI/autoware.ai/wiki/Overview)
+Overview](docs/images/autoware_overview.png)](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Overview)
 
-Autoware provides a rich set of self-driving modules composed of sensing, computing, and actuation capabilities. An overview of those capabilities is described [here](https://github.com/Autoware-AI/autoware.ai/wiki/Overview). Keywords include *Localization, Mapping, Object Detection & Tracking, Traffic Light Recognition, Mission & Motion Planning, Trajectory Generation, Lane Detection & Selection, Vehicle Control, Sensor Fusion, Cameras, LiDARs, RADARs, Deep Learning, Rule-based System, Connected Navigation, Logging, Virtual Reality, and so on*.
+Autoware provides a rich set of self-driving modules composed of sensing, computing, and actuation capabilities. An overview of those capabilities is described [here](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Overview). Keywords include *Localization, Mapping, Object Detection & Tracking, Traffic Light Recognition, Mission & Motion Planning, Trajectory Generation, Lane Detection & Selection, Vehicle Control, Sensor Fusion, Cameras, LiDARs, RADARs, Deep Learning, Rule-based System, Connected Navigation, Logging, Virtual Reality, and so on*.
 
 Free manuals can be also found at [Autoware-Manuals](https://github.com/CPFL/Autoware-Manuals). You are encouraged to contribute to the maintenance of these manuals. Thank you for your cooperation!
 
 ## Getting Started
 
-[![Autoware Demo](docs/images/autoware_demo.png)](https://github.com/Autoware-AI/autoware.ai/wiki/Demo)
+[![Autoware Demo](docs/images/autoware_demo.png)](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Demo)
 
 ### Recommended System Specifications
 
@@ -36,19 +36,19 @@ Free manuals can be also found at [Autoware-Manuals](https://github.com/CPFL/Aut
 
 ### Users Guide
 
-1. [Installation](https://github.com/Autoware-AI/autoware.ai/wiki/Installation)
-    1. [Docker](https://github.com/Autoware-AI/autoware.ai/wiki/Docker)
-    1. [Source](https://github.com/Autoware-AI/autoware.ai/wiki/Source-Build)
-1. [Demo](https://github.com/Autoware-AI/autoware.ai/wiki/ROSBAG-Demo)
-1. [Field Test](https://github.com/Autoware-AI/autoware.ai/wiki/Field-Test)
-1. [Simulation Test](https://github.com/Autoware-AI/autoware.ai/wiki/Simulation-Demo)
-1. [Videos](https://github.com/Autoware-AI/autoware.ai/wiki/Videos)
+1. [Installation](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Installation)
+    1. [Docker](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Docker)
+    1. [Source](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Source-Build)
+1. [Demo](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/ROSBAG-Demo)
+1. [Field Test](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Field-Test)
+1. [Simulation Test](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Simulation-Demo)
+1. [Videos](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Videos)
 
 ### Developers Guide
 
-1. [Contribution Rules](https://github.com/Autoware-AI/autoware.ai/wiki/Contributing-to-Autoware) (**Must Read**)
-1. [Overview](https://github.com/Autoware-AI/autoware.ai/wiki/Overvieww)
-1. [Specification](https://github.com/Autoware-AI/autoware.ai/wiki/Specification)
+1. [Contribution Rules](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Contributing-to-Autoware) (**Must Read**)
+1. [Overview](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Overvieww)
+1. [Specification](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Specification)
 
 
 ## Research Papers for Citation
@@ -77,7 +77,7 @@ You may create 3D map data through Tier IV's [Map Tools](https://maptools.tier4.
 
 ## License
 
-Autoware is provided under the [Apache 2 License](https://github.com/Autoware-AI/autoware.ai/blob/master/LICENSE).
+Autoware is provided under the [Apache 2 License](https://github.com/autowarefoundation/autoware.ai/blob/master/LICENSE).
 
 ## Contact
 
@@ -85,7 +85,7 @@ Autoware is provided under the [Apache 2 License](https://github.com/Autoware-AI
 
 [Autoware Developers Discord Team](https://autoware.herokuapp.com/)
 
-Please see the [Support Guidelines](https://github.com/Autoware-AI/autoware.ai/wiki/Support-guidelines) for more details about getting help.
+Please see the [Support Guidelines](https://github.com/autowarefoundation/autoware_ai_documentation/wiki/Support-guidelines) for more details about getting help.
 
 ***
 <div align="center"><img src="docs/images/autoware_logo_1.png" width="400"/></div>


### PR DESCRIPTION
Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>

## Description
This fixes links to wiki pages for Autoware-AI
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
