### PR TITLE
feat(docker,ansible): download artifacts at runtime

### DIFF
--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -24,3 +24,7 @@
       when: prompt_install_nvidia == 'y'
     - role: autoware.dev_env.docker_engine
     - role: autoware.dev_env.nvidia_container_toolkit
+
+    # ONNX files and other artifacts
+    - role: autoware.dev_env.artifacts
+      when: prompt_download_artifacts == 'y'

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -125,7 +125,7 @@ ARG SETUP_ARGS
 COPY --from=src-imported /rosdep-exec-depend-packages.txt /tmp/rosdep-exec-depend-packages.txt
 # hadolint ignore=SC2002
 RUN --mount=type=ssh \
-  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --download-artifacts --no-cuda-drivers --runtime openadk \
+  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers --runtime openadk \
   && pip uninstall -y ansible ansible-core \
   && apt-get update \
   && cat /tmp/rosdep-exec-depend-packages.txt | xargs apt-get install -y --no-install-recommends \

--- a/docker/autoware-openadk/Dockerfile
+++ b/docker/autoware-openadk/Dockerfile
@@ -105,7 +105,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
 RUN --mount=type=ssh \
-  ./setup-dev-env.sh -y --module dev-tools --download-artifacts openadk \
+  ./setup-dev-env.sh -y --module dev-tools openadk \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -106,9 +106,6 @@ set_variables() {
     fi
 
     # Mount data path if provided
-    if [ ! -d "$DATA_PATH" ]; then
-        # TODO(youtalk)
-    fi
     DATA="-v ${DATA_PATH}:/autoware_data:ro"
 
     # Mount map path if provided

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,7 +20,7 @@ fi
 option_no_nvidia=false
 option_devel=false
 option_headless=false
-DATA_PATH=""
+DATA_PATH="${HOME}/autoware_data"
 MAP_PATH=""
 WORKSPACE_PATH=""
 USER_ID=""
@@ -106,6 +106,9 @@ set_variables() {
     fi
 
     # Mount data path if provided
+    if [ ! -d "$DATA_PATH" ]; then
+        # TODO(youtalk)
+    fi
     DATA="-v ${DATA_PATH}:/autoware_data:ro"
 
     # Mount map path if provided

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,21 +20,23 @@ fi
 option_no_nvidia=false
 option_devel=false
 option_headless=false
+DATA_PATH=""
 MAP_PATH=""
 WORKSPACE_PATH=""
 USER_ID=""
 WORKSPACE=""
-DEFAULT_LAUNCH_CMD="ros2 launch autoware_launch autoware.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit"
+DEFAULT_LAUNCH_CMD="ros2 launch autoware_launch autoware.launch.xml data_path:=/autoware_data map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit"
 
 # Function to print help message
 print_help() {
     echo -e "\n------------------------------------------------------------"
-    echo -e "${RED}Note:${NC} The --map-path option is mandatory if not custom launch command given. Please provide exact path to the map files."
+    echo -e "${RED}Note:${NC} The --data-path and --map-path options are mandatory if not custom launch command given. Please provide exact paths to the data and map files."
     echo -e "      Default launch command: ${GREEN}${DEFAULT_LAUNCH_CMD}${NC}"
     echo -e "------------------------------------------------------------"
     echo -e "${RED}Usage:${NC} run.sh [OPTIONS] [LAUNCH_CMD](optional)"
     echo -e "Options:"
     echo -e "  ${GREEN}--help/-h${NC}       Display this help message"
+    echo -e "  ${GREEN}--data-path${NC}     Specify to mount data files into /autoware_data (mandatory if no custom launch command is provided)"
     echo -e "  ${GREEN}--map-path${NC}      Specify to mount map files into /autoware_map (mandatory if no custom launch command is provided)"
     echo -e "  ${GREEN}--no-nvidia${NC}     Disable NVIDIA GPU support"
     echo -e "  ${GREEN}--devel${NC}         Use the latest development version of Autoware"
@@ -64,6 +66,10 @@ parse_arguments() {
             WORKSPACE_PATH="$2"
             shift
             ;;
+        --data-path)
+            DATA_PATH="$2"
+            shift
+            ;;
         --map-path)
             MAP_PATH="$2"
             shift
@@ -89,11 +95,18 @@ parse_arguments() {
 
 # Set image and workspace variables
 set_variables() {
-    # Check if map path is provided for default launch command
+    # Check if data and map paths are provided for default launch command
+    if [ "$DATA_PATH" == "" ] && [ "$LAUNCH_CMD" == "" ]; then
+        print_help
+        exit 1
+    fi
     if [ "$MAP_PATH" == "" ] && [ "$LAUNCH_CMD" == "" ]; then
         print_help
         exit 1
     fi
+
+    # Mount data path if provided
+    DATA="-v ${DATA_PATH}:/autoware_data:ro"
 
     # Mount map path if provided
     MAP="-v ${MAP_PATH}:/autoware_map:ro"
@@ -150,6 +163,7 @@ main() {
 
     echo -e "${GREEN}\n-----------------------LAUNCHING CONTAINER-----------------------"
     echo -e "${GREEN}IMAGE:${NC} ${IMAGE}"
+    echo -e "${GREEN}DATA PATH(mounted):${NC} ${DATA_PATH}:/autoware_data"
     echo -e "${GREEN}MAP PATH(mounted):${NC} ${MAP_PATH}:/autoware_map"
     echo -e "${GREEN}WORKSPACE(mounted):${NC} ${WORKSPACE_PATH}:/workspace"
     echo -e "${GREEN}LAUNCH CMD:${NC} ${LAUNCH_CMD}"
@@ -159,7 +173,7 @@ main() {
     set -x
     docker run -it --rm --net=host ${GPU_FLAG} ${USER_ID} ${MOUNT_X} \
         -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -v /etc/localtime:/etc/localtime:ro \
-        ${WORKSPACE} ${MAP} ${IMAGE} \
+        ${WORKSPACE} ${DATA} ${MAP} ${IMAGE} \
         ${LAUNCH_CMD}
 }
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,13 +30,13 @@ DEFAULT_LAUNCH_CMD="ros2 launch autoware_launch autoware.launch.xml data_path:=/
 # Function to print help message
 print_help() {
     echo -e "\n------------------------------------------------------------"
-    echo -e "${RED}Note:${NC} The --data-path and --map-path options are mandatory if not custom launch command given. Please provide exact paths to the data and map files."
+    echo -e "${RED}Note:${NC} The --map-path option is mandatory if not custom launch command given. Please provide exact path to the map files."
     echo -e "      Default launch command: ${GREEN}${DEFAULT_LAUNCH_CMD}${NC}"
     echo -e "------------------------------------------------------------"
     echo -e "${RED}Usage:${NC} run.sh [OPTIONS] [LAUNCH_CMD](optional)"
     echo -e "Options:"
     echo -e "  ${GREEN}--help/-h${NC}       Display this help message"
-    echo -e "  ${GREEN}--data-path${NC}     Specify to mount data files into /autoware_data (mandatory if no custom launch command is provided)"
+    echo -e "  ${GREEN}--data-path${NC}     Specify to mount data files into /autoware_data"
     echo -e "  ${GREEN}--map-path${NC}      Specify to mount map files into /autoware_map (mandatory if no custom launch command is provided)"
     echo -e "  ${GREEN}--no-nvidia${NC}     Disable NVIDIA GPU support"
     echo -e "  ${GREEN}--devel${NC}         Use the latest development version of Autoware"
@@ -95,17 +95,13 @@ parse_arguments() {
 
 # Set image and workspace variables
 set_variables() {
-    # Check if data and map paths are provided for default launch command
-    if [ "$DATA_PATH" == "" ] && [ "$LAUNCH_CMD" == "" ]; then
-        print_help
-        exit 1
-    fi
+    # Check if map path is provided for default launch command
     if [ "$MAP_PATH" == "" ] && [ "$LAUNCH_CMD" == "" ]; then
         print_help
         exit 1
     fi
 
-    # Mount data path if provided
+    # Mount data path
     DATA="-v ${DATA_PATH}:/autoware_data:ro"
 
     # Mount map path if provided

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -133,7 +133,7 @@ if [ "$option_yes" = "true" ] || [ "$option_download_artifacts" = "true" ]; then
 fi
 
 # Check downloading artifacts
-if [ "$target_playbook" = "autoware.dev_env.openadk" ]; then
+if [ "$target_playbook" = "autoware.dev_env.docker" ] || [ "$target_playbook" = "autoware.dev_env.openadk" ]; then
     if [ "$option_download_artifacts" = "true" ]; then
         echo -e "\e[36mArtifacts will be downloaded to $option_data_dir\e[m"
         ansible_args+=("--extra-vars" "prompt_download_artifacts=y")


### PR DESCRIPTION
## Description

This PR stops using the `--download-artifacts` option during `docker build` and changes to mounting `~/autoware_data` at runtime. This eliminates the need to store the 651MB `~/autoware_data` in the image every time, thereby reducing the download time and the image size.

I've also made a PR to update the documentation.
https://github.com/autowarefoundation/autoware-documentation/pull/556

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
