### PR TITLE
fix: add pacmod3_msgs repository for pacmod_interface

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -85,6 +85,10 @@ repositories:
     type: git
     url: https://github.com/tier4/pacmod_interface.git
     version: main
+  vehicle/external/pacmod3_msgs:
+    type: git
+    url: https://github.com/astuff/pacmod3_msgs.git
+    version: 1.0.0
   # param
   param/autoware_individual_params:
     type: git


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
`pacmod_interface` depends on `pacmod3_msgs` https://github.com/tier4/pacmod_interface/blob/main/pacmod_interface/package.xml#L19, but it's not available when doing a source checkout via the `autoware.repos` file.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
