### PR TITLE
build(CUDA): update CUDA repo OS, and use nvidia/cuda image as a cuda_base_image

### DIFF
--- a/amd64.env
+++ b/amd64.env
@@ -1,8 +1,8 @@
 rosdistro=humble
 rmw_implementation=rmw_cyclonedds_cpp
 base_image=ubuntu:22.04
-cuda_base_image=ubuntu:22.04
+cuda_base_image=nvidia/cuda:12.0.0-devel-ubuntu22.04
 prebuilt_base_image=ubuntu:22.04
-cuda_version=11.6
-cudnn_version=8.4.1.50-1+cuda11.6
-tensorrt_version=8.4.2-1+cuda11.6
+cuda_version=12.0
+cudnn_version=8.8.1.3-1+cuda12.0
+tensorrt_version=8.6.1.6-1+cuda12.0

--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -20,8 +20,8 @@
           [Warning] Skipping installation of NVIDIA libraries. Please manually install them if you plan to use any dependent components.
       when: prompt_install_nvidia != 'y'
   roles:
-#    - role: autoware.dev_env.cuda
-#      when: prompt_install_nvidia == 'y' and install_devel == 'true'
+    #    - role: autoware.dev_env.cuda
+    #      when: prompt_install_nvidia == 'y' and install_devel == 'true'
     - role: autoware.dev_env.docker_engine
     - role: autoware.dev_env.nvidia_docker
     - role: autoware.dev_env.rocker

--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -20,8 +20,8 @@
           [Warning] Skipping installation of NVIDIA libraries. Please manually install them if you plan to use any dependent components.
       when: prompt_install_nvidia != 'y'
   roles:
-    - role: autoware.dev_env.cuda
-      when: prompt_install_nvidia == 'y' and install_devel == 'true'
+#    - role: autoware.dev_env.cuda
+#      when: prompt_install_nvidia == 'y' and install_devel == 'true'
     - role: autoware.dev_env.docker_engine
     - role: autoware.dev_env.nvidia_docker
     - role: autoware.dev_env.rocker

--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -21,16 +21,7 @@ wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/auto
 
 # Modified from: https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network
 
-# A temporary workaround for Ubuntu 22.04 with the ubuntu2004 repository
-if [[ "$(uname -m)" == "x86_64" ]]; then
-  liburcu6_url=http://archive.ubuntu.com/ubuntu
-else
-  liburcu6_url=http://ports.ubuntu.com/ubuntu-ports
-fi
-sudo echo "deb $liburcu6_url focal main restricted" > /etc/apt/sources.list.d/focal.list
-
-# TODO: Use 22.04 in https://github.com/autowarefoundation/autoware/pull/3084. Currently, 20.04 is intentionally used.
-os=ubuntu2004
+os=ubuntu2204
 wget https://developer.download.nvidia.com/compute/cuda/repos/$os/$(uname -m)/cuda-keyring_1.0-1_all.deb
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
 sudo apt-get update

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -17,7 +17,7 @@
 - name: Install CUDA keyring
   become: true
   ansible.builtin.apt:
-    deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/{{ cuda_architecture.stdout }}/cuda-keyring_1.0-1_all.deb
+    deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/{{ cuda_architecture.stdout }}/cuda-keyring_1.0-1_all.deb
     update_cache: true
 
 - name: Get dash-case name of cuda_version

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -8,22 +8,6 @@
   register: cuda_architecture
   changed_when: false
 
-- name: (tmp for Ubuntu 22.04) Add liburcu6 repository into sources.list for amd64
-  become: true
-  ansible.builtin.apt_repository:
-    repo: deb http://archive.ubuntu.com/ubuntu focal main restricted
-    filename: focal
-    state: present
-  when: cuda_architecture.stdout == "x86_64"
-
-- name: (tmp for Ubuntu 22.04) Add liburcu6 repository into sources.list for arm64
-  become: true
-  ansible.builtin.apt_repository:
-    repo: deb http://ports.ubuntu.com/ubuntu-ports focal main restricted
-    filename: focal
-    state: present
-  when: cuda_architecture.stdout == "aarch64"
-
 - name: Remove old /etc/apt/sources.list.d/cuda.list
   become: true
   ansible.builtin.file:


### PR DESCRIPTION
## Description

- remove workarounds and upgrade to the version that officially supports Ubuntu 22.04. 
  - use CUDA 12.0
  - use nvidia/cuda image as  a cuda_base_image

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
https://github.com/autowarefoundation/autoware/pull/3084
https://github.com/autowarefoundation/autoware/pull/3408


## Tests performed

<!-- Describe how you have tested this PR. -->
TBD

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
TBD

## Interface changes

N/A

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
TBD

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
