### PR TITLE
chore: remove grid_map from repos

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -37,10 +37,6 @@ repositories:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: tier4/universe
-  universe/external/grid_map:
-    type: git
-    url: https://github.com/ANYbotics/grid_map.git
-    version: 74333f037cfce321248dfa7b954a815d4f67d79d
   universe/external/morai_msgs:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
remove `grid_map` from repos after next humble sync
```
❯ apt-cache policy ros-humble-grid-map
ros-humble-grid-map:
  インストールされているバージョン: (なし)
  候補:               2.0.0-1jammy.20220913.181900
  バージョンテーブル:
     2.0.0-1jammy.20220913.181900 500
        500 http://packages.ros.org/ros2-testing/ubuntu jammy/main amd64 Packages
```
https://github.com/ros/rosdistro/pull/34457

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
