### PR TITLE
docs(ansible/cuda): fix outdated cuda version in README

### DIFF
--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -24,7 +24,7 @@ sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
 sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
 sudo apt-get update
-cuda_version=11-4
+cuda_version=11-6
 sudo apt install cuda-${cuda_version} --no-install-recommends
 ```
 


### PR DESCRIPTION
## Description

Update the recommended version of CUDA to install from `11-4` -> `11-6` based on [this discussion](https://github.com/autowarefoundation/autoware/discussions/2961#discussioncomment-3931881).

Note that this value matches the version in the [ansible env variable](https://github.com/autowarefoundation/autoware/blob/e108b8fa9e47307b1f2573be5d0dde828235bcb0/amd64.env#L5).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].  NOTE: there was a [this discussion](https://github.com/autowarefoundation/autoware/discussions/2961#discussioncomment-3931881), but no issue.  Should I open one?

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
