### PR TITLE
ci(docker-build-and-push): fix the order of steps

### DIFF
--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -33,11 +33,11 @@ jobs:
         run: |
           sudo chown -R $USER:$USER ${{ github.workspace }}
 
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-
       - name: Check out repository
         uses: actions/checkout@v3
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Load env
         run: |

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -28,11 +28,11 @@ jobs:
             setup-args: --no-cuda-drivers
             additional-tag-suffix: -cuda
     steps:
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-
       - name: Check out repository
         uses: actions/checkout@v3
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Load env
         run: |


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I'm sorry, we can't switch the order.
https://github.com/autowarefoundation/autoware/actions/runs/3584099059/jobs/6030335670#step:2:1
![image](https://user-images.githubusercontent.com/31987104/204820336-a1164c5a-9d57-4ba6-a7c6-3c6a4f056f38.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
