### PR TITLE
fix(ci): run `vsc import` on `build-main` workflows

### DIFF
--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -44,8 +44,24 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Install vcstool
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install python3-pip
+          pip install --no-cache-dir vcstool
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
+
+      - name: Run vcs import
+        run: |
+          mkdir src
+          vcs import src < autoware.repos
 
       - name: Build 'autoware-universe'
         uses: ./.github/actions/docker-build-and-push

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -39,8 +39,24 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Install vcstool
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install python3-pip
+          pip install --no-cache-dir vcstool
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
+
+      - name: Run vcs import
+        run: |
+          mkdir src
+          vcs import src < autoware.repos
 
       - name: Build 'autoware-universe'
         uses: ./.github/actions/docker-build-and-push


### PR DESCRIPTION
## Description

This PR fixes the failure of `build-main` CI. https://github.com/autowarefoundation/autoware/actions/workflows/build-main.yaml
This occurred because of https://github.com/autowarefoundation/autoware/pull/4738.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/9304401153

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
