### PR TITLE
chore(.clang-tidy): set readability-inconsistent-declaration-parameter-name.IgnoreMacros to true

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -425,6 +425,8 @@ CheckOptions:
     value: ""
   - key: portability-simd-intrinsics.Suggest
     value: "0"
+  - key: readability-function-cognitive-complexity.IgnoreMacros
+    value: "1"
   - key: readability-else-after-return.WarnOnUnfixable
     value: "1"
   - key: readability-identifier-naming.NamespaceCase


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

https://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html

It's too noisy without this config due to logging macros.

Before:

<details>

```console
❯ clang-tidy -p build/ tmp/lanelet2_extension/lib/visualization.cpp
41454 warnings and 1 error generated.
Error while processing /home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp.
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:257:17: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
  const int N = polygon.points.size();
                ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:362:21: warning: function 'polygon2Triangle' has cognitive complexity of 28 (threshold 25) [readability-function-cognitive-complexity]
void visualization::polygon2Triangle(
                    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:366:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (!isClockWise(poly)) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:376:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  for (int i = 0; i < N; i++) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:386:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  while (N >= 3) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:389:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    for (int i = 0; i < N; i++) {
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:391:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (theta) {
      ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:400:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        for (int j = j_begin; j != j_end; j = (j + 1) % N) {
        ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:401:11: note: +5, including nesting penalty of 4, nesting level increased to 5
          if (isWithinTriangle(p0, p1, p2, poly.points.at(j))) {
          ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:407:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (is_ear) {
        ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:413:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (clipped_vertex < 0 || clipped_vertex >= N) {
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:413:28: note: +1
    if (clipped_vertex < 0 || clipped_vertex >= N) {
                           ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:444:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (clipped_vertex == N) {
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:450:40: note: +2, including nesting penalty of 1, nesting level increased to 2
    int i_prev = (clipped_vertex == 0) ? N - 1 : clipped_vertex - 1;
                                       ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:443:9: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
    N = poly.points.size();
        ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:552:21: warning: narrowing conversion from 'lanelet::Id' (aka 'long') to signed type 'visualization_msgs::msg::Marker_::_id_type' (aka 'int') is implementation-defined [cppcoreguidelines-narrowing-conversions]
        marker.id = ls.id();
                    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:619:17: warning: narrowing conversion from 'lanelet::Id' (aka 'long') to signed type 'visualization_msgs::msg::Marker_::_id_type' (aka 'int') is implementation-defined [cppcoreguidelines-narrowing-conversions]
    marker.id = da_reg_elem->id();
                ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:694:17: warning: narrowing conversion from 'lanelet::Id' (aka 'long') to signed type 'visualization_msgs::msg::Marker_::_id_type' (aka 'int') is implementation-defined [cppcoreguidelines-narrowing-conversions]
    marker.id = no_reg_elem->id();
                ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:728:53: warning: function 'pedestrianMarkingsAsMarkerArray' has cognitive complexity of 60 (threshold 25) [readability-function-cognitive-complexity]
visualization_msgs::msg::MarkerArray visualization::pedestrianMarkingsAsMarkerArray(
                                                    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:732:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (pedestrian_markings.empty()) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:737:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  for (const auto & linestring : pedestrian_markings) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:739:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (utils::lineStringToPolygon(linestring, &polygon)) {
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:741:7: note: +1, nesting level increased to 2
    } else {
      ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:742:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      RCLCPP_ERROR_STREAM(
      ^
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:1593:3: note: expanded from macro 'RCLCPP_ERROR_STREAM'
  do { \
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:742:7: note: +4, including nesting penalty of 3, nesting level increased to 4
      RCLCPP_ERROR_STREAM(
      ^
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:1601:5: note: expanded from macro 'RCLCPP_ERROR_STREAM'
    RCUTILS_LOG_ERROR_NAMED( \
    ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:994:3: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
  RCUTILS_LOG_COND_NAMED( \
  ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:67:3: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
  do { \
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:742:7: note: +5, including nesting penalty of 4, nesting level increased to 5
      RCLCPP_ERROR_STREAM(
      ^
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:1601:5: note: expanded from macro 'RCLCPP_ERROR_STREAM'
    RCUTILS_LOG_ERROR_NAMED( \
    ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:994:3: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
  RCUTILS_LOG_COND_NAMED( \
  ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:68:5: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
    RCUTILS_LOGGING_AUTOINIT; \
    ^
/opt/ros/humble/include/rcutils/rcutils/logging.h:525:3: note: expanded from macro 'RCUTILS_LOGGING_AUTOINIT'
  do { \
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:742:7: note: +6, including nesting penalty of 5, nesting level increased to 6
      RCLCPP_ERROR_STREAM(
      ^
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:1601:5: note: expanded from macro 'RCLCPP_ERROR_STREAM'
    RCUTILS_LOG_ERROR_NAMED( \
    ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:994:3: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
  RCUTILS_LOG_COND_NAMED( \
  ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:68:5: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
    RCUTILS_LOGGING_AUTOINIT; \
    ^
/opt/ros/humble/include/rcutils/rcutils/logging.h:526:5: note: expanded from macro 'RCUTILS_LOGGING_AUTOINIT'
    if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:742:7: note: +7, including nesting penalty of 6, nesting level increased to 7
      RCLCPP_ERROR_STREAM(
      ^
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:1601:5: note: expanded from macro 'RCLCPP_ERROR_STREAM'
    RCUTILS_LOG_ERROR_NAMED( \
    ^

(many lines ommited)

Suppressed 41651 warnings (41438 in non-user code, 213 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
```

