### PR TITLE
chore(.markdownlint.yaml): use ordered style for MD029

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,6 +3,8 @@ default: true
 MD013: false
 MD024:
   siblings_only: true
+MD029:
+  style: ordered
 MD033: false
 MD041: false
 MD046: false


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

To use consistent styles, I think it's good to use `ordered` for MD029.
The default value is `one_or_ordered`, and it allows two different styles.

For more details, please refer to https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md029---ordered-list-item-prefix.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
