### PR TITLE
feat(autoware.repos): change vls driver to nebula driver

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -75,10 +75,14 @@ repositories:
     type: git
     url: https://github.com/tier4/tamagawa_imu_driver.git
     version: ros2
-  sensor_component/external/velodyne_vls:
+  sensor_component/external/nebula:
     type: git
-    url: https://github.com/tier4/velodyne_vls.git
-    version: tier4/universe
+    url: https://github.com/tier4/nebula.git
+    version: main
+  sensor_component/external/transport_drivers:
+    type: git
+    url: https://github.com/MapIV/transport_drivers.git
+    version: tcp
   # sensor_kit
   sensor_kit/sample_sensor_kit_launch:
     type: git


### PR DESCRIPTION
## Description

**This PR should be tested in conjunction with** https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/64
This PR changes the LiDAR driver used from `velodyne_vls` to [Nebula](https://github.com/tier4/nebula).
Nebula is actively maintained, supports more different LiDARs, and has been tested to have feature parity with `velodyne_vls` for Velodyne VLP16 and Velodyne VLS128.

## Tests performed

This has been tested with the Autoware `sample_sensor_kit_launch` on branch `feat/nebula` and the sample Autoware map and rosbag data found here:
https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/

Localization, pointcloud preprocessing, and perception were all found to work with the same performance as with the previous `velodyne_vls` driver.

## Effects on system behavior

System behavior should be the same as when using the previous `velodyne_vls` LiDAR driver, with some performance benefits (and more to come as Nebula is developed and optimized).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
