### PR TITLE
fix(docker-build-and-push): remove ccache stats

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -183,7 +183,3 @@ runs:
         echo 'runtime URL ${{ steps.artifact-upload-step-runtime.outputs.artifact-url }}'
       shell: bash
 
-    - name: Show ccache stats
-      run: |
-        ccache -s
-      shell: bash

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -182,4 +182,3 @@ runs:
         echo 'devel URL ${{ steps.artifact-upload-step-devel.outputs.artifact-url }}'
         echo 'runtime URL ${{ steps.artifact-upload-step-runtime.outputs.artifact-url }}'
       shell: bash
-


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
 Remove ccache stats from build-main jobs since prebuilt container is not being used in these jobs. Instead ccache is utilized in build-test-differential jobs in `autoware-universe`. So ccache stats would be available in those jobs.

Follow up from:
- https://github.com/autowarefoundation/autoware/pull/4622

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
