### PR TITLE
feat(ci): cache apt archives in `vcs-import` workflow

### DIFF
--- a/.github/workflows/vcs-import.yaml
+++ b/.github/workflows/vcs-import.yaml
@@ -24,7 +24,7 @@ jobs:
             /var/lib/apt
           key: apt-${{ runner.os }}-${{ github.ref_name }}
           restore-keys: |
-            apt-
+            apt-${{ runner.os }}-
 
       - name: Install pip for rosdep
         run: |

--- a/.github/workflows/vcs-import.yaml
+++ b/.github/workflows/vcs-import.yaml
@@ -22,6 +22,9 @@ jobs:
           path: |
             /var/cache/apt
             /var/lib/apt
+          key: apt-${{ runner.os }}-${{ github.ref_name }}
+          restore-keys: |
+            apt-
 
       - name: Install pip for rosdep
         run: |

--- a/.github/workflows/vcs-import.yaml
+++ b/.github/workflows/vcs-import.yaml
@@ -16,6 +16,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Cache apt archives
+        uses: actions/cache@v3
+        with:
+          path: |
+            /var/cache/apt
+            /var/lib/apt
+
       - name: Install pip for rosdep
         run: |
           sudo apt-get -y update


### PR DESCRIPTION
## Description

This PR adds the cache action to the `vcs-import` workflow to cache apt archives.
This is expected to speed up the execution of `rosdep install`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
