### PR TITLE
chore: add error handling for held packages during rmw installation

### DIFF
--- a/ansible/roles/rmw_implementation/tasks/main.yaml
+++ b/ansible/roles/rmw_implementation/tasks/main.yaml
@@ -9,6 +9,8 @@
     name: ros-{{ rosdistro }}-{{ rmw_implementation__dash_case_rmw_implementation.stdout }}
     state: latest
     update_cache: true
+  register: apt_install_result
+  failed_when: "'Held packages were changed' not in apt_install_result.msg"
 
 - name: Add RMW_IMPLEMENTATION to .bashrc
   ansible.builtin.lineinfile:

--- a/ansible/roles/rmw_implementation/tasks/main.yaml
+++ b/ansible/roles/rmw_implementation/tasks/main.yaml
@@ -3,14 +3,25 @@
   register: rmw_implementation__dash_case_rmw_implementation
   changed_when: false
 
+- name: Hold check of ros-{{ rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout }}
+  ansible.builtin.command: apt-mark showhold
+  register: held_ros_packages
+  changed_when: false
+
 - name: Install ros-{{ rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout }}
   become: true
   ansible.builtin.apt:
     name: ros-{{ rosdistro }}-{{ rmw_implementation__dash_case_rmw_implementation.stdout }}
     state: latest
     update_cache: true
-  register: apt_install_result
-  failed_when: "'Held packages were changed' not in apt_install_result.msg"
+  when: "'ros-' + rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout not in held_ros_packages.stdout"
+  register: install_result
+  failed_when: false
+
+- name: Display warning if ROS 2 RMW package is held
+  ansible.builtin.debug:
+    msg: ROS 2 RMW package 'ros-{{ rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout }}' is apt-mark hold. Skipping installation.
+  when: not install_result.changed
 
 - name: Add RMW_IMPLEMENTATION to .bashrc
   ansible.builtin.lineinfile:


### PR DESCRIPTION
## Description

This PR implements a similar fix to the one applied in [PR #4585](https://github.com/autowarefoundation/autoware/pull/4585). 
The changes address the handling of the ROS RMW (ROS Middleware) installation process, specifically when packages are already pinned.

## Tests performed

### Premise
![image](https://github.com/autowarefoundation/autoware/assets/15172687/d4ec519d-3fd5-44d4-956d-7c53f2e1e86a)
ROS rmw packages are held.

### before 
![image](https://github.com/autowarefoundation/autoware/assets/15172687/7686f67a-4985-4311-a9a5-e85b054f5ece)
Errored in `Install ros-humble-rmw-cyclonedds-cpp`.

### after (held packages)
![image](https://github.com/autowarefoundation/autoware/assets/15172687/34fcf20c-c052-46dd-95c8-0614f63f778d)

### after (not held packages)
![image](https://github.com/autowarefoundation/autoware/assets/15172687/a156c6b2-518b-4418-8380-0e145f522e99)

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
