### PR TITLE
fix(docker): replace ADD by RUN curl

### DIFF
--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -43,10 +43,10 @@ RUN rm -rf \
   /etc/apt/sources.list.d/nvidia-docker.list
 
 ## Register Vulkan GPU vendors
-ADD "https://gitlab.com/nvidia/container-images/vulkan/raw/dc389b0445c788901fda1d85be96fd1cb9410164/nvidia_icd.json" /etc/vulkan/icd.d/nvidia_icd.json
-RUN chmod 644 /etc/vulkan/icd.d/nvidia_icd.json
-ADD "https://gitlab.com/nvidia/container-images/opengl/raw/5191cf205d3e4bb1150091f9464499b076104354/glvnd/runtime/10_nvidia.json" /etc/glvnd/egl_vendor.d/10_nvidia.json
-RUN chmod 644 /etc/glvnd/egl_vendor.d/10_nvidia.json
+RUN curl https://gitlab.com/nvidia/container-images/vulkan/raw/dc389b0445c788901fda1d85be96fd1cb9410164/nvidia_icd.json -o /etc/vulkan/icd.d/nvidia_icd.json \
+  && chmod 644 /etc/vulkan/icd.d/nvidia_icd.json
+RUN curl https://gitlab.com/nvidia/container-images/opengl/raw/5191cf205d3e4bb1150091f9464499b076104354/glvnd/runtime/10_nvidia.json -o /etc/glvnd/egl_vendor.d/10_nvidia.json \
+  && chmod 644 /etc/glvnd/egl_vendor.d/10_nvidia.json
 
 ## Register OpenCL GPU vendors
 RUN mkdir -p /etc/OpenCL/vendors \


### PR DESCRIPTION
Fix `invalid not-modified ETag` error

Signed-off-by: Vincent Richard <vincent.francois.richard@gmail.com>

## Description

Downloading data with `ADD` sometimes cause `invalid not-modified ETag` error.
Replaced with `curl`, which seems to work just fine.

See https://github.com/autowarefoundation/autoware/issues/3238

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