</details>

After:

<details>

```console
❯ clang-tidy -p build/ tmp/lanelet2_extension/lib/visualization.cpp
41415 warnings and 1 error generated.
Error while processing /home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp.
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:257:17: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
  const int N = polygon.points.size();
                ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:362:21: warning: function 'polygon2Triangle' has cognitive complexity of 28 (threshold 25) [readability-function-cognitive-complexity]
void visualization::polygon2Triangle(
                    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:366:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  if (!isClockWise(poly)) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:376:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  for (int i = 0; i < N; i++) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:386:3: note: +1, including nesting penalty of 0, nesting level increased to 1
  while (N >= 3) {
  ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:389:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    for (int i = 0; i < N; i++) {
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:391:7: note: +3, including nesting penalty of 2, nesting level increased to 3
      if (theta) {
      ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:400:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        for (int j = j_begin; j != j_end; j = (j + 1) % N) {
        ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:401:11: note: +5, including nesting penalty of 4, nesting level increased to 5
          if (isWithinTriangle(p0, p1, p2, poly.points.at(j))) {
          ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:407:9: note: +4, including nesting penalty of 3, nesting level increased to 4
        if (is_ear) {
        ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:413:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (clipped_vertex < 0 || clipped_vertex >= N) {
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:413:28: note: +1
    if (clipped_vertex < 0 || clipped_vertex >= N) {
                           ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:444:5: note: +2, including nesting penalty of 1, nesting level increased to 2
    if (clipped_vertex == N) {
    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:450:40: note: +2, including nesting penalty of 1, nesting level increased to 2
    int i_prev = (clipped_vertex == 0) ? N - 1 : clipped_vertex - 1;
                                       ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:443:9: warning: narrowing conversion from 'std::vector::size_type' (aka 'unsigned long') to signed type 'int' is implementation-defined [cppcoreguidelines-narrowing-conversions]
    N = poly.points.size();
        ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:552:21: warning: narrowing conversion from 'lanelet::Id' (aka 'long') to signed type 'visualization_msgs::msg::Marker_::_id_type' (aka 'int') is implementation-defined [cppcoreguidelines-narrowing-conversions]
        marker.id = ls.id();
                    ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:619:17: warning: narrowing conversion from 'lanelet::Id' (aka 'long') to signed type 'visualization_msgs::msg::Marker_::_id_type' (aka 'int') is implementation-defined [cppcoreguidelines-narrowing-conversions]
    marker.id = da_reg_elem->id();
                ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:694:17: warning: narrowing conversion from 'lanelet::Id' (aka 'long') to signed type 'visualization_msgs::msg::Marker_::_id_type' (aka 'int') is implementation-defined [cppcoreguidelines-narrowing-conversions]
    marker.id = no_reg_elem->id();
                ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:847:53: error: out-of-line definition of 'lineStringsAsMarkerArray' does not match any declaration in namespace 'lanelet::visualization' [clang-diagnostic-error]
visualization_msgs::msg::MarkerArray visualization::lineStringsAsMarkerArray(
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:874:28: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
  const float lss_center = std::max(lss * 0.1, 0.02);
                           ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:1156:27: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
    const float heading = std::atan2((*(i + 1)).y() - (*i).y(), (*(i + 1)).x() - (*i).x());
                          ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:1158:28: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
    const float x_offset = lss * 0.5 * std::sin(heading);
                           ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:1159:28: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
    const float y_offset = lss * 0.5 * std::cos(heading);
                           ^
/home/kenji/ghq/github.com/autowarefoundation/autoware_common/tmp/lanelet2_extension/lib/visualization.cpp:1238:27: warning: narrowing conversion from 'double' to 'float' [cppcoreguidelines-narrowing-conversions]
    const float heading = std::atan2((*(i + 1)).y() - (*i).y(), (*(i + 1)).x() - (*i).x());
                          ^
Suppressed 41616 warnings (41404 in non-user code, 212 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
```

</details>

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
