### PR TITLE
ci(update-tool-versions): update clang-format version check

### DIFF
--- a/.github/workflows/update-tool-versions.yaml
+++ b/.github/workflows/update-tool-versions.yaml
@@ -25,8 +25,11 @@ jobs:
       - name: Get clang-format version
         id: get-clang-format-version
         run: |
-          latest_tag_name=$(gh release view --repo https://github.com/llvm/llvm-project --json tagName --jq ".tagName")
-          echo ::set-output name=version::$(echo "$latest_tag_name" | sd '.*-(.*)' '$1')
+          function get-latest-pip-version() {
+            pip index versions "$1" 2>/dev/null | head -n1 | sd '.*\((.*)\)' '$1'
+          }
+
+          echo ::set-output name=version::$(get-latest-pip-version clang-format)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/ansible/roles/pre_commit/README.md
+++ b/ansible/roles/pre_commit/README.md
@@ -14,7 +14,7 @@ The `clang_format_version` variable can also be found in:
 [./defaults/main.yaml](./defaults/main.yaml)
 
 ```bash
-clang_format_version=15.0.4
+clang_format_version=14.0.6
 pip3 install pre-commit clang-format==${clang_format_version}
 
 sudo apt install golang

--- a/ansible/roles/pre_commit/defaults/main.yaml
+++ b/ansible/roles/pre_commit/defaults/main.yaml
@@ -1,1 +1,1 @@
-clang_format_version: 15.0.4
+clang_format_version: 14.0.6


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Originally it was from https://github.com/llvm/llvm-project/tags, which may cause version inconsistency, but it's simpler if we get the version from pip.

An example of version inconsistency: https://github.com/autowarefoundation/autoware/actions/runs/3597614205/jobs/6059539767

```
    "msg": "\n:stderr: WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.\nERROR: Could not find a version that satisfies the requirement clang-format==15.0.6 (from versions: 6.0.1, 7.1.0, 8.0.1, 9.0.0, 10.0.1, 10.0.1.1, 11.0.1, 11.0.1.1, 11.0.1.2, 11.1.0, 11.1.0.1, 11.1.0.2, 12.0.1, 12.0.1.1, 12.0.1.2, 13.0.0, 13.0.1, 13.0.1.1, 14.0.0, 14.0.1, 14.0.3, 14.0.4, 14.0.5, 14.0.6, 15.0.4)\nERROR: No matching distribution found for clang-format==15.0.6\n"
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
