### PR TITLE
fix(setup): fix pipx check

### DIFF
--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -114,7 +114,7 @@ if ! (command -v git >/dev/null 2>&1); then
 fi
 
 # Install pipx for ansible
-if ! (python3 -m pipx >/dev/null 2>&1); then
+if ! (python3 -m pipx --version >/dev/null 2>&1); then
     sudo apt-get -y update
     sudo apt-get -y install python3-pip python3-venv
     python3 -m pip install --user pipx


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`python3 -m pipx` always returns `EXIT_FAILURE`.

```console
$ python3 -m pipx >/dev/null 2>&1
$ echo $?
1
```

Adding `--version` works as expected.

```console
$ python3 -m pipx --version >/dev/null 2>&1
$ echo $?
0
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
