### PR TITLE
feat(ansible): verify OS before running playbooks

### DIFF
--- a/ansible/playbooks/core.yaml
+++ b/ansible/playbooks/core.yaml
@@ -2,11 +2,9 @@
   connection: local
   pre_tasks:
     - name: Verify OS
-      ansible.builtin.shell: |
-        if ! cat /etc/os-release | grep 'VERSION_ID="20.04"'; then
-          echo 'Please use "Ubuntu 20.04".'
-          exit 1
-        fi
+      ansible.builtin.fail:
+        msg: Only Ubuntu 20.04 is supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
+      when: ansible_distribution_version != '20.04'
 
     - name: Print args
       ansible.builtin.debug:

--- a/ansible/playbooks/core.yaml
+++ b/ansible/playbooks/core.yaml
@@ -1,6 +1,13 @@
 - hosts: localhost
   connection: local
   pre_tasks:
+    - name: Verify OS
+      ansible.builtin.shell: |
+        if ! cat /etc/os-release | grep 'VERSION_ID="20.04"'; then
+          echo 'Please use "Ubuntu 20.04".'
+          exit 1
+        fi
+
     - name: Print args
       ansible.builtin.debug:
         msg:

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -7,6 +7,13 @@
         Install NVIDIA libraries? [y/N]
       private: false
   pre_tasks:
+    - name: Verify OS
+      ansible.builtin.shell: |
+        if ! cat /etc/os-release | grep 'VERSION_ID="20.04"'; then
+          echo 'Please use "Ubuntu 20.04".'
+          exit 1
+        fi
+
     - name: Print args
       ansible.builtin.debug:
         msg:
@@ -15,6 +22,7 @@
           - cuda_version: "{{ cuda_version }}"
           - cudnn_version: "{{ cudnn_version }}"
           - tensorrt_version: "{{ tensorrt_version }}"
+
     - name: Show a warning if the NVIDIA libraries will not be installed
       ansible.builtin.pause:
         seconds: 10

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -8,11 +8,9 @@
       private: false
   pre_tasks:
     - name: Verify OS
-      ansible.builtin.shell: |
-        if ! cat /etc/os-release | grep 'VERSION_ID="20.04"'; then
-          echo 'Please use "Ubuntu 20.04".'
-          exit 1
-        fi
+      ansible.builtin.fail:
+        msg: Only Ubuntu 20.04 is supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
+      when: ansible_distribution_version != '20.04'
 
     - name: Print args
       ansible.builtin.debug:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It's useful if we can verify OS during setup.
Considering that the `docker` playbook can run on any platform, I've added the check in `core.yaml` and `universe.yaml`.

```
ansible-playbook autoware.dev_env.universe --ask-become-pass --extra-vars install_devel=true --extra-vars rosdistro=galactic --extra-vars rmw_implementation=rmw_cyclonedds_cpp --extra-vars base_image=ubuntu:20.04 --extra-vars cuda_base_image=nvidia/cuda:11.6.2-devel-ubuntu20.04 --extra-vars cuda_version=11.6 --extra-vars cudnn_version=8.4.1.50-1+cuda11.6 --extra-vars tensorrt_version=8.4.2-1+cuda11.6 
BECOME password: 
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
[WARNING]: running playbook inside collection autoware.dev_env
[Warning] Some Autoware components depend on the CUDA, cuDNN and TensorRT NVIDIA libraries which have end-user license agreements that should be reviewed before installation.
Install NVIDIA libraries? [y/N]: y

PLAY [localhost] *********************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************
ok: [localhost]

TASK [Verify OS] *********************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "if ! cat /etc/os-release | grep 'VERSION_ID=\"20.04\"'; then\n  echo 'Please use \"Ubuntu 20.04\".'\n  exit 1\nfi\n", "delta": "0:00:00.006079", "end": "2022-11-30 22:09:38.025985", "msg": "non-zero return code", "rc": 1, "start": "2022-11-30 22:09:38.019906", "stderr": "", "stderr_lines": [], "stdout": "Please use \"Ubuntu 20.04\".", "stdout_lines": ["Please use \"Ubuntu 20.04\"."]}

PLAY RECAP ***************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

Failed.
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
