### PR TITLE
feat(autoware.repos): add glog with v0.6.0 as a ros pkg

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -69,6 +69,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/ament_cmake.git
     version: feat/faster_ament_libraries_deduplicate
+  universe/external/glog:  # TODO(Horibe): to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
+    type: git
+    url: https://github.com/tier4/glog.git
+    version: v0.6.0_t4-ros
   # launcher
   launcher/autoware_launch:
     type: git


### PR DESCRIPTION
## Description

Currently, We are using Google's [glog](https://github.com/google/glog) library to capture stack traces when a process dies, which is very useful for development. See examples in Autoware: [ex1](https://github.com/autowarefoundation/autoware.universe/blob/81c432e8110ca54acc5e6fc4a757eff87724c39b/perception/map_based_prediction/src/map_based_prediction_node.cpp#L718-L719), [ex2](https://github.com/autowarefoundation/autoware.universe/blob/81c432e8110ca54acc5e6fc4a757eff87724c39b/localization/ndt_scan_matcher/src/ndt_scan_matcher_node.cpp#L23-L24).

![image](https://github.com/autowarefoundation/autoware/assets/21360593/ea977a4e-88d9-4e20-8afc-37aa9fc8bfff)


Due to the way of ROS 2 component launch procedure, glog sometimes be loaded as a module. However, it's not permissible to initialize glog multiple times, and glog will terminate the process if this occurs.

We can find some discussions about that, for example [here](https://code.google.com/archive/p/google-glog/issues/113).

To avoid this, it's necessary to use the `IsGoogleLoggingInitialized()` API, introduced in version v0.6.0 of glog. However, the glog deb package distributed with Ubuntu 22 is based on version v0.4.0. I plan to resolve this issue by registering version v0.6.0 in the repos. 

I note that the Ubuntu 24 glog deb package adopts version v0.6.0, so updating to Ubuntu 24 will allow us to eliminate this dependency.



## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

1. Import autoware.repos
2. run build
3. check the psim/lsim works well.
4. check if `kill -15 <pid>` will show the glog on terminal

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

None

## Effects on system behavior

None (glog version will be updated. We need to follow the update in each package) 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
