### PR TITLE
ci(workflows): update bot labels

### DIFF
--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -29,8 +29,8 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           pre-commit-config: .pre-commit-config-ansible.yaml
           pr-labels: |
-            bot
-            pre-commit-ansible-autoupdate
+            tag:bot
+            tag:pre-commit-autoupdate
           pr-branch: pre-commit-ansible-autoupdate
           pr-title: "ci(pre-commit-ansible): autoupdate"
           pr-commit-message: "ci(pre-commit-ansible): autoupdate"

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -29,8 +29,8 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           pre-commit-config: .pre-commit-config.yaml
           pr-labels: |
-            bot
-            pre-commit-autoupdate
+            tag:bot
+            tag:pre-commit-autoupdate
           pr-branch: pre-commit-autoupdate
           pr-title: "ci(pre-commit): autoupdate"
           pr-commit-message: "ci(pre-commit): autoupdate"

--- a/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -29,8 +29,8 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           pre-commit-config: .pre-commit-config-optional.yaml
           pr-labels: |
-            bot
-            pre-commit-optional-autoupdate
+            tag:bot
+            tag:pre-commit-autoupdate
           pr-branch: pre-commit-optional-autoupdate
           pr-title: "ci(pre-commit-optional): autoupdate"
           pr-commit-message: "ci(pre-commit-optional): autoupdate"

--- a/.github/workflows/update-tool-versions.yaml
+++ b/.github/workflows/update-tool-versions.yaml
@@ -49,8 +49,8 @@ jobs:
           commit-message: "chore: update tool versions"
           body: ""
           labels: |
-            bot
-            update-tool-versions
+            tag:bot
+            tag:update-tool-versions
           signoff: true
           delete-branch: true
 


### PR DESCRIPTION
## Description

Part of:
- https://github.com/autowarefoundation/autoware/issues/3955

Updates the labels for some bots.
Also merges `pre-commit-autoupdate` and its friends under a single label.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
