### PR TITLE
docs: add note to use rocker without the CUDA environment error

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -32,6 +32,8 @@ docker run --rm -it \
 
 To run with `rocker`:
 
+If you use `rocker<=0.2.9`, add an option of `--env NVIDIA_DRIVER_CAPABILITIES=""` or `--env NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics` to avoid the CUDA environment error. See [this issue](https://github.com/autowarefoundation/autoware/issues/2452) in more details.
+
 ```bash
 rocker --nvidia --x11 --user \
  --volume {path_to_your_workspace} \

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,7 +32,7 @@ docker run --rm -it \
 
 To run with `rocker`:
 
-If you use `rocker<=0.2.9`, add an option of `--env NVIDIA_DRIVER_CAPABILITIES=""` or `--env NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics` to avoid the CUDA environment error. See [this issue](https://github.com/autowarefoundation/autoware/issues/2452) in more details.
+If you use `rocker<=0.2.9`, add an option of `--env NVIDIA_DRIVER_CAPABILITIES=""` or `--env NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics` to avoid the CUDA environment error. For more details, see [this issue](https://github.com/autowarefoundation/autoware/issues/2452).
 
 ```bash
 rocker --nvidia --x11 --user \


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

Add description to avoid the CUDA error with rocker. Related issue is <https://github.com/autowarefoundation/autoware/issues/2452>.

I used the imaged built yesterday.

```
❯ rocker --nvidia --x11 --user -- ghcr.io/autowarefoundation/autoware-universe:galactic-latest-cuda nvidia-smi
...
Executing command: 
docker run --rm -it  --gpus all  -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1   -e XAUTHORITY=/tmp/.docker084qjmbl.xauth -v /tmp/.docker084qjmbl.xauth:/tmp/.docker084qjmbl.xauth   -v /tmp/.X11-unix:/tmp/.X11-unix   -v /etc/localtime:/etc/localtime:ro  a443643da2c6 nvidia-smi
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "nvidia-smi": executable file not found in $PATH: unknown.

❯ rocker --nvidia --x11 --user --env NVIDIA_DRIVER_CAPABILITIES="" -- ghcr.io/autowarefoundation/autoware-universe:galactic-latest-cuda nvidia-smi
...
Executing command: 
docker run --rm -it -e NVIDIA_DRIVER_CAPABILITIES=  --gpus all  -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1   -e XAUTHORITY=/tmp/.dockera_uls_ph.xauth -v /tmp/.dockera_uls_ph.xauth:/tmp/.dockera_uls_ph.xauth   -v /tmp/.X11-unix:/tmp/.X11-unix   -v /etc/localtime:/etc/localtime:ro  a443643da2c6 nvidia-smi
Wed Jul 13 10:39:48 2022       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 515.48.07    Driver Version: 515.48.07    CUDA Version: 11.7     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA GeForce ...  On   | 00000000:01:00.0  On |                  N/A |
|  0%   44C    P8    19W / 220W |   1240MiB /  8192MiB |     13%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
+-----------------------------------------------------------------------------+

```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
