### PR TITLE
revert: install each package of tensorrt

### DIFF
--- a/amd64.env
+++ b/amd64.env
@@ -4,4 +4,4 @@ base_image=ubuntu:20.04
 cuda_base_image=nvidia/cuda:11.6.2-devel-ubuntu20.04
 cuda_version=11.6
 cudnn_version=8.4.1.50-1+cuda11.6
-tensorrt_version=8.4.2.4-1+cuda11.6
+tensorrt_version=8.4.2-1+cuda11.6

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -36,4 +36,3 @@
     - libnvparsers-dev
     - libnvonnxparsers-dev
     - libnvinfer-samples
-

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -4,7 +4,16 @@
     name:
       - libcudnn8={{ cudnn_version }}
       - libcudnn8-dev={{ cudnn_version }}
-      - tensorrt={{ tensorrt_version }}
+      - libnvinfer8={{ tensorrt_version }}
+      - libnvinfer-plugin8={{ tensorrt_version }}
+      - libnvparsers8={{ tensorrt_version }}
+      - libnvonnxparsers8={{ tensorrt_version }}
+      - libnvinfer-bin={{ tensorrt_version }}
+      - libnvinfer-dev={{ tensorrt_version }}
+      - libnvinfer-plugin-dev={{ tensorrt_version }}
+      - libnvparsers-dev={{ tensorrt_version }}
+      - libnvonnxparsers-dev={{ tensorrt_version }}
+      - libnvinfer-samples={{ tensorrt_version }}
     allow_downgrade: true
     update_cache: true
 
@@ -17,4 +26,14 @@
   with_items:
     - libcudnn8
     - libcudnn8-dev
-    - tensorrt
+    - libnvinfer8
+    - libnvinfer-plugin8
+    - libnvparsers8
+    - libnvonnxparsers8
+    - libnvinfer-bin
+    - libnvinfer-dev
+    - libnvinfer-plugin-dev
+    - libnvparsers-dev
+    - libnvonnxparsers-dev
+    - libnvinfer-samples
+


### PR DESCRIPTION
## Description

The old version of tensorrt meta package is not prohibited to be installed as below.
```
The following packages have unmet dependencies:
 tensorrt : Depends: libnvinfer8 (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvinfer-plugin8 (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvparsers8 (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvonnxparsers8 (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvinfer-bin (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvinfer-dev (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvinfer-plugin-dev (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvparsers-dev (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvonnxparsers-dev (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
            Depends: libnvinfer-samples (= 8.4.1-1+cuda11.6) but 8.4.3-1+cuda11.6 is to be installed
E: Unable to correct problems, you have held broken packages.
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
