### PR TITLE
ci(docker-build-and-push): add provenance=false to fix errors in combining multi-arch images

### DIFF
--- a/.github/actions/combine-multi-arch-images/action.yaml
+++ b/.github/actions/combine-multi-arch-images/action.yaml
@@ -95,11 +95,12 @@ runs:
           echo "amd64_image: $amd64_image"
           echo "arm64_image: $arm64_image"
 
-          docker manifest create ${{ steps.set-image-name.outputs.image-name }}:$base_tag \
+          if docker manifest create ${{ steps.set-image-name.outputs.image-name }}:$base_tag \
             $amd64_image \
-            $arm64_image
+            $arm64_image; then
 
-          docker manifest push ${{ steps.set-image-name.outputs.image-name }}:$base_tag
+            docker manifest push ${{ steps.set-image-name.outputs.image-name }}:$base_tag
+          fi
         done
       env:
         ALL_TAGS: ${{ steps.get-all-tags.outputs.tags }}

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -84,7 +84,7 @@ runs:
         password: ${{ github.token }}
 
     - name: Build and push
-      uses: docker/bake-action@v2
+      uses: docker/bake-action@v3
       with:
         # Checking event_name for https://github.com/autowarefoundation/autoware/issues/2796
         push: ${{ github.event_name == 'schedule' || github.ref_name == github.event.repository.default_branch || github.event_name == 'push'}}
@@ -92,5 +92,6 @@ runs:
           docker/${{ inputs.bake-target }}/docker-bake.hcl
           ${{ steps.meta-devel.outputs.bake-file }}
           ${{ steps.meta-prebuilt.outputs.bake-file }}
+        provenance: false
         set: |
           ${{ inputs.build-args }}


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

There is an error occurring in creating Docker manifests now.
https://github.com/orgs/autowarefoundation/discussions/3594

Seeing https://github.com/docker/buildx/issues/1509, probably `provenance` is the cause.
So I disabled it.

Other reference links:
- https://github.com/docker/bake-action#customizing
- https://github.com/docker/build-push-action/releases/tag/v4.0.0
- https://docs.docker.com/build/attestations/slsa-provenance/
- https://docs.docker.com/build/attestations/attestation-storage/

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
