### PR TITLE
ci(build-main): improve storage cleaning and ci build pipeline

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -14,6 +14,10 @@ inputs:
   tag-suffix:
     description: ""
     required: false
+  allow-push:
+    description: ""
+    default: "true"
+    required: false
 
 runs:
   using: composite
@@ -87,7 +91,7 @@ runs:
       uses: docker/bake-action@v3
       with:
         # Checking event_name for https://github.com/autowarefoundation/autoware/issues/2796
-        push: ${{ github.event_name == 'schedule' || github.ref_name == github.event.repository.default_branch || github.event_name == 'push'}}
+        push: ${{ (github.event_name == 'schedule' || github.ref_name == github.event.repository.default_branch || github.event_name == 'push') && inputs.allow-push == 'true' }}
         files: |
           docker/${{ inputs.bake-target }}/docker-bake.hcl
           ${{ steps.meta-devel.outputs.bake-file }}

--- a/.github/actions/free-disk-space/action.yaml
+++ b/.github/actions/free-disk-space/action.yaml
@@ -12,25 +12,18 @@ runs:
         fi
       shell: bash
 
-    # https://github.community/t/bug-strange-no-space-left-on-device-ioexceptions-on-github-runners/17616
-    - name: Free disk space
-      run: |
-        df -h
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: true
 
-        sudo apt-get -y purge \
-          dotnet* \
-          ghc* \
-          php* \
-          || true
-        sudo apt-get -y autoremove
-        sudo apt-get -y autoclean
-
-        sudo rm -rf \
-          /usr/local/lib/android \
-          /usr/share/dotnet/ \
-          /opt/ghc
-
-        docker rmi $(docker image ls -aq) || true
-
-        df -h
-      shell: bash
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: false

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -6,11 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  load-env:
-    uses: ./.github/workflows/load-env.yaml
-
   build-main-self-hosted:
-    needs: load-env
     runs-on: [self-hosted, linux, ARM64]
     strategy:
       fail-fast: false
@@ -51,13 +47,13 @@ jobs:
         with:
           bake-target: autoware-universe
           build-args: |
