### PR TITLE
chore(clang-tidy): add SharedFuture in performance-unnecessary-value-param.AllowedTypes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -418,7 +418,7 @@ CheckOptions:
   - key: performance-unnecessary-copy-initialization.AllowedTypes
     value: ""
   - key: performance-unnecessary-value-param.AllowedTypes
-    value: ".*Ptr;SharedFuture"
+    value: ".*Ptr;.*SharedFuture"
   - key: performance-unnecessary-value-param.IncludeStyle
     value: google
   - key: portability-simd-intrinsics.Std

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -418,7 +418,7 @@ CheckOptions:
   - key: performance-unnecessary-copy-initialization.AllowedTypes
     value: ""
   - key: performance-unnecessary-value-param.AllowedTypes
-    value: ".*Ptr"
+    value: ".*Ptr;SharedFuture"
   - key: performance-unnecessary-value-param.IncludeStyle
     value: google
   - key: portability-simd-intrinsics.Std


### PR DESCRIPTION
## Description

Not to use NOLINT in https://github.com/autowarefoundation/autoware.universe/pull/1589

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
