### PR TITLE
ci(docker-build-and-push): remove a workaround for docker/bake-action

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -85,15 +85,6 @@ runs:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
 
-    # For https://github.com/docker/buildx/issues/756
-    - name: Merge json files
-      run: |
-        jq -s ".[0] * .[1]" \
-          "${{ steps.meta-devel.outputs.bake-file }}" \
-          "${{ steps.meta-prebuilt.outputs.bake-file }}" \
-          > bake.json
-      shell: bash
-
     - name: Build and push
       uses: docker/bake-action@v2
       with:
@@ -101,6 +92,7 @@ runs:
         push: ${{ github.event_name == 'schedule' || github.ref_name == github.event.repository.default_branch }}
         files: |
           docker/${{ inputs.bake-target }}/docker-bake.hcl
-          bake.json
+          ${{ steps.meta-devel.outputs.bake-file }}
+          ${{ steps.meta-prebuilt.outputs.bake-file }}
         set: |
           ${{ inputs.build-args }}


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Moved from https://github.com/autowarefoundation/autoware_core_universe_prototype/pull/245.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
