### PR TITLE
feat(ansible): set default value for install_dev variable

### DIFF
--- a/ansible/playbooks/openadk.yaml
+++ b/ansible/playbooks/openadk.yaml
@@ -25,7 +25,7 @@
     - role: autoware.dev_env.kisak_mesa
       when: module == 'base'
     - role: autoware.dev_env.build_tools
-      when: module == 'all' and install_devel=='true'
+      when: module == 'all' and install_devel=='y'
 
     # Module specific dependencies
     - role: autoware.dev_env.geographiclib

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -16,7 +16,7 @@
       prompt: |-
         [Warning] Do you want to install recommended development tools for Autoware? [y/N]
       private: false
-      default: 'y'
+      default: "y"
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -16,7 +16,7 @@
       prompt: |-
         [Warning] Do you want to install recommended development tools for Autoware? [y/N]
       private: false
-      default: "y"
+      default: y
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -16,7 +16,7 @@
       prompt: |-
         [Warning] Do you want to install recommended development tools for Autoware? [y/N]
       private: false
-      default: true
+      default: 'y'
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:
@@ -57,7 +57,7 @@
 
     # Autoware devel dependencies
     - role: autoware.dev_env.dev_tools
-      when: install_devel == 'true'
+      when: install_devel == 'y'
 
     # ONNX files and other artifacts
     - role: autoware.dev_env.artifacts

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -12,6 +12,11 @@
         [Warning] Should the ONNX model files and other artifacts be downloaded alongside setting up the development environment.
         Download artifacts? [y/N]
       private: false
+    - name: install_devel
+      prompt: |-
+        [Warning] Do you want to install recommended development tools for Autoware? [y/N]
+      private: false
+      default: true
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -35,7 +35,7 @@
       - libcublas-dev-{{ cuda__dash_case_cuda_version.stdout }}
       - libcurand-dev-{{ cuda__dash_case_cuda_version.stdout }}
     update_cache: true
-  when: install_devel == 'true'
+  when: install_devel == 'y'
 
 - name: Install CUDA libraries except for cuda-drivers
   become: true
@@ -46,7 +46,7 @@
       - libcublas-{{ cuda__dash_case_cuda_version.stdout }}
       - libcurand-{{ cuda__dash_case_cuda_version.stdout }}
     update_cache: true
-  when: install_devel == 'false'
+  when: install_devel == 'N'
 
 - name: Install extra CUDA libraries for x86_64
   become: true

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -25,7 +25,7 @@
     allow_change_held_packages: true
     allow_downgrade: true
     update_cache: true
-  when: install_devel == 'true'
+  when: install_devel == 'y'
 
 # apt-mark hold
 - name: Prevent CUDA-related packages from upgrading
@@ -53,4 +53,4 @@
     - libnvinfer-headers-plugin-dev
     - libnvparsers-dev
     - libnvonnxparsers-dev
-  when: install_devel == 'true'
+  when: install_devel == 'y'

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -121,9 +121,9 @@ fi
 # Check installation of dev package
 if [ "$option_runtime" = "true" ]; then
     ansible_args+=("--extra-vars" "ros2_installation_type=ros-base") # ROS installation type, default "desktop"
-    ansible_args+=("--extra-vars" "install_devel=false")
+    ansible_args+=("--extra-vars" "install_devel=N")
 else
-    ansible_args+=("--extra-vars" "install_devel=true")
+    ansible_args+=("--extra-vars" "install_devel=y")
 fi
 
 # Check downloading artifacts


### PR DESCRIPTION
## Description
Due to the refactoring, it seems like the evaluator for testing scenario testing is failing.
It seems like it is due to change in expected variables for universe playbook, where the refactored version expects `install_devel` to be set.

I modified the playbook to set true as default.
However, the modification now prompts the user to install dev_tools. If there are any other way to set default value for the variable without prompting, please let me know.

## Tests performed
Tested locally with ./setup-dev-env.sh, and tested with the evaluator.

## Effects on system behavior
The new script now prompts the user to install dev_tools when the script is executed.

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
