### PR TITLE
feat(setup): change option --no-dev to --runtime

### DIFF
--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -27,9 +27,9 @@ while [ "$1" != "" ]; do
         # Disable installation of 'cuda-drivers' in the role 'cuda'.
         option_no_cuda_drivers=true
         ;;
-    --no-dev)
-        # Disable installation dev packages .
-        option_no_dev=true
+    --runtime)
+        # Disable installation dev package of role 'cuda' and 'tensorrt'.
+        option_runtime=true
         ;;
     *)
         args+=("$1")
@@ -82,8 +82,9 @@ if [ "$option_no_cuda_drivers" = "true" ]; then
 fi
 
 # Check installation of dev package
-if [ "$option_no_dev" = "true" ]; then
+if [ "$option_runtime" = "true" ]; then
     ansible_args+=("--extra-vars" "install_devel=false")
+    # ROS installation type, default "desktop"
     ansible_args+=("--extra-vars" "installation_type=ros-base")
 else
     ansible_args+=("--extra-vars" "install_devel=true")


### PR DESCRIPTION
Signed-off-by: yuexiang.cai sinan.cai@autocore.ai
## Description
Split from https://github.com/autowarefoundation/autoware/pull/2922.

The option --runtime will be used at the `set up runtime environment` phase in [DockerFile](https://github.com/autowarefoundation/autoware/pull/2922/files#diff-36a199a2dbe6455795f2485b956ac1791a8e001492166414332288a216a9aa55:~:text=%23%23%20Set%20up%20runtime%20environment), and the docker base image would be nvidia/cuda:x.x.x-**runtime**-ubuntuxx.xx. For ease of understanding, change the option name from --no-dev to --runtime.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
