### PR TITLE
fix(docker): broken OpenGL with old mesa libs

### DIFF
--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -58,6 +58,7 @@ RUN mkdir -p /etc/OpenCL/vendors \
 ## TODO: remove/re-evaluate after Ubuntu 24.04 is released
 ## Fix OpenGL issues (e.g. black screen in rviz2) due to old mesa lib in Ubuntu 22.04
 ## See https://github.com/autowarefoundation/autoware.universe/issues/2789
+# hadolint ignore=DL3008
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \
   && apt-add-repository ppa:kisak/kisak-mesa \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -55,6 +55,15 @@ RUN mkdir -p /etc/OpenCL/vendors \
   && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd \
   && chmod 644 /etc/OpenCL/vendors/nvidia.icd
 
+## Fix OpenGL issues (e.g. black screen in rviz2) due to old mesa lib in Ubuntu 22.04
+## See https://github.com/autowarefoundation/autoware.universe/issues/2789
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \
+  && apt-add-repository ppa:kisak/kisak-mesa \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  libegl-mesa0 libegl1-mesa-dev libgbm-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri libglapi-mesa libglx-mesa0 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 ## Create entrypoint
 # hadolint ignore=DL3059
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc

--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -59,9 +59,9 @@ RUN mkdir -p /etc/OpenCL/vendors \
 ## Fix OpenGL issues (e.g. black screen in rviz2) due to old mesa lib in Ubuntu 22.04
 ## See https://github.com/autowarefoundation/autoware.universe/issues/2789
 # hadolint ignore=DL3008
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y software-properties-common \
   && apt-add-repository ppa:kisak/kisak-mesa \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   libegl-mesa0 libegl1-mesa-dev libgbm-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri libglapi-mesa libglx-mesa0 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -55,6 +55,7 @@ RUN mkdir -p /etc/OpenCL/vendors \
   && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd \
   && chmod 644 /etc/OpenCL/vendors/nvidia.icd
 
+## TODO: remove/re-evaluate after Ubuntu 24.04 is released
 ## Fix OpenGL issues (e.g. black screen in rviz2) due to old mesa lib in Ubuntu 22.04
 ## See https://github.com/autowarefoundation/autoware.universe/issues/2789
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \


### PR DESCRIPTION
## Description

Fix https://github.com/autowarefoundation/autoware.universe/issues/2789

How to test:
```sh
# build and test on cuda version
$ ./docker/build.sh --no-prebuilt
$ docker run --rm --network=host -e DISPLAY -e XAUTHORITY=/tmp/.Xauthority -v ~/.Xauthority:/tmp/.Xauthority -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda /bin/bash -c "source /opt/ros/humble/setup.bash; ros2 run rviz2 rviz2"
# build and test on no cuda version
$ ./docker/build.sh --no-prebuilt --no-cuda
$ docker run --rm --network=host -e DISPLAY -e XAUTHORITY=/tmp/.Xauthority -v ~/.Xauthority:/tmp/.Xauthority -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/autowarefoundation/autoware-universe:humble-latest /bin/bash -c "source /opt/ros/humble/setup.bash; ros2 run rviz2 rviz2"
```
- Before the PR -> rviz2 opens with 3D view all black
- After the PR -> rviz2 shows default 3D view (with the grid)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
