### PR TITLE
feat(autoware.repos): add fork of ament_cmake for faster build

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -61,6 +61,10 @@ repositories:
     type: git
     url: https://github.com/MapIV/llh_converter.git
     version: ros2
+  universe/external/ament_cmake: # TODO(mitsudome-r): remove when https://github.com/ament/ament_cmake/pull/448 is merged
+    type: git
+    url: https://github.com/autowarefoundation/ament_cmake.git
+    version: feat/faster_ament_libraries_deduplicate
   # launcher
   launcher/autoware_launch:
     type: git


### PR DESCRIPTION
## Description
This PR will add the fork of ament_cmake which makes the build of Autoware faster. This originated from the discussion in https://github.com/orgs/autowarefoundation/discussions/3491. We were waiting for [this PR](https://github.com/ament/ament_cmake/pull/448) to be merged to the upstream, but we already have issues with build check CI taking too much time in autoware.universe so I think it's worth using the fork until the PR is merged to upstream.

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/orgs/autowarefoundation/discussions/3491
https://github.com/ament/ament_cmake/pull/448

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
run vcs import and check with colcon build.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
On my machine, build time has changed from:
```
Summary: 340 packages finished [48min 18s]
```

to: 
```
Summary: 363 packages finished [30min 19s]
```

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
