### PR TITLE
feat(autoware.repos): change velodyne driver repository to AWF

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -75,10 +75,10 @@ repositories:
     type: git
     url: https://github.com/tier4/tamagawa_imu_driver.git
     version: ros2
-  sensor_component/external/velodyne_vls:
+  sensor_component/external/awf_velodyne:
     type: git
-    url: https://github.com/tier4/velodyne_vls.git
-    version: tier4/universe
+    url: https://github.com/autowarefoundation/awf_velodyne.git
+    version: awf/main
   # sensor_kit
   sensor_kit/sample_sensor_kit_launch:
     type: git


### PR DESCRIPTION
## Description
In order to create debian package, we are renaming velodyne driver packages by adding prefix `awf_` so that we can avoid conflict with the upstream packages.

This PR will point to the branch with renamed packages.

Related Issue:
https://github.com/autowarefoundation/autoware/issues/3222#issuecomment-1475656867
<!-- Write a brief description of this PR. -->

## Notes to reviewers
This should be merged with other PRs for launch files:
- sensor_kit_launch
- awsim_sensor_kit_launch

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
