### PR TITLE
fix(gitignore): add capture folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ log/
 
 # Jetbrains
 .idea/
+
+# rviz Screen Capture
+capture/


### PR DESCRIPTION
Signed-off-by: Mehmet Dogru <42mehmetdogru42@gmail.com>

## Description

`tier4_screen_capture_rviz_plugin` package in autoware.universe writes videos and screenshots in a `capture` folder located in wherever autoware is being run. Since autoware is run mainly in autoware root folder I suggest adding this folder to .gitignore

To try this out run planning_simulator in autoware root folder and add `AutowareScreenCapturePanel`. Capture screenshot or capture screen.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
