### PR TITLE
feat(docker): introduce autoware-core stage

### DIFF
--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -103,6 +103,7 @@ COPY --from=src-imported /autoware/src/sensor_component /autoware/src/sensor_com
 COPY --from=src-imported /autoware/src/sensor_kit /autoware/src/sensor_kit
 COPY --from=src-imported /autoware/src/universe /autoware/src/universe
 COPY --from=autoware-core /autoware/install /opt/autoware/
+# hadolint ignore=SC1091
 RUN --mount=type=ssh \
   apt-get update \
   && rosdep update \

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -39,6 +39,17 @@ RUN --mount=type=ssh \
 # Create entrypoint
 CMD ["/bin/bash"]
 
+FROM $BASE_IMAGE as src-imported
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /autoware
+COPY autoware.repos /autoware/
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  ros-dev-tools \
+  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
+RUN --mount=type=ssh \
+  mkdir src \
+  && vcs import src < autoware.repos
+
 FROM base as prebuilt
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
@@ -56,14 +67,10 @@ RUN --mount=type=ssh \
   && find / -name 'libcu*.a' -delete \
   && find / -name 'libnv*.a' -delete
 
-# Copy repository files
-COPY autoware.repos /autoware/
-
 # Install rosdep dependencies
+COPY --from=src-imported /autoware/src /autoware/src
 RUN --mount=type=ssh \
-  mkdir src \
-  && vcs import src < autoware.repos \
-  && apt-get update \
+  apt-get update \
   && rosdep update \
   && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src --rosdistro "$ROS_DISTRO" \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \
@@ -101,12 +108,11 @@ ARG LIB_DIR
 ARG SETUP_ARGS
 
 # Set up runtime environment and artifacts
-COPY autoware.repos /autoware/
+COPY --from=src-imported /autoware/src /autoware/src
 RUN --mount=type=ssh \
   ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --download-artifacts --no-cuda-drivers --runtime openadk \
   && pip uninstall -y ansible ansible-core \
-  && mkdir src \
-  && vcs import src < autoware.repos \
+  && apt-get update \
   && rosdep update \
   && DEBIAN_FRONTEND=noninteractive rosdep install -y --dependency-types=exec --ignore-src --from-paths src --rosdistro "$ROS_DISTRO" \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache \
@@ -114,7 +120,7 @@ RUN --mount=type=ssh \
   && find / -name "*.o" -type f -delete \
   && find / -name "*.h" -type f -delete \
   && find / -name "*.hpp" -type f -delete \
-  && rm -rf /autoware/src /autoware/ansible /autoware/autoware.repos \
+  && rm -rf /autoware/src /autoware/ansible \
     /root/.local/pipx /opt/ros/"$ROS_DISTRO"/include /etc/apt/sources.list.d/cuda*.list \
     /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -50,13 +50,9 @@ RUN --mount=type=ssh \
   mkdir src \
   && vcs import src < autoware.repos
 
-FROM base as prebuilt
+FROM base as openadk-base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-ARG ROS_DISTRO
 ARG SETUP_ARGS
-ENV CCACHE_DIR="/var/tmp/ccache"
-ENV CC="/usr/lib/ccache/gcc"
-ENV CXX="/usr/lib/ccache/g++"
 
 # cspell: ignore libcu libnv
 # Set up development environment
@@ -67,8 +63,15 @@ RUN --mount=type=ssh \
   && find / -name 'libcu*.a' -delete \
   && find / -name 'libnv*.a' -delete
 
-# Install rosdep dependencies
-COPY --from=src-imported /autoware/src /autoware/src
+FROM openadk-base as autoware-core
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/var/tmp/ccache"
+ENV CC="/usr/lib/ccache/gcc"
+ENV CXX="/usr/lib/ccache/g++"
+
+# Install rosdep dependencies and build core packages
+COPY --from=src-imported /autoware/src/core /autoware/src/core
 RUN --mount=type=ssh \
   apt-get update \
   && rosdep update \
