### PR TITLE
chore(docker): change the cmake's build tool from `make` to `ninja`

### DIFF
--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -68,6 +68,7 @@ RUN --mount=type=ssh \
   && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src --rosdistro "$ROS_DISTRO" \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --cmake-args \
+    " -GNinja" \
     " -Wno-dev" \
     " --no-warn-unused-cli" \
     -DCMAKE_BUILD_TYPE=Release \

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -64,6 +64,7 @@ RUN --mount=type=ssh \
   mkdir src \
   && vcs import src < autoware.repos \
   && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends ninja-build \
   && rosdep update \
   && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src --rosdistro "$ROS_DISTRO" \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \


### PR DESCRIPTION
## Description

This PR has changed the cmake's build tool from `make` to `ninja`.
`ninja` is typically faster than `make` to rebuild modified source code.
So when using cache properly, the `ninja` build time would be faster than `make`.

https://ninja-build.org/

The results of the `colcon build` time using my local PC are shown below. There may be a few overhead.
- `make`: 40min 59.55s
- `ninja`: 41min 57.07s

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
