### PR TITLE
chore: ignore node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ capture/
 
 # CodeChecker
 .codechecker/
+
+# Node.js
+node_modules/


### PR DESCRIPTION
## Description

The pre-commit, a GitHub Action, generates a temporary file similar to `node_modules/.cache/prettier/.prettier-caches/~~~~.json`, which is then automatically committed.
This pull request prevents the commit of temporary files in the `node_modules` folder.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
