### PR TITLE
feat(ansible): add new task to install libqt5charts5-dev

### DIFF
--- a/ansible/roles/autoware_universe/tasks/main.yaml
+++ b/ansible/roles/autoware_universe/tasks/main.yaml
@@ -1,3 +1,10 @@
+- name: Install libqt5charts5-dev # remove this task after merging https://github.com/ros/rosdistro/pull/39705.
+  become: true
+  ansible.builtin.apt:
+    name: libqt5charts5-dev
+    state: latest
+    update_cache: true
+
 - name: Install geographiclib-tools
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
## Description

Add new task to install `libqt5charts5-dev` so that we can develop utility tools with qt charts.

Related PR: https://github.com/autowarefoundation/autoware.universe/pull/6154 (I use the lib in this PR.)

**NOTE**: After merging https://github.com/ros/rosdistro/pull/39705, I'll remove this task.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed that `libqt5charts5-dev` was installed correctly with `./setup-dev-env.sh`.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
