### PR TITLE
fix(repos): autoware_common to sync lanlet2 

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,8 +1,11 @@
 exclude_paths:
   - src/
+  - build/
+  - install/
+  - log/
 
 skip_list:
-  - meta-no-info # We don't publish to Ansible Galaxy.
+  - galaxy # We don't publish to Ansible Galaxy.
   - package-latest # Since this is a development environment, we allow the latest versions.
 
 warn_list: []

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -1,5 +1,7 @@
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v6.9.0
+    rev: v6.16.1
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          - ansible

--- a/ansible/playbooks/core.yaml
+++ b/ansible/playbooks/core.yaml
@@ -1,4 +1,5 @@
-- hosts: localhost
+- name: Set up source development environments for Autoware Core
+  hosts: localhost
   connection: local
   pre_tasks:
     - name: Verify OS

--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -1,4 +1,5 @@
-- hosts: localhost
+- name: Set up Docker development environments for Autoware
+  hosts: localhost
   connection: local
   vars_prompt:
     - name: prompt_install_nvidia

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -1,4 +1,5 @@
-- hosts: localhost
+- name: Set up source development environments for Autoware Universe
+  hosts: localhost
   connection: local
   vars_prompt:
     - name: prompt_install_nvidia

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -38,22 +38,22 @@
 
 - name: Get dash-case name of cuda_version
   ansible.builtin.shell: bash -c 'sed -e "s/\./-/g" <<< $(echo {{ cuda_version }})'
-  register: dash_case_cuda_version
+  register: cuda__dash_case_cuda_version
   changed_when: false
 
 - name: Install CUDA libraries except for cuda-drivers
   become: true
   ansible.builtin.apt:
     name:
-      - cuda-cudart-dev-{{ dash_case_cuda_version.stdout }}
-      - cuda-command-line-tools-{{ dash_case_cuda_version.stdout }}
-      - cuda-minimal-build-{{ dash_case_cuda_version.stdout }}
-      - cuda-libraries-dev-{{ dash_case_cuda_version.stdout }}
-      - cuda-nvml-dev-{{ dash_case_cuda_version.stdout }}
-      - cuda-nvprof-{{ dash_case_cuda_version.stdout }}
-      - libnpp-dev-{{ dash_case_cuda_version.stdout }}
-      - libcusparse-dev-{{ dash_case_cuda_version.stdout }}
-      - libcublas-dev-{{ dash_case_cuda_version.stdout }}
+      - cuda-cudart-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - cuda-command-line-tools-{{ cuda__dash_case_cuda_version.stdout }}
+      - cuda-minimal-build-{{ cuda__dash_case_cuda_version.stdout }}
+      - cuda-libraries-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - cuda-nvml-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - cuda-nvprof-{{ cuda__dash_case_cuda_version.stdout }}
+      - libnpp-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - libcusparse-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - libcublas-dev-{{ cuda__dash_case_cuda_version.stdout }}
       - libnccl-dev
     update_cache: true
 

--- a/ansible/roles/docker_engine/tasks/main.yaml
+++ b/ansible/roles/docker_engine/tasks/main.yaml
@@ -37,24 +37,24 @@
 
 - name: Save result of 'dpkg --print-architecture'
   ansible.builtin.command: dpkg --print-architecture
-  register: deb_architecture
+  register: docker_engine__deb_architecture
   changed_when: false
 
 - name: Save result of 'lsb_release -cs'
   ansible.builtin.command: lsb_release -cs
-  register: lsb_release_cs
+  register: docker_engine__lsb_release_cs
   changed_when: false
 
 - name: Save result of 'lsb_release -is'
   ansible.builtin.command: lsb_release -is
-  register: lsb_release_is
+  register: docker_engine__lsb_release_is
   changed_when: false
 
 # echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 - name: Add Docker apt repository to source list
   become: true
   ansible.builtin.apt_repository:
