### PR TITLE
feat: making ros2 installation optional in environment setup

### DIFF
--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -12,7 +12,7 @@
         [Warning] Should the ONNX model files and other artifacts be downloaded alongside setting up the development environment.
         Download artifacts? [y/N]
       private: false
-    - name: prompt_install_new_ros2
+    - name: prompt_install_ros2_desktop
       prompt: |-
         [Warning] ROS 2 is required for Autoware. Please refer to https://docs.ros.org/en/humble/Installation.html for more information.
         Install ROS 2? [y/N]
@@ -42,10 +42,10 @@
   roles:
     # Autoware base dependencies
     - role: autoware.dev_env.ros2
-      when: prompt_install_new_ros2 == 'y'
+      when: prompt_install_ros2_desktop == 'y'
     - role: autoware.dev_env.ros2_dev_tools
     - role: autoware.dev_env.rmw_implementation
-      when: prompt_install_new_ros2 == 'y'
+      when: prompt_install_ros2_desktop == 'y'
     - role: autoware.dev_env.gdown
     - role: autoware.dev_env.build_tools
 

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -16,7 +16,7 @@
       prompt: |-
         [Warning] ROS 2 is required for Autoware. Please refer to https://docs.ros.org/en/humble/Installation.html for more information.
         Install ROS 2? [y/N]
-      default: "y"
+      default: y
       private: false
   pre_tasks:
     - name: Verify OS

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -12,6 +12,12 @@
         [Warning] Should the ONNX model files and other artifacts be downloaded alongside setting up the development environment.
         Download artifacts? [y/N]
       private: false
+    - name: prompt_install_new_ros2
+      prompt: |-
+        [Warning] ROS 2 is required for Autoware. Please refer to https://docs.ros.org/en/humble/Installation.html for more information.
+        Install ROS 2? [y/N]
+      default: 'y'
+      private: false
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:
@@ -36,8 +42,10 @@
   roles:
     # Autoware base dependencies
     - role: autoware.dev_env.ros2
+      when: prompt_install_new_ros2 == 'y'
     - role: autoware.dev_env.ros2_dev_tools
     - role: autoware.dev_env.rmw_implementation
+      when: prompt_install_new_ros2 == 'y'
     - role: autoware.dev_env.gdown
     - role: autoware.dev_env.build_tools
 

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -16,7 +16,7 @@
       prompt: |-
         [Warning] ROS 2 is required for Autoware. Please refer to https://docs.ros.org/en/humble/Installation.html for more information.
         Install ROS 2? [y/N]
-      default: 'y'
+      default: "y"
       private: false
   pre_tasks:
     - name: Verify OS


### PR DESCRIPTION
## Description

Making ROS2 installation in the environment setup optional.

Expected use case:

1. Some users have installed or even lock a certain ROS2 version in their local environment before using Autoware. Giving them an option to skip the ROS2 installation makes environment setup easier for all side.
2. Exposing an argument to skip ROS2 installation for certain docker image building. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