@@ -85,6 +88,36 @@ RUN --mount=type=ssh \
   && rm -rf /autoware/build /autoware/src
 
 CMD ["/bin/bash"]
+
+FROM openadk-base as prebuilt
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/var/tmp/ccache"
+ENV CC="/usr/lib/ccache/gcc"
+ENV CXX="/usr/lib/ccache/g++"
+
+# Install rosdep dependencies and build the other packages
+COPY --from=src-imported /autoware/src/launcher /autoware/src/launcher
+COPY --from=src-imported /autoware/src/param /autoware/src/param
+COPY --from=src-imported /autoware/src/sensor_component /autoware/src/sensor_component
+COPY --from=src-imported /autoware/src/sensor_kit /autoware/src/sensor_kit
+COPY --from=src-imported /autoware/src/universe /autoware/src/universe
+COPY --from=autoware-core /autoware/install /opt/autoware/
+RUN --mount=type=ssh \
+  apt-get update \
+  && rosdep update \
+  && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src --rosdistro "$ROS_DISTRO" \
+  && source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --cmake-args \
+    " -Wno-dev" \
+    " --no-warn-unused-cli" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  && find /autoware/install -type d -exec chmod 777 {} \; \
+  && chmod -R 777 /var/tmp/ccache \
+  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache \
+  && rm -rf /autoware/build /autoware/src
 
 FROM prebuilt as devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -126,11 +159,12 @@ RUN --mount=type=ssh \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
 # Copy prebuilt binaries
-COPY --from=prebuilt /autoware/install/ /autoware/install/
+COPY --from=autoware-core /autoware/install /opt/autoware/
+COPY --from=prebuilt /autoware/install /opt/autoware/
 
 # Copy bash aliases
 COPY docker/autoware-openadk/etc/.bash_aliases /root/.bash_aliases
-RUN echo "source /autoware/install/setup.bash" > /etc/bash.bashrc
+RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
 
 # Create entrypoint
 COPY docker/autoware-openadk/etc/ros_entrypoint.sh /ros_entrypoint.sh

--- a/docker/autoware-openadk/etc/ros_entrypoint.sh
+++ b/docker/autoware-openadk/etc/ros_entrypoint.sh
@@ -23,7 +23,7 @@ else
     # Add sudo privileges to the user
     echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
-    # Source ROS2
+    # Source ROS 2
     # hadolint ignore=SC1090
     source "/opt/ros/$ROS_DISTRO/setup.bash"
     source /opt/autoware/setup.bash

--- a/docker/autoware-openadk/etc/ros_entrypoint.sh
+++ b/docker/autoware-openadk/etc/ros_entrypoint.sh
@@ -10,6 +10,7 @@ GROUP_NAME=${LOCAL_GROUP}
 # Check if any of the variables are empty
 if [[ -z $USER_ID || -z $USER_NAME || -z $GROUP_ID || -z $GROUP_NAME ]]; then
     source "/opt/ros/$ROS_DISTRO/setup.bash"
+    source /opt/autoware/setup.bash
     source /autoware/install/setup.bash
     exec "$@"
 else
@@ -25,6 +26,7 @@ else
     # Source ROS2
     # hadolint ignore=SC1090
     source "/opt/ros/$ROS_DISTRO/setup.bash"
+    source /opt/autoware/setup.bash
     source /autoware/install/setup.bash
 
     # Execute the command as the user


### PR DESCRIPTION
## Description

- [ ] #4709 

This PR adds the `autoware-core` stage between the` base` and `prebuilt` stages.
This is a milestone for the multi-stage per-component builds mentioned in the discussion below. I will break down the `prebuilt` stage further in the next PR.
https://github.com/orgs/autowarefoundation/discussions/4661


The graph of the stage structure is shown below.
![Screenshot from 2024-05-13 15-34-34](https://github.com/autowarefoundation/autoware/assets/579333/738818f3-7466-4b18-aff6-7e859532cc2c)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
