### PR TITLE
fix(docker): register Vulkan GPU vendors

### DIFF
--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -42,6 +42,12 @@ RUN rm -rf \
   /etc/apt/sources.list.d/docker.list \
   /etc/apt/sources.list.d/nvidia-docker.list
 
+## Register Vulkan GPU vendors
+ADD "https://gitlab.com/nvidia/container-images/vulkan/raw/dc389b0445c788901fda1d85be96fd1cb9410164/nvidia_icd.json" /etc/vulkan/icd.d/nvidia_icd.json
+RUN chmod 644 /etc/vulkan/icd.d/nvidia_icd.json
+ADD "https://gitlab.com/nvidia/container-images/opengl/raw/5191cf205d3e4bb1150091f9464499b076104354/glvnd/runtime/10_nvidia.json" /etc/glvnd/egl_vendor.d/10_nvidia.json
+RUN chmod 644 /etc/glvnd/egl_vendor.d/10_nvidia.json
+
 ## Create entrypoint
 # hadolint ignore=DL3059
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc


### PR DESCRIPTION
## Description

Partial fix for https://github.com/autowarefoundation/autoware/issues/2427.
The json files are needed for Vulkan to discover the Nvidia drivers. We were doing the same thing in the [Autoware.Auto docker file](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/blob/e3e26be1ab4b822996df60f261d031d7924f20ac/tools/ade_image/Dockerfile#L100). 

Alternatively, the change could happen in the [rocker](https://github.com/osrf/rocker) repository. But this way it ensures that it also works for people that want to use docker directly.

There is still a problem with the `:latest-cuda` version of the docker image, where Vulkan won't be able to use an Nvidia GPU with the current setup. Because in the base image `NVIDIA_DRIVER_CAPABILITIES` is set to "compute,utility", so rocker doesn't overwrite it. But the Vulkan drivers from the host need "graphics" to be exposed, according to the [documentation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities).
cc @kenji-miyake as you made some changes to rocker recently about this.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
