### PR TITLE
ci(mirror-main-branch): add a new workflow to mirror the main branch to the main distro branch

### DIFF
--- a/.github/workflows/mirror-main-branch.yaml
+++ b/.github/workflows/mirror-main-branch.yaml
@@ -1,0 +1,15 @@
+name: mirror-main-branch
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  mirror-main-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zofrex/mirror-branch@v1
+        with:
+          target-branch: humble


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It's useful if we mirror the main branch to the main distro branch (now it's humble).
- The supported ROS distro becomes clear.
- Distro branches can provide stable interfaces.
    For example, if some user write the following reference in `ansible-galaxy-requirements.yaml`, it may cause drastic changes.

    ```yaml
      - name: https://github.com/autowarefoundation/autoware.git#/ansible
        type: git
        version: main
    ```

    However, if they depend on `humble`, the changes are relatively small.

    ```yaml
      - name: https://github.com/autowarefoundation/autoware.git#/ansible
        type: git
        version: humble
    ```

Related: ROS 2 mirrors `rolling` to `master`. It's a little different usage from us.
https://github.com/ros2/ros2/blob/07c27c934a6a1269fec2828f4c1a4ff40430d44d/.github/workflows/mirror-rolling-to-master.yaml

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
