### PR TITLE
feat(morai_msgs): appending a message package for MORAI SIM: Drive 

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -33,6 +33,10 @@ repositories:
     type: git
     url: https://github.com/ANYbotics/grid_map.git
     version: ba2f9cb6e62f7ee9c5bac7401391a211e442e459
+  universe/external/morai_msgs:
+    type: git
+    url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
+    version: main
   universe/external/muSSP:
     type: git
     url: https://github.com/tier4/muSSP.git


### PR DESCRIPTION
## Description
- Purpose : To maintain consistency with other packages

## Related links
[issue link](https://github.com/autowarefoundation/autoware/issues/2739)
[related PR link](https://github.com/autowarefoundation/autoware.universe/pull/1107)

## Notes for reviewers
At first, the morai_msgs package was in [universe/autoware.universe/tools/simulator_test/]. but in the simulation working group, it was decided to remove it and then, append it to autoware.repos to maintain consistency with other packages.
For now, the [related PR link](https://github.com/autowarefoundation/autoware.universe/pull/1107) is pending because it fails to be built. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

