### PR TITLE
chore: add discussion templates for general category

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yaml
+++ b/.github/DISCUSSION_TEMPLATE/general.yaml
@@ -1,0 +1,13 @@
+body:
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I have read [CODE OF CONDUCT](https://github.com/autowarefoundation/autoware/blob/main/CODE_OF_CONDUCT.md) and [Support Guidelines](https://autowarefoundation.github.io/autoware-documentation/main/support/support-guidelines/#github-discussions) before creating this Discussion post.
+          required: true
+  - type: textarea
+    attributes:
+      label: Contents
+      description: Write your contents here
+    validations:
+      required: true


### PR DESCRIPTION
## Description
This adds template for General category in GitHub Discussion.
We are having some bots spamming our Discussion board, and I'm hoping this could mitigate those spams.


## Tests performed

You can try creating Discussion on my fork to check how it looks.
![image](https://github.com/autowarefoundation/autoware/assets/43976834/281fc054-f8ca-47a6-b010-33831cc8e833)


## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

People would have to fill in a template when they create a Discussion under General category

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
