### PR TITLE
feat(docker): add --no-prebuilt option to skip prebuilt

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,6 +16,9 @@ while [ "$1" != "" ]; do
         option_platform="$2"
         shift
         ;;
+    --no-prebuilt)
+        option_no_prebuilt=true
+        ;;
     *)
         args+=("$1")
         ;;
@@ -30,6 +33,14 @@ if [ "$option_no_cuda" = "true" ]; then
 else
     setup_args="--no-cuda-drivers"
     image_name_suffix="-cuda"
+fi
+
+# Set prebuilt options
+if [ "$option_no_prebuilt" = "true" ]; then
+    targets="devel"
+else
+    # default targets include devel and prebuilt
+    targets=""
 fi
 
 # Set platform
@@ -60,5 +71,6 @@ docker buildx bake --no-cache --load --progress=plain -f "$SCRIPT_DIR/autoware-u
     --set "*.args.BASE_IMAGE=$base_image" \
     --set "*.args.SETUP_ARGS=$setup_args" \
     --set "devel.tags=ghcr.io/autowarefoundation/autoware-universe:$rosdistro-latest$image_name_suffix" \
-    --set "prebuilt.tags=ghcr.io/autowarefoundation/autoware-universe:$rosdistro-latest-prebuilt$image_name_suffix"
+    --set "prebuilt.tags=ghcr.io/autowarefoundation/autoware-universe:$rosdistro-latest-prebuilt$image_name_suffix" \
+    "$targets"
 set +x


### PR DESCRIPTION
Signed-off-by: Vincent Richard <vincent.francois.richard@gmail.com>

## Description

Although developers can fetch latest docker image from ghcr.io/autowarefoundation/autoware-universe, it is sometimes useful to build the image on your own machine with the `./docker/build.sh` script. Unfortunately, the script does not give the choice not to build the `prebuilt` image, which takes quite a lot of time and is usually not very useful to developers as they would most likely compile Autoware themselves anyway.

For those who don't need the `prebuilt` image, I want to add the option `--no-prebuilt`.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
