### PR TITLE
revert: revert "ci(pre-commit-optional): autoupdate"

### DIFF
--- a/.pre-commit-config-optional.yaml
+++ b/.pre-commit-config-optional.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.11.0
+    rev: v3.10.3
     hooks:
       - id: markdown-link-check
         args: [--config=.markdown-link-check.json]


### PR DESCRIPTION
Reverts autowarefoundation/autoware#3349 because it has a bug: https://github.com/tcort/markdown-link-check/pull/249