### PR TITLE
ci(backport): use generated token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -20,7 +20,14 @@ jobs:
         )
       )
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
       - uses: tibdex/backport@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           title_template: "<%= title %> (backport #<%= number %>)"


### PR DESCRIPTION
## Description

Github actions are not working with `secrets.GITHUB_TOKEN` in backport action.
This PR fixes it by using https://github.com/tibdex/github-app-token.
I refered to https://github.com/autowarefoundation/autoware/blob/main/.github/workflows/sync-files.yaml#L19-L24.


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

In my forked autoware, I tested.

- add same fixes
https://github.com/h-ohta/autoware/commit/6fd539aa56ca2545b751cf93073051d141d42a39
- create PR, merged, labeled
https://github.com/h-ohta/autoware/pull/1
- create backport PR and github actions works fine.
https://github.com/h-ohta/autoware/pull/2

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
