### PR TITLE
chore(.clang-tidy): fix settings of readability-identifier-naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -432,8 +432,8 @@ CheckOptions:
     value: lower_case
   - key: readability-identifier-naming.ClassCase
     value: CamelCase
-  - key: readability-identifier-naming.PrivateMemberPrefix
-    value: ""
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
   - key: readability-identifier-naming.StructCase
     value: CamelCase
   - key: readability-identifier-naming.FunctionCase
@@ -441,7 +441,11 @@ CheckOptions:
   - key: readability-identifier-naming.VariableCase
     value: lower_case
   - key: readability-identifier-naming.GlobalConstantCase
-    value: UPPER_CASE
+    value: lower_case
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: g_
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: lower_case
   - key: readability-inconsistent-declaration-parameter-name.IgnoreMacros
     value: "1"
   - key: readability-inconsistent-declaration-parameter-name.Strict


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

The settings that I added in https://github.com/autowarefoundation/autoware/pull/2763 was a bit wrong.

- Use `_` for PrivateMemberSuffix.
    [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Variable_Names) says `Data members of classes, both static and non-static, are named like ordinary nonmember variables, but with a trailing underscore`.
- Use lower_case with prefix `g_` for GlobalConstantCase.
    [ROS 2 Docs](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html#variable-naming) says `For global variables use lowercase with underscores prefixed with g_`. 
- Use lower_case for ConstexprVariableCase.
    For [these lines](https://github.com/autowarefoundation/autoware_common/blob/ac39ea4524e983d9d422815996423707482d8494/autoware_utils/include/autoware_utils/math/constants.hpp#L20-L21).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
