### PR TITLE
fix: remove bin and samples to keep backward compatibility

### DIFF
--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -8,12 +8,10 @@
       - libnvinfer-plugin8={{ tensorrt_version }}
       - libnvparsers8={{ tensorrt_version }}
       - libnvonnxparsers8={{ tensorrt_version }}
-      - libnvinfer-bin={{ tensorrt_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
       - libnvparsers-dev={{ tensorrt_version }}
       - libnvonnxparsers-dev={{ tensorrt_version }}
-      - libnvinfer-samples={{ tensorrt_version }}
     allow_downgrade: true
     update_cache: true
 
@@ -30,9 +28,7 @@
     - libnvinfer-plugin8
     - libnvparsers8
     - libnvonnxparsers8
-    - libnvinfer-bin
     - libnvinfer-dev
     - libnvinfer-plugin-dev
     - libnvparsers-dev
     - libnvonnxparsers-dev
-    - libnvinfer-samples


### PR DESCRIPTION
## Description

Some users still use cuda-11.4 and libnvinfer-bin/sample packages for cuda-11.4 doesn't exist.
To keep backward compatibility temporarily, I removed them once.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
