### PR TITLE
ci: add set git config to resolve when ansible-galaxy-requirements has private repository

### DIFF
--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -10,17 +10,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Generate token
-        id: generate-token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
-
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Ansible Galaxy depends for ansible-lint
         run: |

--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -10,6 +10,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
       - name: Install Ansible Galaxy depends for ansible-lint
         run: |
           ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml

--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -10,6 +10,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
       - name: Run setup script
         run: |
           ./setup-dev-env.sh -y -v universe

--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -10,17 +10,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Generate token
-        id: generate-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
-
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run setup script
         run: |


### PR DESCRIPTION
## Description

When ansible-galaxy-requirements.yaml has private repository, we fail to install in github actions because we don't have tokens.
So, I add set git config.

## Related links

https://github.com/tier4/pilot-auto/pull/768

## Tests performed

pass pre-commit-ansible and setup-universe

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
