### PR TITLE
fix(setup): install pip in the setup script

### DIFF
--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -113,10 +113,15 @@ if ! (command -v git >/dev/null 2>&1); then
     sudo apt-get -y install git
 fi
 
+# Install pip for ansible
+if ! (python3 -m pip --version >/dev/null 2>&1); then
+    sudo apt-get -y update
+    sudo apt-get -y install python3-pip python3-venv
+fi
+
 # Install pipx for ansible
 if ! (python3 -m pipx --version >/dev/null 2>&1); then
     sudo apt-get -y update
-    sudo apt-get -y install python3-pip python3-venv
     python3 -m pip install --user pipx
 fi
 


### PR DESCRIPTION
## Description

- fix ansible install when type `./setup-dev-env.sh`

related to this problem
` {"changed": false, "msg": "Unable to find any of pip3 to use.  pip needs to be installed."} `
https://stackoverflow.com/questions/57729144/ansible-playbook-error-message-unable-to-find-any-of-pip3-to-use-pip-needs-to


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
