### PR TITLE
ci(pre-commit-autoupdate): enable also for public repositories

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   check-secret:
-    if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
     uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
     secrets:
       secret: ${{ secrets.APP_ID }}


### PR DESCRIPTION
Replace `pre-commit.ci` because this can be used more flexibly, for example daily (more frequent) or workflow_dispatch (at any timing).

For those who use `sync-files` like https://github.com/autowarefoundation/autoware.universe/pull/2838 and don't want this workflow to run, they can disable it here: https://github.com/autowarefoundation/autoware/actions/workflows/pre-commit-autoupdate.yaml

![image](https://user-images.githubusercontent.com/31987104/217694681-b35c2077-96b0-48b5-b62c-9a40f9f85875.png)

Related:
- https://github.com/autowarefoundation/autoware/pull/3263
- https://github.com/autowarefoundation/autoware_common/pull/155
