### PR TITLE
Fix/repos edgeauto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Autoware - the world's leading open-source software project for autonomous driving
+# Edge.Auto
 
 ![Autoware_RViz](https://user-images.githubusercontent.com/63835446/158918717-58d6deaf-93fb-47f9-891d-e242b02cba7b.png)
 [![Discord](https://img.shields.io/discord/953808765935816715?label=Autoware%20Discord&style=for-the-badge)](https://discord.gg/Q94UsPvReQ)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ mkdir src
 vcs import src < autoware.repos
 
 source /opt/ros/humble/setup.bash
-rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+rosdep install -y -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
   --packages-up-to edge_auto_launch

--- a/README.md
+++ b/README.md
@@ -1,51 +1,20 @@
 # Edge.Auto
 
-![Autoware_RViz](https://user-images.githubusercontent.com/63835446/158918717-58d6deaf-93fb-47f9-891d-e242b02cba7b.png)
-[![Discord](https://img.shields.io/discord/953808765935816715?label=Autoware%20Discord&style=for-the-badge)](https://discord.gg/Q94UsPvReQ)
+## Getting Started
 
-Autoware is an open-source software stack for self-driving vehicles, built on the [Robot Operating System (ROS)](https://www.ros.org/). It includes all of the necessary functions to drive an autonomous vehicles from localization and object detection to route planning and control, and was created with the aim of enabling as many individuals and organizations as possible to contribute to open innovations in autonomous driving technology.
+```sh
+git clone https://github.com/tier4/edge-auto.git
+cd edge-auto
 
-![Autoware architecture](https://static.wixstatic.com/media/984e93_552e338be28543c7949717053cc3f11f~mv2.png/v1/crop/x_0,y_1,w_1500,h_879/fill/w_863,h_506,al_c,usm_0.66_1.00_0.01,enc_auto/Autoware-GFX_edited.png)
+./setup-dev-env.sh
 
-## Documentation
+cd autoware
+mkdir src
+vcs import src < autoware.repos
 
-To learn more about using or developing Autoware, refer to the [Autoware documentation site](https://autowarefoundation.github.io/autoware-documentation/main/). You can find the source for the documentation in [autowarefoundation/autoware-documentation](https://github.com/autowarefoundation/autoware-documentation).
+source /opt/ros/humble/setup.bash
+rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 
-## Repository overview
-
-- [autowarefoundation/autoware](https://github.com/autowarefoundation/autoware)
-  - Meta-repository containing `.repos` files to construct an Autoware workspace.
-  - It is anticipated that this repository will be frequently forked by users, and so it contains minimal information to avoid unnecessary differences.
-- [autowarefoundation/autoware_common](https://github.com/autowarefoundation/autoware_common)
-  - Library/utility type repository containing commonly referenced ROS packages.
-  - These packages were moved to a separate repository in order to reduce CI execution time
-- [autowarefoundation/autoware.core](https://github.com/autowarefoundation/autoware.core)
-  - Main repository for high-quality, stable ROS packages for Autonomous Driving.
-  - Based on [Autoware.Auto](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto) and [Autoware.Universe](https://github.com/autowarefoundation/autoware.universe).
-- [autowarefoundation/autoware.universe](https://github.com/autowarefoundation/autoware.universe)
-  - Repository for experimental, cutting-edge ROS packages for Autonomous Driving.
-  - Autoware Universe was created to make it easier for researchers and developers to extend the functionality of Autoware Core
-- [autowarefoundation/autoware_launch](https://github.com/autowarefoundation/autoware_launch)
-  - Launch configuration repository containing node configurations and their parameters.
-- [autowarefoundation/autoware-github-actions](https://github.com/autowarefoundation/autoware-github-actions)
-  - Contains [reusable GitHub Actions workflows](https://docs.github.com/ja/actions/learn-github-actions/reusing-workflows) used by multiple repositories for CI.
-  - Utilizes the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) concept.
-- [autowarefoundation/autoware-documentation](https://github.com/autowarefoundation/autoware-documentation)
-  - Documentation repository for Autoware users and developers.
-  - Since Autoware Core/Universe has multiple repositories, a central documentation repository is important to make information accessible from a single place.
-
-## Using Autoware.AI
-
-If you wish to use Autoware.AI, the previous version of Autoware based on ROS 1, switch to [autoware-ai](https://github.com/autowarefoundation/autoware.ai/tree/autoware-ai) branch. However, be aware that Autoware.AI will reach the end-of-life by the end of 2022, and we strongly recommend transitioning to Autoware Core/Universe for future use.
-
-## Contributing
-
-- [There is no formal process to become a contributor](https://github.com/autowarefoundation/autoware-projects/wiki#contributors) - you can comment on any [existing issues](https://github.com/autowarefoundation/autoware.universe/issues) or make a pull request on any Autoware repository!
-  - Make sure to follow the [Contribution Guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
-  - Take a look at Autoware's [various working groups](https://github.com/autowarefoundation/autoware-projects/wiki#working-group-list) to gain an understanding of any work in progress and to see how projects are managed.
-- If you have any technical questions, you can start a discussion in the [Q&A category](https://github.com/autowarefoundation/autoware/discussions/categories/q-a) to request help and confirm if a potential issue is a bug or not.
-
-## Useful resources
-
-- [Autoware Foundation homepage](https://www.autoware.org/)
-- [Support guidelines](https://autowarefoundation.github.io/autoware-documentation/main/support/support-guidelines/)
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
+  --packages-up-to edge_auto_launch
+```

--- a/autoware.repos
+++ b/autoware.repos
@@ -33,7 +33,7 @@ repositories:
     version: main
   individual_params:
     type: git
-    url: https://github.com/tier4/perception_ecu_individual_params.git  # (TODO) rename repo
+    url: https://github.com/tier4/edge_auto_individual_params.git
     version: main
   calibration_tools:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -11,6 +11,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main
+  autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: main
   autoware_auto_msgs:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
@@ -39,3 +43,31 @@ repositories:
     type: git
     url: git@github.com:tier4/nebula.git
     version: main
+  transport_drivers:
+    type: git
+    url: https://github.com/MapIV/transport_drivers.git
+    version: tcp
+  lidartag:
+    type: git
+    url: git@github.com:tier4/LiDARTag.git
+    version: humble
+  lidartag_msgs:
+    type: git
+    url: git@github.com:tier4/LiDARTag_msgs.git
+    version: tier4/universe
+  apriltag_msgs:
+    type: git
+    url: git@github.com:christianrauch/apriltag_msgs.git
+    version: 2.0.0
+  apriltag_ros:
+    type: git
+    url: git@github.com:christianrauch/apriltag_ros.git
+    version: e814e9e5d5f1bfb60a4aa685d30977c632bbc540
+  ros2_numpy:
+    type: git
+    url: git@github.com:Box-Robotics/ros2_numpy.git
+    version: humble
+  image_pipeline:
+    type: git
+    url: https://github.com/tier4/image_pipeline.git
+    version: 47964112293eb19f9f57254b2e6b68706954cc63

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,109 +1,41 @@
 repositories:
-  # core
-  core/autoware_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: main
-  core/autoware_adapi_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: main
-  core/autoware_common:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
-    version: main
-  core/autoware.core:
-    type: git
-    url: https://github.com/autowarefoundation/autoware.core.git
-    version: main
-  core/external/autoware_auto_msgs: # TODO(mfc): Remove when autoware_msgs is merged
-    type: git
-    url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
-  # universe
-  universe/autoware.universe:
+  autoware.universe:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe.git
     version: main
-  universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Improve design/code and transfer to AWF
+  autoware_common:
     type: git
-    url: https://github.com/tier4/tier4_ad_api_adaptor.git
-    version: tier4/universe
-  universe/external/tier4_autoware_msgs:
+    url: https://github.com/autowarefoundation/autoware_common.git
+    version: main
+  autoware_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: main
+  autoware_auto_msgs:
+    type: git
+    url: https://github.com/tier4/autoware_auto_msgs.git
+    version: tier4/main
+  autoware.universe:
+    type: git
+    url: https://github.com/autowarefoundation/autoware.universe.git
+    version: main
+  tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: tier4/universe
-  universe/external/morai_msgs:
+  launcher:
     type: git
-    url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
+    url: https://github.com/tier4/edge_auto_launch.git
     version: main
-  universe/external/muSSP:
+  individual_params:
     type: git
-    url: https://github.com/tier4/muSSP.git
-    version: tier4/main
-  universe/external/ndt_omp:
-    type: git
-    url: https://github.com/tier4/ndt_omp.git
-    version: tier4/main
-  universe/external/pointcloud_to_laserscan:
-    type: git
-    url: https://github.com/tier4/pointcloud_to_laserscan.git
-    version: tier4/main
-  universe/external/eagleye:
-    type: git
-    url: https://github.com/MapIV/eagleye.git
-    version: autoware-main
-  universe/external/rtklib_ros_bridge:
-    type: git
-    url: https://github.com/MapIV/rtklib_ros_bridge.git
-    version: ros2-v0.1.0
-  universe/external/llh_converter:
-    type: git
-    url: https://github.com/MapIV/llh_converter.git
-    version: ros2
-  # launcher
-  launcher/autoware_launch:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_launch.git
+    url: https://github.com/tier4/perception_ecu_individual_params.git  # (TODO) rename repo
     version: main
-  # sensor_component
-  sensor_component/external/sensor_component_description:
+  calibration_tools:
     type: git
-    url: https://github.com/tier4/sensor_component_description.git
+    url: https://github.com/tier4/CalibrationTools.git
     version: main
-  sensor_component/external/tamagawa_imu_driver:
+  nebula:
     type: git
-    url: https://github.com/tier4/tamagawa_imu_driver.git
-    version: ros2
-  sensor_component/external/velodyne_vls:
-    type: git
-    url: https://github.com/tier4/velodyne_vls.git
-    version: tier4/universe
-  # sensor_kit
-  sensor_kit/sample_sensor_kit_launch:
-    type: git
-    url: https://github.com/autowarefoundation/sample_sensor_kit_launch.git
-    version: main
-  sensor_kit/external/awsim_sensor_kit_launch: # TODO: Integrate into sample_sensor_kit_launch
-    type: git
-    url: https://github.com/RobotecAI/awsim_sensor_kit_launch.git
-    version: main
-  # vehicle
-  vehicle/sample_vehicle_launch:
-    type: git
-    url: https://github.com/autowarefoundation/sample_vehicle_launch.git
-    version: main
-  vehicle/external/pacmod_interface:
-    type: git
-    url: https://github.com/tier4/pacmod_interface.git
-    version: main
-  # param
-  param/autoware_individual_params:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_individual_params.git
-    version: main
-  # middleware
-  middleware/external/heaphook:
-    type: git
-    url: https://github.com/tier4/heaphook.git
+    url: git@github.com:tier4/nebula.git
     version: main

--- a/autoware.repos
+++ b/autoware.repos
@@ -38,7 +38,7 @@ repositories:
   calibration_tools:
     type: git
     url: https://github.com/tier4/CalibrationTools.git
-    version: main
+    version: tier4/universe
   nebula:
     type: git
     url: git@github.com:tier4/nebula.git

--- a/simulator.repos
+++ b/simulator.repos
@@ -1,5 +1,0 @@
-repositories:
-  simulator/scenario_simulator:
-    type: git
-    url: https://github.com/tier4/scenario_simulator_v2.git
-    version: master


### PR DESCRIPTION
## Related Links

https://github.com/tier4/edge-auto-jetson/pull/24

## Description

I changed repo names according to renaming `perception_ecu` -> `edge_auto`.

## Review Procedure

```sh
vcs import src < autoware.repos
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
