### PR TITLE
ci(actions): add set cuda path action

### DIFF
--- a/.github/actions/set-cuda-path/action.yaml
+++ b/.github/actions/set-cuda-path/action.yaml
@@ -1,0 +1,13 @@
+name: set-cuda-path
+description: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Set cuda path
+      run: |
+        CUDA_PATH=/usr/local/cuda
+        echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
+        echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+      shell: bash


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
add composite action to set cuda path in github actions environment.
I refer [this lines](https://github.com/eyalroz/cuda-api-wrappers/blob/831666a0bfd1af0f44f4fa234ee2d983d347fcaa/.github/action-scripts/install-cuda-ubuntu.sh#L200-L207)

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
https://github.com/autowarefoundation/autoware.universe/pull/2810

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
