### PR TITLE
ci(.pre-commit-config-ansible.yaml): update ansible-lint version

### DIFF
--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v5.3.2
+    rev: v6.8.6
     hooks:
       - id: ansible-lint

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v6.8.6
+    rev: v5.4.0
     hooks:
       - id: ansible-lint


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

Update ansible-lint version to merge <https://github.com/autowarefoundation/autoware/pull/3029>.

[This CI error](https://github.com/autowarefoundation/autoware/actions/runs/3469781105/jobs/5797182594) is a bug and it has fixed in https://github.com/ansible/ansible-lint/pull/1859 and [v5.4.0](https://github.com/ansible/ansible-lint/releases/tag/v5.4.0)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
