### PR TITLE
feat: escape install task if the specific package is held

### DIFF
--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -4,6 +4,8 @@ This role installs [ROS 2](http://www.ros2.org/) following [this page](https://d
 
 Additional steps may be needed depending on the `rosdistro` you choose.
 
+To prevent the update of the ROS 2 packages, if ros-`distro`-desktop is held, the installation process for the packages will be skipped and output warining.
+
 <!-- TODO: Add these steps to the role if Humble requires. -->
 
 ```bash

--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -4,7 +4,7 @@ This role installs [ROS 2](http://www.ros2.org/) following [this page](https://d
 
 Additional steps may be needed depending on the `rosdistro` you choose.
 
-To prevent the update of the ROS 2 packages, if ros-`distro`-desktop is held, the installation process for the packages will be skipped and output warining.
+To prevent the update of the ROS 2 packages, if ros-`distro`-desktop is held, the installation process for the packages will be skipped and output warning.
 
 <!-- TODO: Add these steps to the role if Humble requires. -->
 

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -34,12 +34,25 @@
     state: present
     update_cache: true
 
+- name: Check if ros-{{ rosdistro }}-{{ ros2_installation_type }} is held
+  command: apt-mark showhold
+  register: held_ros_packages
+  changed_when: false
+
 - name: Install ros-{{ rosdistro + '-' + ros2_installation_type }}
   become: true
   ansible.builtin.apt:
     name: ros-{{ rosdistro }}-{{ ros2_installation_type }}
     state: latest
     update_cache: true
+  when: "'ros-' + rosdistro + '-' + ros2_installation_type not in held_ros_packages.stdout"
+  register: install_result
+  failed_when: false
+
+- name: Display warning if ROS 2 package is held
+  ansible.builtin.debug:
+    msg: ROS package 'ros-{{ rosdistro + '-' + ros2_installation_type }}' is apt-mark hold. Skipping installation.
+  when: install_result.changed == false
 
 - name: Add PATH to .bashrc
   ansible.builtin.lineinfile:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -34,7 +34,7 @@
     state: present
     update_cache: true
 
-- name: Check if ros-{{ rosdistro }}-{{ ros2_installation_type }} is held
+- name: Hold check of ros-{{ rosdistro + '-' + ros2_installation_type }}
   ansible.builtin.command: apt-mark showhold
   register: held_ros_packages
   changed_when: false

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -52,7 +52,7 @@
 - name: Display warning if ROS 2 package is held
   ansible.builtin.debug:
     msg: ROS package 'ros-{{ rosdistro + '-' + ros2_installation_type }}' is apt-mark hold. Skipping installation.
-  when: install_result.changed == false
+  when: not install_result.changed
 
 - name: Add PATH to .bashrc
   ansible.builtin.lineinfile:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -35,7 +35,7 @@
     update_cache: true
 
 - name: Check if ros-{{ rosdistro }}-{{ ros2_installation_type }} is held
-  command: apt-mark showhold
+  ansible.builtin.command: apt-mark showhold
   register: held_ros_packages
   changed_when: false
 


### PR DESCRIPTION
## Description

When a user, who wants to continue operating Autoware on a specific version of "ros-distro-desktop", executes the setup-dev-env.sh with the ROS packages already held, the installation of ROS 2 fails, and all other installation roles , such as fetching the latest ONNX files, are not executed.

This PR changes is escaping the ROS 2 installation process and issuing a warning when it's already held.


## Tests performed
* Before testing, all of ROS packages are held.
![Screenshot from 2024-04-02 15-53-01](https://github.com/autowarefoundation/autoware/assets/15172687/9cda1fbf-1406-439d-b8f0-b0bdf33ac112)

* Result of setup-dev-env.sh. Failed and other roles are not executed.
![Screenshot from 2024-04-02 16-10-59](https://github.com/autowarefoundation/autoware/assets/15172687/d647d37a-7588-458e-aef1-3158caab5431)

1. If ros-humble-desktop is held and other dependencies package is held.
  * install: skipped (OK)
  * warining: output (OK)
![Screenshot from 2024-04-02 15-59-55](https://github.com/autowarefoundation/autoware/assets/15172687/77e8d4a2-8cf7-4446-a464-89a0244530cc)

2. If ros-humble-desktop is not held and others is held.
  * install: changed (OK)
  * warining: skipped (OK)
![Screenshot from 2024-04-02 15-59-18](https://github.com/autowarefoundation/autoware/assets/15172687/90d5f499-6576-4424-b65c-88ca142a06a3)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
