### PR TITLE
feat(autoware): update architecture_type .webauto-ci.yaml

### DIFF
--- a/.webauto-ci.yaml
+++ b/.webauto-ci.yaml
@@ -20,7 +20,7 @@ simulations:
         launch_autoware: "true"
         autoware_launch_package: autoware_launch
         autoware_launch_file: planning_simulator.launch.xml
-        architecture_type: awf/universe
+        architecture_type: awf/universe/20230906
         vehicle_model: sample_vehicle
         sensor_model: sample_sensor_kit
         initialize_duration: "90"


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
cc. @h-ohta, @mitsudome-r 
The `architecture_type` param of the `.webauto-ci.yaml` file needs to be updated to be able to run scenario_simulator in the AWF project in Autoware Evaluator. Currently, Autoware cannot recognize the traffic lights.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
