### PR TITLE
chore: add release scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,20 @@
+# Scripts for Autoware
+
+## freeze-repos.sh
+
+### Prerequisites
+
+- [yq](https://github.com/mikefarah/yq)
+
+  ```bash
+  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
+  sudo add-apt-repository ppa:rmescandon/yq
+  sudo apt update
+  sudo apt install yq -y
+  ```
+
+### Usage
+
+```bash
+./scripts/freeze-repos.sh
+```

--- a/scripts/freeze-repos.sh
+++ b/scripts/freeze-repos.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euC
+
+function update_repository_version {
+    local -r repos_file="$1"
+    local -r repository="$2"
+
+    url=$(yq ".repositories[] | select(key == \"$repository\").url" "$repos_file")
+    version=$(yq ".repositories[] | select(key == \"$repository\").version" "$repos_file")
+
+    tag_hash=$(git ls-remote --tags "$url" "$version" | awk '{print $1}')
+    branch_hash=$(git ls-remote --heads "$url" "$version" | awk '{print $1}')
+
+    if [ -n "$tag_hash" ]; then
+        new_version="$tag_hash"
+    elif [ -n "$branch_hash" ]; then
+        new_version="$branch_hash"
+    else
+        new_version="$version"
+    fi
+
+    echo "$repository: $new_version"
+    yq --inplace ".repositories.\"$repository\".version = \"$new_version\"" "$repos_file"
+}
+
+function get_repositories_in_repos() {
+    local -r repos_file="$1"
+
+    yq '.repositories' "$repos_file" | grep -E "^[a-zA-Z]+" | sed "s/:.*//g"
+}
+
+function freeze_repos_file {
+    local -r repos_file="$1"
+
+    local -r repositories=$(get_repositories_in_repos "$repos_file")
+    if [ -z "$repositories" ]; then
+        echo "no repository found"
+        exit 1
+    fi
+
+    for repository in $repositories; do
+        update_repository_version "$repos_file" "$repository"
+    done
+}
+
+function freeze_all_repos_files {
+    for repos_file in *.repos; do
+        freeze_repos_file "$repos_file"
+    done
+}
+
+function main {
+    if ! (command -v yq >/dev/null 2>&1); then
+        echo "yq not found"
+        exit 1
+    fi
+
+    freeze_all_repos_files
+
+    git add "*.repos"
+    git commit -s -m "chore(release): freeze repos files"
+}
+
+if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

To release fixed versions of Autoware, using scripts is useful.
It's also possible with [vcstool](https://github.com/dirk-thomas/vcstool) by the command `vcs export --exact`, but it collapses the format of `.repos` files.

Note: This script is just a tentative one, and I'm planning to develop a tool in the future.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