-    repo: deb [arch={{ deb_architecture.stdout }} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/{{ lsb_release_is.stdout | lower }} {{ lsb_release_cs.stdout }} stable
+    repo: deb [arch={{ docker_engine__deb_architecture.stdout }} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/{{ docker_engine__lsb_release_is.stdout | lower }} {{ docker_engine__lsb_release_cs.stdout }} stable
     filename: docker
     state: present
     update_cache: true

--- a/ansible/roles/git_lfs/tasks/main.yaml
+++ b/ansible/roles/git_lfs/tasks/main.yaml
@@ -8,11 +8,12 @@
 
 # ref: https://github.com/ansible/ansible-lint/issues/1780
 - name: Check if git lfs is installed # https://github.com/git-lfs/git-lfs/issues/901
-  git_config:
+  community.general.git_config:
     list_all: true
     scope: global
-  register: git_global_config
+  register: git_lfs__git_global_config
 
 - name: Setup Git LFS
-  command: git lfs install
-  when: "'filter.lfs.required' not in git_global_config.config_values"
+  ansible.builtin.command: git lfs install
+  when: "'filter.lfs.required' not in git_lfs__git_global_config.config_values"
+  changed_when: true

--- a/ansible/roles/nvidia_docker/tasks/main.yaml
+++ b/ansible/roles/nvidia_docker/tasks/main.yaml
@@ -5,12 +5,12 @@
 
 - name: Save result of '. /etc/os-release;echo $ID$VERSION_ID'
   ansible.builtin.shell: . /etc/os-release;echo $ID$VERSION_ID
-  register: distribution
+  register: nvidia_docker__distribution
   changed_when: false
 
 - name: Save result of 'curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list'
   ansible.builtin.uri:
-    url: https://nvidia.github.io/nvidia-docker/{{ distribution.stdout }}/nvidia-docker.list
+    url: https://nvidia.github.io/nvidia-docker/{{ nvidia_docker__distribution.stdout }}/nvidia-docker.list
     return_content: true
   register: nvidia_docker_list
 

--- a/ansible/roles/pacmod/tasks/main.yaml
+++ b/ansible/roles/pacmod/tasks/main.yaml
@@ -6,14 +6,14 @@
 
 - name: Save result of 'lsb_release -sc'
   ansible.builtin.command: lsb_release -sc
-  register: lsb_release
+  register: pacmod__lsb_release
   changed_when: false
 
 # echo "deb [trusted=yes] https://s3.amazonaws.com/autonomoustuff-repo/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/autonomoustuff-public.list
 - name: Add AutonomouStuff apt repository to source list
   become: true
   ansible.builtin.apt_repository:
-    repo: deb [trusted=yes] https://s3.amazonaws.com/autonomoustuff-repo/ {{ lsb_release.stdout }} main
+    repo: deb [trusted=yes] https://s3.amazonaws.com/autonomoustuff-repo/ {{ pacmod__lsb_release.stdout }} main
     filename: autonomoustuff-public
     state: present
     update_cache: true

--- a/ansible/roles/rmw_implementation/tasks/main.yaml
+++ b/ansible/roles/rmw_implementation/tasks/main.yaml
@@ -1,12 +1,12 @@
 - name: Get dash-case name of rmw_implementation
   ansible.builtin.shell: bash -c 'sed -e "s/_/-/g" <<< $(echo {{ rmw_implementation }})'
-  register: dash_case_rmw_implementation
+  register: rmw_implementation__dash_case_rmw_implementation
   changed_when: false
 
-- name: Install ros-{{ rosdistro }}-{{ dash_case_rmw_implementation.stdout }}
+- name: Install ros-{{ rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout }}
   become: true
   ansible.builtin.apt:
-    name: ros-{{ rosdistro }}-{{ dash_case_rmw_implementation.stdout }}
+    name: ros-{{ rosdistro }}-{{ rmw_implementation__dash_case_rmw_implementation.stdout }}
     state: latest
     update_cache: true
 

--- a/ansible/roles/rocker/tasks/main.yaml
+++ b/ansible/roles/rocker/tasks/main.yaml
@@ -4,22 +4,23 @@
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
     dest: /usr/share/keyrings/ros-archive-keyring.gpg
+    mode: 644
 
 - name: Save result of 'dpkg --print-architecture'
   ansible.builtin.command: dpkg --print-architecture
-  register: deb_architecture
+  register: rocker__deb_architecture
   changed_when: false
 
 - name: Save result of 'lsb_release -cs'
   ansible.builtin.command: lsb_release -cs
-  register: lsb_release_cs
+  register: rocker__lsb_release_cs
   changed_when: false
 
 # echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 - name: Add ROS 2 apt repository to source list
   become: true
   ansible.builtin.apt_repository:
-    repo: deb [arch={{ deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ lsb_release_cs.stdout }} main
+    repo: deb [arch={{ rocker__deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ rocker__lsb_release_cs.stdout }} main
     filename: ros2
     state: present
     update_cache: true

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -13,27 +13,28 @@
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
     dest: /usr/share/keyrings/ros-archive-keyring.gpg
+    mode: 644
 
 - name: Save result of 'dpkg --print-architecture'
   ansible.builtin.command: dpkg --print-architecture
-  register: deb_architecture
+  register: ros2__deb_architecture
   changed_when: false
 
 - name: Save result of 'source /etc/os-release && echo $UBUNTU_CODENAME'
   ansible.builtin.shell: bash -c 'source /etc/os-release && echo $UBUNTU_CODENAME'
-  register: ubuntu_codename
+  register: ros2__ubuntu_codename
   changed_when: false
 
 # echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 - name: Add ROS 2 apt repository to source list
   become: true
   ansible.builtin.apt_repository:
-    repo: deb [arch={{ deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ ubuntu_codename.stdout }} main
+    repo: deb [arch={{ ros2__deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ ros2__ubuntu_codename.stdout }} main
     filename: ros2
     state: present
     update_cache: true
 
-- name: Install ros-{{ rosdistro }}-{{ installation_type }}
+- name: Install ros-{{ rosdistro + '-' + installation_type }}
   become: true
   ansible.builtin.apt:
     name: ros-{{ rosdistro }}-{{ installation_type }}

--- a/autoware.repos
+++ b/autoware.repos
@@ -11,7 +11,7 @@ repositories:
   core/autoware_common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
-    version: 34338c0d9e68ea8c7598a66f319cdcb6d92873a3
+    version: awsim-stable
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Because of the update of lanelet2, humble `autoware_common`  build fails.
To take in the below hotfixes, update the `autoware_common` hash to `awsim-stable`,
- https://github.com/autowarefoundation/autoware_common/pull/183
- https://github.com/autowarefoundation/autoware_common/pull/184

[TIER IV internal link](https://star4.slack.com/archives/C4P0NSMB5/p1685519926106899)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

success build locally

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
