### PR TITLE
fix(ansible): disable artifact download prompt in with -y flag

### DIFF
--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -101,8 +101,8 @@ else
     ansible_args+=("--extra-vars" "tensorrt_install_devel=true")
 fi
 
-# Check downloading artifacts 
-if [ "$option_yes" = "true" ]  || [ "$option_download_artifacts" = "true" ]; then
+# Check downloading artifacts
+if [ "$option_yes" = "true" ] || [ "$option_download_artifacts" = "true" ]; then
     echo -e "\e[36mArtifacts will be downloaded to $option_data_dir\e[m"
     ansible_args+=("--extra-vars" "prompt_download_artifacts=y")
 fi

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -38,6 +38,10 @@ while [ "$1" != "" ]; do
         option_data_dir="$2"
         shift
         ;;
+    --download-artifacts)
+        # Set download artifacts option
+        option_download_artifacts=true
+        ;;
     *)
         args+=("$1")
         ;;
@@ -95,6 +99,12 @@ if [ "$option_runtime" = "true" ]; then
     ansible_args+=("--extra-vars" "ros2_installation_type=ros-base")
 else
     ansible_args+=("--extra-vars" "tensorrt_install_devel=true")
+fi
+
+# Check downloading artifacts 
+if [ "$option_yes" = "true" ]  || [ "$option_download_artifacts" = "true" ]; then
+    echo -e "\e[36mArtifacts will be downloaded to $option_data_dir\e[m"
+    ansible_args+=("--extra-vars" "prompt_download_artifacts=y")
 fi
 
 ansible_args+=("--extra-vars" "data_dir=$option_data_dir")


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fix https://github.com/autowarefoundation/autoware/issues/4006.
Also new --download-artifacts option was introduced. User can configure if he want to download artifacts or no then starting the script. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

With ```./setup-dev-env.sh -y``` no prompts are produced.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
