### PR TITLE
revert: "feat(repos): add heaphook to repos (#3306)"

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -102,8 +102,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_individual_params.git
     version: main
-  # middleware
-  middleware/external/heaphook:
-    type: git
-    url: https://github.com/tier4/heaphook.git
-    version: main


### PR DESCRIPTION
This reverts commit 2f4855cdafcead27958e1da0cf92f5947c0d57e4.

## Description

This PR should be merged after next humble sync.
```
❯ sudo apt-cache policy ros-humble-heaphook
ros-humble-heaphook:
  Installed: 0.1.0-1jammy.20230523.212338
  Candidate: 0.1.0-1jammy.20230523.212338
  Version table:
 *** 0.1.0-1jammy.20230523.212338 500
        500 http://packages.ros.org/ros2-testing/ubuntu jammy/main amd64 Packages
        100 /var/lib/dpkg/status
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
