### PR TITLE
feat(ansible): add yabloc archive extraction to andsible script

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -13,6 +13,11 @@
     mode: "644"
     checksum: sha256:1f660e15f95074bade32b1f80dbf618e9cee1f0b9f76d3f4671cb9be7f56eb3a
 
+- name: Extract yabloc_pose_initializer/resources.tar.gz
+  ansible.builtin.unarchive:
+    src: "{{ data_dir }}/yabloc_pose_initializer/resources.tar.gz"
+    dest: "{{ data_dir }}/yabloc_pose_initializer/"
+
 # image_projection_based_fusion
 - name: Create image_projection_based_fusion directory inside {{ data_dir }}
   ansible.builtin.file:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Add extraction step after downloading artifacts for yabloc_pose_initializer. Otherwise package will not be able to access it's artifacts.  

See https://github.com/autowarefoundation/autoware.universe/issues/3137

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
