### PR TITLE
fix(tensorrt_role): add holding libnvinfer-headers-plugin-dev to fix version conflict

### DIFF
--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -39,6 +39,7 @@ libnvinfer-dev=${tensorrt_version} \
 libnvinfer-plugin-dev=${tensorrt_version} \
 libnvinfer-headers-plugin-dev=${tensorrt_version} \
 libnvparsers-dev=${tensorrt_version} \
+libnvinfer-headers-dev=${tensorrt_version} \
 libnvonnxparsers-dev=${tensorrt_version}
 
 sudo apt-mark hold \
@@ -47,5 +48,6 @@ libnvinfer-dev \
 libnvinfer-plugin-dev \
 libnvparsers-dev \
 libnvonnxparsers-dev \
+libnvinfer-headers-dev \
 libnvinfer-headers-plugin-dev
 ```

--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -37,6 +37,7 @@ sudo apt-get install -y \
 libcudnn8-dev=${cudnn_version} \
 libnvinfer-dev=${tensorrt_version} \
 libnvinfer-plugin-dev=${tensorrt_version} \
+libnvinfer-headers-plugin-dev=${tensorrt_version} \
 libnvparsers-dev=${tensorrt_version} \
 libnvonnxparsers-dev=${tensorrt_version}
 
@@ -45,5 +46,6 @@ libcudnn8-dev \
 libnvinfer-dev \
 libnvinfer-plugin-dev \
 libnvparsers-dev \
-libnvonnxparsers-dev
+libnvonnxparsers-dev \
+libnvinfer-headers-plugin-dev
 ```

--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -37,9 +37,9 @@ sudo apt-get install -y \
 libcudnn8-dev=${cudnn_version} \
 libnvinfer-dev=${tensorrt_version} \
 libnvinfer-plugin-dev=${tensorrt_version} \
+libnvinfer-headers-dev=${tensorrt_version} \
 libnvinfer-headers-plugin-dev=${tensorrt_version} \
 libnvparsers-dev=${tensorrt_version} \
-libnvinfer-headers-dev=${tensorrt_version} \
 libnvonnxparsers-dev=${tensorrt_version}
 
 sudo apt-mark hold \

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -18,6 +18,7 @@
       - libcudnn8-dev={{ cudnn_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
+      - libnvinfer-headers-dev={{ tensorrt_version }}
       - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
       - libnvparsers-dev={{ tensorrt_version }}
       - libnvonnxparsers-dev={{ tensorrt_version }}
@@ -48,6 +49,7 @@
     - libcudnn8-dev
     - libnvinfer-dev
     - libnvinfer-plugin-dev
+    - libnvinfer-headers-dev
     - libnvinfer-headers-plugin-dev
     - libnvparsers-dev
     - libnvonnxparsers-dev

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -18,6 +18,7 @@
       - libcudnn8-dev={{ cudnn_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
+      - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
       - libnvparsers-dev={{ tensorrt_version }}
       - libnvonnxparsers-dev={{ tensorrt_version }}
     allow_change_held_packages: true
@@ -47,6 +48,7 @@
     - libcudnn8-dev
     - libnvinfer-dev
     - libnvinfer-plugin-dev
+    - libnvinfer-headers-plugin-dev
     - libnvparsers-dev
     - libnvonnxparsers-dev
   when: install_devel == 'true'


### PR DESCRIPTION
## Description

add holding libnvinfer-headers-plugin-dev to fix version conflict

## Tests performed

Locally build from [nvidia-docker](https://hub.docker.com/layers/nvidia/cuda/12.3.1-devel-ubuntu22.04/images/sha256-af963432696b5f170a64ceddcac9fc4df01292f0f35d52e24bc0750ec169332d), and manage to fix the version conflict.

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
