### PR TITLE
refactor(ansible): rename some variables to conform new lint rules

### DIFF
--- a/.github/workflows/update-tool-versions.yaml
+++ b/.github/workflows/update-tool-versions.yaml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Update clang-format version
         run: |
-          sd '(clang_format_version): .*' '$1: ${{ steps.get-clang-format-version.outputs.version }}' ansible/roles/pre_commit/defaults/main.yaml
-          sd '(clang_format_version)=.*' '$1=${{ steps.get-clang-format-version.outputs.version }}' ansible/roles/pre_commit/README.md
+          sd '(pre_commit_clang_format_version): .*' '$1: ${{ steps.get-clang-format-version.outputs.version }}' ansible/roles/pre_commit/defaults/main.yaml
+          sd '(pre_commit_clang_format_version)=.*' '$1=${{ steps.get-clang-format-version.outputs.version }}' ansible/roles/pre_commit/README.md
 
       - name: Create PR
         id: create-pr

--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -21,7 +21,7 @@
       when: prompt_install_nvidia != 'y'
   roles:
     - role: autoware.dev_env.cuda
-      when: prompt_install_nvidia == 'y' and install_devel == 'true'
+      when: prompt_install_nvidia == 'y' and tensorrt_install_devel == 'true'
     - role: autoware.dev_env.docker_engine
     - role: autoware.dev_env.nvidia_docker
     - role: autoware.dev_env.rocker

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -37,10 +37,10 @@
     # Core
     - role: autoware.dev_env.autoware_core
     - role: autoware.dev_env.ccache
-      when: install_devel == 'true'
+      when: tensorrt_install_devel == 'true'
     - role: autoware.dev_env.plotjuggler
     - role: autoware.dev_env.pre_commit
-      when: install_devel == 'true'
+      when: tensorrt_install_devel == 'true'
     - role: autoware.dev_env.ros2
     - role: autoware.dev_env.ros2_dev_tools
     - role: autoware.dev_env.rmw_implementation
@@ -48,7 +48,7 @@
     # Universe
     - role: autoware.dev_env.autoware_universe
     - role: autoware.dev_env.cuda
-      when: prompt_install_nvidia == 'y' and install_devel == 'true'
+      when: prompt_install_nvidia == 'y' and tensorrt_install_devel == 'true'
     - role: autoware.dev_env.pacmod
       when: rosdistro != 'rolling'
     - role: autoware.dev_env.tensorrt

--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -7,7 +7,7 @@ This role installs [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) fol
 | Name                 | Required | Description                      |
 | -------------------- | -------- | -------------------------------- |
 | cuda_version         | true     | The version of CUDA Toolkit.     |
-| install_cuda_drivers | false    | Whether to install cuda-drivers. |
+| cuda_install_drivers | false    | Whether to install cuda-drivers. |
 
 ## Manual Installation
 

--- a/ansible/roles/cuda/defaults/main.yaml
+++ b/ansible/roles/cuda/defaults/main.yaml
@@ -1,1 +1,1 @@
-install_cuda_drivers: true
+cuda_install_drivers: true

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -54,7 +54,7 @@
     name:
       - cuda-drivers
     update_cache: true
-  when: install_cuda_drivers | bool
+  when: cuda_install_drivers | bool
 
 - name: Add PATH to .bashrc
   ansible.builtin.lineinfile:

