### PR TITLE
feat(docker): cache `ccache` to the Docker build cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Build Autoware
 COPY --from=src-imported /autoware/src /autoware/src
-RUN source /opt/ros/"$ROS_DISTRO"/setup.bash \
+RUN --mount=type=cache,target=${CCACHE_DIR} \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --cmake-args \
     " -Wno-dev" \
     " --no-warn-unused-cli" \


### PR DESCRIPTION
## Description

> This PR cache `ccache` to the Docker build cache.

I'm sorry but this PR is the re-submission of https://github.com/autowarefoundation/autoware/pull/4772.
It was mistakenly deleted by the correction of https://github.com/autowarefoundation/autoware/pull/4778/files#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL91.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/9314720463

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
