### PR TITLE
fix(cuda): install NVML development library

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -34,6 +34,7 @@
       - libcusparse-dev-{{ cuda__dash_case_cuda_version.stdout }}
       - libcublas-dev-{{ cuda__dash_case_cuda_version.stdout }}
       - libcurand-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - cuda-nvml-dev-{{ cuda__dash_case_cuda_version.stdout }}
     update_cache: true
   when: install_devel == 'true'
 


### PR DESCRIPTION
## Description

Recently, after running `setup_dev_env.sh` and installing NVIDIA libraries, there's an issue where part of NVML (`nvml.h`) is not installed. This affects the `gpu_monitor` node in `system_monitor`, which uses NVML. The `gpu_monitor` recognized NVML doesn't exist and publish errors as it is unable to access the GPU.

![image](https://github.com/autowarefoundation/autoware/assets/57388357/2a8c52e6-8bb1-418d-9d5c-98ea36dfdfc2)

See also https://github.com/autowarefoundation/autoware.universe/issues/6787.

I'd like to explicitly install NVML as a workaround for this issue.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

1. Completely remove NVIDIA drivers and libraries.
    ```console
    sudo apt purge cuda-*
    sudo apt purge nvidia-*
    sudo apt purge libcudnn*
    sudo apt purge libnv*
    ```

2. Confirm that only `hwloc/nvml.h` exists.
    ```console
    ❯ find /usr -type f -name nvml.h
    /usr/include/hwloc/nvml.h
    ```

3. Run `setup_dev_env.sh` and installi NVIDIA libraries.
    ```console
    ❯ ./setup-dev-env.sh
    ...
    [Warning] Some Autoware components depend on the CUDA, cuDNN and TensorRT NVIDIA libraries which have end-user     license agreements that should be reviewed before installation.
    Install NVIDIA libraries? [y/N]: y
    ```

4. Confirm that the NVIDIA's `nvml.h` is installed
    ```console
    ❯ find /usr -type f -name nvml.h
    /usr/local/cuda-12.3/targets/x86_64-linux/include/nvml.h
    /usr/include/hwloc/nvml.h
    ```

5. Delete the build and install directories for system_monitor.
    ```console
    ❯ rm -rf install/system_monitor/ build/system_monitor/
    ```

6. Build `system_monito`r and ensure build uses NVML (`GPU PLATFORM: nvml`), and build completes successfully.
    ```console
    ❯ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-w" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache --event-handlers console_direct+ --packages-select system_monitor
    ...
    -- SYSTEM_PROCESSOR: x86_64
    -- CPU PLATFORM: intel
    -- GPU PLATFORM: nvml
    ...
    Finished <<< system_monitor [3min 2s]

    Summary: 1 package finished [3min 4s]
      1 package had stderr output: system_monitor
    ```

7. Run Autoware.
    ```console
    ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/data/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit launch_system_monitor:=true
    ```

8. Run runtime_monitor and  Confirm the `gpu_monitor` does not report an error.
    ```console
    ros2 run rqt_runtime_monitor rqt_runtime_monitor
    ```
   
![image](https://github.com/autowarefoundation/autoware/assets/57388357/38b662bd-3ab0-4e67-b8a7-0a4e80bd8e93)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