--- a/ansible/roles/pre_commit/README.md
+++ b/ansible/roles/pre_commit/README.md
@@ -6,16 +6,16 @@ This role installs dependent tools for [pre-commit](https://pre-commit.com/).
 
 | Name                 | Required | Description                 |
 | -------------------- | -------- | --------------------------- |
-| clang_format_version | false    | The version of ClangFormat. |
+| pre_commit_clang_format_version | false    | The version of ClangFormat. |
 
 ## Manual Installation
 
-The `clang_format_version` variable can also be found in:
+The `pre_commit_clang_format_version` variable can also be found in:
 [./defaults/main.yaml](./defaults/main.yaml)
 
 ```bash
-clang_format_version=17.0.4
-pip3 install pre-commit clang-format==${clang_format_version}
+pre_commit_clang_format_version=17.0.4
+pip3 install pre-commit clang-format==${pre_commit_clang_format_version}
 
 sudo apt install golang
 ```

--- a/ansible/roles/pre_commit/README.md
+++ b/ansible/roles/pre_commit/README.md
@@ -4,8 +4,8 @@ This role installs dependent tools for [pre-commit](https://pre-commit.com/).
 
 ## Inputs
 
-| Name                 | Required | Description                 |
-| -------------------- | -------- | --------------------------- |
+| Name                            | Required | Description                 |
+| ------------------------------- | -------- | --------------------------- |
 | pre_commit_clang_format_version | false    | The version of ClangFormat. |
 
 ## Manual Installation

--- a/ansible/roles/pre_commit/defaults/main.yaml
+++ b/ansible/roles/pre_commit/defaults/main.yaml
@@ -1,1 +1,1 @@
-clang_format_version: 17.0.4
+pre_commit_clang_format_version: 17.0.4

--- a/ansible/roles/pre_commit/tasks/main.yaml
+++ b/ansible/roles/pre_commit/tasks/main.yaml
@@ -7,7 +7,7 @@
 - name: Install clang-format
   ansible.builtin.pip:
     name: clang-format
-    version: "{{ clang_format_version }}"
+    version: "{{ pre_commit_clang_format_version }}"
     executable: pip3
 
 - name: Install Go

--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -19,11 +19,11 @@ $ apt-cache policy | grep universe
 | Name              | Required | Description                                      |
 | ----------------- | -------- | ------------------------------------------------ |
 | rosdistro         | true     | The ROS distro.                                  |
-| installation_type | false    | The installation type (`desktop` or `ros-base`). |
+| ros2_installation_type | false    | The installation type (`desktop` or `ros-base`). |
 
 ## Manual Installation
 
-The `installation_type` variable can also be found in:
+The `ros2_installation_type` variable can also be found in:
 [./defaults/main.yaml](./defaults/main.yaml)
 
 For Universe, the `rosdistro` variable can also be found in:
@@ -57,8 +57,8 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-a
 sudo apt update
 
 # Desktop Install
-installation_type=desktop
-sudo apt install ros-${rosdistro}-${installation_type}
+ros2_installation_type=desktop
+sudo apt install ros-${rosdistro}-${ros2_installation_type}
 
 # Environment setup
 # (Optional) You can source ros2 in the ~/.bashrc file.

--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -16,9 +16,9 @@ $ apt-cache policy | grep universe
 
 ## Inputs
 
-| Name              | Required | Description                                      |
-| ----------------- | -------- | ------------------------------------------------ |
-| rosdistro         | true     | The ROS distro.                                  |
+| Name                   | Required | Description                                      |
+| ---------------------- | -------- | ------------------------------------------------ |
+| rosdistro              | true     | The ROS distro.                                  |
 | ros2_installation_type | false    | The installation type (`desktop` or `ros-base`). |
 
 ## Manual Installation

--- a/ansible/roles/ros2/defaults/main.yaml
+++ b/ansible/roles/ros2/defaults/main.yaml
@@ -1,1 +1,1 @@
-installation_type: desktop
+ros2_installation_type: desktop

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -34,10 +34,10 @@
     state: present
     update_cache: true
 
-- name: Install ros-{{ rosdistro + '-' + installation_type }}
+- name: Install ros-{{ rosdistro + '-' + ros2_installation_type }}
   become: true
   ansible.builtin.apt:
-    name: ros-{{ rosdistro }}-{{ installation_type }}
+    name: ros-{{ rosdistro }}-{{ ros2_installation_type }}
     state: latest
     update_cache: true
 

--- a/ansible/roles/tensorrt/defaults/main.yaml
+++ b/ansible/roles/tensorrt/defaults/main.yaml
@@ -1,1 +1,1 @@
-install_devel: true
+tensorrt_install_devel: true

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -23,7 +23,7 @@
     allow_change_held_packages: true
     allow_downgrade: true
     update_cache: true
-  when: install_devel | bool
+  when: tensorrt_install_devel | bool
 
 # apt-mark hold
 - name: Prevent CUDA-related packages from upgrading
@@ -49,4 +49,4 @@
     - libnvinfer-plugin-dev
     - libnvparsers-dev
     - libnvonnxparsers-dev
-  when: install_devel | bool
+  when: tensorrt_install_devel | bool

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Set up development environment for Autoware Core/Universe.
-# Usage: setup-dev-env.sh <installation_type('core' or 'universe')> [-y] [-v] [--no-nvidia]
+# Usage: setup-dev-env.sh <ros2_installation_type('core' or 'universe')> [-y] [-v] [--no-nvidia]
 # Note: -y option is only for CI.
 
 set -e
@@ -90,11 +90,11 @@ fi
 
 # Check installation of dev package
 if [ "$option_runtime" = "true" ]; then
-    ansible_args+=("--extra-vars" "install_devel=false")
+    ansible_args+=("--extra-vars" "tensorrt_install_devel=false")
     # ROS installation type, default "desktop"
-    ansible_args+=("--extra-vars" "installation_type=ros-base")
+    ansible_args+=("--extra-vars" "ros2_installation_type=ros-base")
 else
-    ansible_args+=("--extra-vars" "install_devel=true")
+    ansible_args+=("--extra-vars" "tensorrt_install_devel=true")
 fi
 
 ansible_args+=("--extra-vars" "data_dir=$option_data_dir")


### PR DESCRIPTION
## Description

Related PR:
- https://github.com/autowarefoundation/autoware/pull/3512

Updating to `ansible-lint` version
- from `rev: v6.16.1`
- to `rev: v6.22.0`

caused following errors:
- https://github.com/autowarefoundation/autoware/actions/runs/6871052871/job/18687163006?pr=3512

> `var-naming[no-role-prefix]`: Variables names from within roles should use role_name_ as a prefix. Underlines are accepted before the prefix.

More info can be found in: https://ansible.readthedocs.io/projects/lint/rules/var-naming/ 

This PR renames the variables and their usages in this repository to fix this.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
