### PR TITLE
fix(ccache): enable ccache on bare-metal setups

### DIFF
--- a/ansible/roles/build_tools/tasks/main.yaml
+++ b/ansible/roles/build_tools/tasks/main.yaml
@@ -39,3 +39,4 @@
   ansible.builtin.shell: source ~/.bashrc
   args:
     executable: /bin/bash
+  changed_when: false

--- a/ansible/roles/build_tools/tasks/main.yaml
+++ b/ansible/roles/build_tools/tasks/main.yaml
@@ -8,7 +8,7 @@
 - name: Add CCACHE_DIR to .bashrc
   ansible.builtin.lineinfile:
     dest: ~/.bashrc
-    line: export CCACHE_DIR="/ccache"
+    line: export CCACHE_DIR="/var/tmp/ccache"
     state: present
     create: true
     mode: 0644
@@ -31,7 +31,7 @@
 
 - name: Create ccache directory
   ansible.builtin.file:
-    path: /ccache
+    path: /var/tmp/ccache
     state: directory
     mode: 0755
 

--- a/ansible/roles/build_tools/tasks/main.yaml
+++ b/ansible/roles/build_tools/tasks/main.yaml
@@ -28,3 +28,14 @@
     state: present
     create: true
     mode: 0644
+
+- name: Create ccache directory
+  ansible.builtin.file:
+    path: /ccache
+    state: directory
+    mode: 0755
+
+- name: Source .bashrc
+  ansible.builtin.shell: source ~/.bashrc
+  args:
+    executable: /bin/bash

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -16,10 +16,10 @@
   ansible.builtin.apt:
     name:
       - libcudnn8-dev={{ cudnn_version }}
-      - libnvinfer-headers-dev={{ tensorrt_version }}
-      - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
+      - libnvinfer-headers-dev={{ tensorrt_version }}
+      - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
       - libnvparsers-dev={{ tensorrt_version }}
       - libnvonnxparsers-dev={{ tensorrt_version }}
     allow_change_held_packages: true

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -20,8 +20,6 @@
       - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
-      - libnvinfer-headers-dev={{ tensorrt_version }}
-      - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
       - libnvparsers-dev={{ tensorrt_version }}
       - libnvonnxparsers-dev={{ tensorrt_version }}
     allow_change_held_packages: true

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -16,6 +16,8 @@
   ansible.builtin.apt:
     name:
       - libcudnn8-dev={{ cudnn_version }}
+      - libnvinfer-headers-dev={{ tensorrt_version }}
+      - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
       - libnvinfer-headers-dev={{ tensorrt_version }}

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -45,7 +45,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ARG SETUP_ARGS
 ARG ROS_DISTRO
-ENV CCACHE_DIR=/ccache
+ENV CCACHE_DIR="/var/tmp/ccache"
 ENV CC="/usr/lib/ccache/gcc"
 ENV CXX="/usr/lib/ccache/g++"
 
@@ -74,7 +74,7 @@ RUN --mount=type=ssh \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   && find /autoware/install -type d -exec chmod 777 {} \; \
-  && chmod -R 777 /ccache \
+  && chmod -R 777 /var/tmp/ccache \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache \
   && rm -rf /autoware/build /autoware/src
 

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -45,6 +45,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ARG SETUP_ARGS
 ARG ROS_DISTRO
+ENV CCACHE_DIR=/ccache
+ENV CC="/usr/lib/ccache/gcc"
+ENV CXX="/usr/lib/ccache/g++"
 
 # Set up development environment
 RUN --mount=type=ssh \


### PR DESCRIPTION
## Description

Enable usage of ccache both in docker build and on bare-metal installations

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Built Autoware locally.

## Effects on system behavior

Faster builds with ccache support in bare-metal setups
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
