### PR TITLE
refactor(setup): use pipx for Ansible to avoid conflicts between pip and apt packages

### DIFF
--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -101,23 +101,16 @@ if ! (command -v git >/dev/null 2>&1); then
     sudo apt-get -y install git
 fi
 
-# Install pip for ansible
-if ! (command -v pip3 >/dev/null 2>&1); then
+# Install pipx for ansible
+if ! (python3 -m pipx >/dev/null 2>&1); then
     sudo apt-get -y update
-    sudo apt-get -y install python3-pip
+    sudo apt-get -y install python3-pip python3-venv
+    python3 -m pip install --user pipx
 fi
 
 # Install ansible
-ansible_version=$(pip3 list | grep -oP "^ansible\s+\K([0-9]+)" || true)
-if [ "$ansible_version" != "6" ]; then
-    sudo apt-get -y purge ansible
-    pip3 install -U "ansible==6.*"
-    # Workaround for https://github.com/autowarefoundation/autoware/issues/2849
-    pip3 install -U "pyOpenSSL>=22.0.0"
-fi
-
-# For Python packages installed with user privileges
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pipx ensurepath
+pipx install --include-deps --force "ansible==6.*"
 
 # Install ansible collections
 echo -e "\e[36m"ansible-galaxy collection install -f -r "$SCRIPT_DIR/ansible-galaxy-requirements.yaml" "\e[m"

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -110,6 +110,7 @@ fi
 
 # Install ansible
 python3 -m pipx ensurepath
+export PATH="${PIPX_BIN_DIR:=$HOME/.local/bin}:$PATH"
 pipx install --include-deps --force "ansible==6.*"
 
 # Install ansible collections


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Installing ansible via `pip` can conflict with some apt packages.

```console
$ docker run --rm -it ubuntu:20.04 /bin/bash
$ apt update && DEBIAN_FRONTEND=noninteractive apt -y install python3-flask && apt -y install python3-pip && pip install ansible
$ python3
>>> import flask
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.8/dist-packages/jinja2/__init__.py)
```

Also previously, there was a similar error.
https://github.com/autowarefoundation/autoware/issues/2849

To avoid these kinds of errors, I'd like to use `pipx` instead, which can create a virtual environment for application packages.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
