### PR TITLE
ci(build): enable daily build

### DIFF
--- a/.github/workflows/build-humble-self-hosted.yaml
+++ b/.github/workflows/build-humble-self-hosted.yaml
@@ -2,7 +2,7 @@ name: build-humble-self-hosted
 
 on:
   schedule:
-    - cron: 0 0 * * 0
+    - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-humble.yaml
+++ b/.github/workflows/build-humble.yaml
@@ -2,7 +2,7 @@ name: build-humble
 
 on:
   schedule:
-    - cron: 0 0 * * 0
+    - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -2,7 +2,7 @@ name: build-main-self-hosted
 
 on:
   schedule:
-    - cron: 0 0 * * 0
+    - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -2,7 +2,7 @@ name: build-main
 
 on:
   schedule:
-    - cron: 0 0 * * 0
+    - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

To detect errors quickly, I'd like to fasten the frequency of the build CI from weekly to daily.
To avoid conflicts with other workflows, I used 12:00 for these workflows.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