-            *.platform=linux/amd64
+            *.platform=linux/arm64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.PREBUILT_BASE_IMAGE=${{ env.prebuilt_base_image }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
           tag-prefix: ${{ env.rosdistro }}-
-          tag-suffix: ${{ matrix.additional-tag-suffix }}-amd64
+          tag-suffix: ${{ matrix.additional-tag-suffix }}-arm64
           allow-push: false
 
       - name: Show disk space

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -12,36 +12,54 @@ jobs:
   build-main-self-hosted:
     needs: load-env
     runs-on: [self-hosted, linux, ARM64]
-    container: ${{ needs.load-env.outputs.base-image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - no-cuda
+          - cuda
+        include:
+          - name: no-cuda
+            base_image_env: base_image
+            setup-args: --no-nvidia
+            additional-tag-suffix: ""
+          - name: cuda
+            base_image_env: cuda_base_image
+            setup-args: --no-cuda-drivers
+            additional-tag-suffix: -cuda
     steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Run setup script
-        run: |
-          ./setup-dev-env.sh -y
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
-      - name: Set git config
-        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+      - name: Load env
+        run: |
+          cat amd64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
+          if [ "$(uname -m)" = "aarch64" ]; then
+            cat arm64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
+          fi
+
+      - name: Build 'autoware-universe'
+        uses: ./.github/actions/docker-build-and-push
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          bake-target: autoware-universe
+          build-args: |
+            *.platform=linux/amd64
+            *.args.ROS_DISTRO=${{ env.rosdistro }}
+            *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
+            *.args.PREBUILT_BASE_IMAGE=${{ env.prebuilt_base_image }}
+            *.args.SETUP_ARGS=${{ matrix.setup-args }}
+          tag-prefix: ${{ env.rosdistro }}-
+          tag-suffix: ${{ matrix.additional-tag-suffix }}-amd64
+          allow-push: false
 
-      - name: Run vcs import
+      - name: Show disk space
         run: |
-          mkdir src
-          vcs import src < autoware.repos
-
-      - name: Run vcs export
-        run: |
-          vcs export --exact src || true
-
-      - name: Run rosdep install
-        run: |
-          sudo apt-get -y update
-          rosdep update
-          DEBIAN_FRONTEND=noninteractive rosdep install -y --from-paths src --ignore-src --rosdistro ${{ needs.load-env.outputs.rosdistro }}
-
-      - name: Build
-        run: |
-          . /opt/ros/${{ needs.load-env.outputs.rosdistro }}/setup.sh
-          colcon build --event-handlers console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=Release
+          df -h

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -6,42 +6,51 @@ on:
   workflow_dispatch:
 
 jobs:
-  load-env:
-    uses: ./.github/workflows/load-env.yaml
-
   build-main:
-    needs: load-env
     runs-on: ubuntu-latest
-    container: ${{ needs.load-env.outputs.base-image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - no-cuda
+          - cuda
+        include:
+          - name: no-cuda
+            base_image_env: base_image
+            setup-args: --no-nvidia
+            additional-tag-suffix: ""
+          - name: cuda
+            base_image_env: cuda_base_image
+            setup-args: --no-cuda-drivers
+            additional-tag-suffix: -cuda
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Run setup script
-        run: |
-          ./setup-dev-env.sh -y
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
-      - name: Set git config
-        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+      - name: Load env
+        run: |
+          cat amd64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
+          if [ "$(uname -m)" = "aarch64" ]; then
+            cat arm64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
+          fi
+
+      - name: Build 'autoware-universe'
+        uses: ./.github/actions/docker-build-and-push
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          bake-target: autoware-universe
+          build-args: |
+            *.platform=linux/amd64
+            *.args.ROS_DISTRO=${{ env.rosdistro }}
+            *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
+            *.args.PREBUILT_BASE_IMAGE=${{ env.prebuilt_base_image }}
+            *.args.SETUP_ARGS=${{ matrix.setup-args }}
+          tag-prefix: ${{ env.rosdistro }}-
+          tag-suffix: ${{ matrix.additional-tag-suffix }}-amd64
+          allow-push: false
 
-      - name: Run vcs import
+      - name: Show disk space
         run: |
-          mkdir src
-          vcs import src < autoware.repos
-
-      - name: Run vcs export
-        run: |
-          vcs export --exact src || true
-
-      - name: Run rosdep install
-        run: |
-          sudo apt-get -y update
-          rosdep update
-          DEBIAN_FRONTEND=noninteractive rosdep install -y --from-paths src --ignore-src --rosdistro ${{ needs.load-env.outputs.rosdistro }}
-
-      - name: Build
-        run: |
-          . /opt/ros/${{ needs.load-env.outputs.rosdistro }}/setup.sh
-          colcon build --event-handlers console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=Release
+          df -h


### PR DESCRIPTION
## Description

### Intro

I was looking for a solution to fix the `out of storage` issues in CI.

I've found out https://github.com/marketplace/actions/free-disk-space-ubuntu action.

Then realized we also had [a custom free-disk-space action](https://github.com/autowarefoundation/autoware/blob/0d594f70b2a5913c9f1f061b5454c516f6c2911b/.github/actions/free-disk-space/action.yaml).

But it wasn't removing enough unused junk from the provided runner instance.

With this PR, we now utilize the established marketplace [free-disk-space-ubuntu action](https://github.com/marketplace/actions/free-disk-space-ubuntu).

### Visible outcomes

[See my post down below this page](https://github.com/autowarefoundation/autoware/pull/4191#issuecomment-1954069465)

### Issue with the `build-main*` workflows

I first wanted this to be with as little change as possible.

So I just added it to the existing build-main workflow.

https://github.com/autowarefoundation/autoware/blob/0d594f70b2a5913c9f1f061b5454c516f6c2911b/.github/workflows/build-main.yaml#L15

But the free-disk-space didn't work because, as I linked in the line above, it runs it in a container.

Because of this, I had to modify the existing "docker-build-and-push-main" workflows to reuse them, just for building, not pushing.

This way, this PR hopefully resolves the issue and builds the Autoware everyday as expected.

## Tests performed

- **build-main:**
  - https://github.com/autowarefoundation/autoware/actions/runs/7974689376
- **build-main-self-hosted:**
  - https://github.com/autowarefoundation/autoware/actions/runs/7974691828

Once these CIs pass, we can merge these.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
