### PR TITLE
refactor(docker): use Docker build cache to cache deb files

### DIFF
--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -56,8 +56,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/arm64
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -56,6 +56,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/arm64
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -51,6 +51,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/amd64
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -51,8 +51,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/amd64
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -68,6 +68,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/arm64
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -68,8 +68,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/arm64
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -63,6 +63,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/amd64
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -63,8 +63,8 @@ jobs:
           bake-target: autoware-openadk
           build-args: |
             *.platform=linux/amd64
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}:buildcache,mode=max
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 # Install apt packages
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
   --mount=type=cache,sharing=locked,target=/var/lib/apt \
   rm /etc/apt/apt.conf.d/docker-clean \
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
@@ -33,7 +33,7 @@ WORKDIR /autoware
 
 # Set up base environment
 RUN --mount=type=ssh \
-  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/cache/apt \
   --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module base --runtime openadk \
   && pip uninstall -y ansible ansible-core \
@@ -55,7 +55,7 @@ ENV CXX="/usr/lib/ccache/g++"
 # cspell: ignore libcu libnv
 # Set up development environment
 RUN --mount=type=ssh \
-  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/cache/apt \
   --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers openadk \
   && pip uninstall -y ansible ansible-core \
@@ -68,7 +68,7 @@ COPY autoware.repos /autoware/
 
 # Install rosdep dependencies
 RUN --mount=type=ssh \
-  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/cache/apt \
   --mount=type=cache,sharing=locked,target=/var/lib/apt \
   mkdir src \
   && vcs import src < autoware.repos \
@@ -93,7 +93,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
 RUN --mount=type=ssh \
-  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/cache/apt \
   --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module dev-tools --download-artifacts openadk \
   && pip uninstall -y ansible ansible-core \
@@ -114,7 +114,7 @@ ARG SETUP_ARGS
 # Set up runtime environment and artifacts
 COPY autoware.repos /autoware/
 RUN --mount=type=ssh \
-  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/cache/apt \
   --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --download-artifacts --no-cuda-drivers --runtime openadk \
   && pip uninstall -y ansible ansible-core \

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -6,7 +6,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 # Install apt packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt \
+  rm /etc/apt/apt.conf.d/docker-clean \
+  && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   git \
   ssh \
   wget \
@@ -17,7 +20,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-ins
   vim \
   unzip \
   lsb-release \
-  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
+  && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
 # Add GitHub to known hosts for private repositories
 RUN mkdir -p ~/.ssh \
@@ -30,10 +33,12 @@ WORKDIR /autoware
 
 # Set up base environment
 RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module base --runtime openadk \
   && pip uninstall -y ansible ansible-core \
   && pip install --no-cache-dir vcstool \
-  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache \
+  && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc
 
 # Create entrypoint
@@ -50,9 +55,11 @@ ENV CXX="/usr/lib/ccache/g++"
 # cspell: ignore libcu libnv
 # Set up development environment
 RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers openadk \
   && pip uninstall -y ansible ansible-core \
-  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache \
+  && apt-get autoremove -y && rm -rf $HOME"/.cache \
   && find / -name 'libcu*.a' -delete \
   && find / -name 'libnv*.a' -delete
 
@@ -61,6 +68,8 @@ COPY autoware.repos /autoware/
 
 # Install rosdep dependencies
 RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt \
   mkdir src \
   && vcs import src < autoware.repos \
   && apt-get update \
@@ -74,7 +83,7 @@ RUN --mount=type=ssh \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   && find /autoware/install -type d -exec chmod 777 {} \; \
   && chmod -R 777 /var/tmp/ccache \
-  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache \
+  && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && rm -rf /autoware/build /autoware/src
 
 CMD ["/bin/bash"]
@@ -84,9 +93,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
 RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module dev-tools --download-artifacts openadk \
   && pip uninstall -y ansible ansible-core \
-  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
+  && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
 # Create entrypoint
 COPY docker/autoware-openadk/etc/ros_entrypoint.sh /ros_entrypoint.sh
@@ -103,13 +114,15 @@ ARG SETUP_ARGS
 # Set up runtime environment and artifacts
 COPY autoware.repos /autoware/
 RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --download-artifacts --no-cuda-drivers --runtime openadk \
   && pip uninstall -y ansible ansible-core \
   && mkdir src \
   && vcs import src < autoware.repos \
   && rosdep update \
   && DEBIAN_FRONTEND=noninteractive rosdep install -y --dependency-types=exec --ignore-src --from-paths src --rosdistro "$ROS_DISTRO" \
-  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache \
+  && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && find /usr/lib/$LIB_DIR-linux-gnu -name "*.a" -type f -delete \
   && find / -name "*.o" -type f -delete \
   && find / -name "*.h" -type f -delete \

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -59,7 +59,7 @@ RUN --mount=type=ssh \
   --mount=type=cache,sharing=locked,target=/var/lib/apt \
   ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers openadk \
   && pip uninstall -y ansible ansible-core \
-  && apt-get autoremove -y && rm -rf $HOME"/.cache \
+  && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && find / -name 'libcu*.a' -delete \
   && find / -name 'libnv*.a' -delete
 


### PR DESCRIPTION
## Description

This PR introduces the Docker build cache. 

https://docs.docker.com/build/cache/

This will cache the deb files downloaded by `apt-get install` into the container registry, which is expected to speed up the installation of dependent packages.

A separate PR will also cache colcon build's ccache to the container registry.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/9091177421

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
