### PR TITLE
ci(pre-commit-optional): add quiet option to show only errors

### DIFF
--- a/.pre-commit-config-optional.yaml
+++ b/.pre-commit-config-optional.yaml
@@ -3,4 +3,4 @@ repos:
     rev: v3.11.1
     hooks:
       - id: markdown-link-check
-        args: [--config=.markdown-link-check.json]
+        args: [--quiet, --config=.markdown-link-check.json]


### PR DESCRIPTION
## Description

>   -q, --quiet            displays errors only

Even if the test passes, the log is output, so it's hard to find the error. This option solves it.

## Tests performed

Not applicable.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
