### PR TITLE
chore: hold check of plotjuggler-ros package and display warning if held

### DIFF
--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -49,7 +49,7 @@
       - ros-{{ rosdistro }}-plotjuggler-ros
     state: latest
     update_cache: true
-  when: "'ros-' + rosdistro + '-' + plotjuggler-ros not in held_ros_packages.stdout"
+  when: "'ros-' + rosdistro + '-plotjuggler-ros' not in held_ros_packages.stdout"
   register: install_result
   failed_when: false
 

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -37,6 +37,11 @@
     state: latest
     update_cache: true
 
+- name: Hold check of ros-{{ rosdistro }}-plotjuggler-ros
+  ansible.builtin.command: apt-mark showhold
+  register: held_ros_packages
+  changed_when: false
+
 - name: Install plotjuggler
   become: true
   ansible.builtin.apt:
@@ -44,3 +49,12 @@
       - ros-{{ rosdistro }}-plotjuggler-ros
     state: latest
     update_cache: true
+  when: "'ros-' + rosdistro + '-' + plotjuggler-ros not in held_ros_packages.stdout"
+  register: install_result
+  failed_when: false
+
+- name: Display warning if plotjuggler-ros package is held
+  ansible.builtin.debug:
+    msg: ROS package 'ros-{{ rosdistro }}-plotjuggler-ros' is apt-mark hold. Skipping installation.
+  when: not install_result.changed
+

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -37,7 +37,7 @@
     state: latest
     update_cache: true
 
-- name: Hold check of ros-{{ rosdistro }}-plotjuggler-ros
+- name: Hold check of ros-{{ rosdistro + '-plotjuggler-ros' }}
   ansible.builtin.command: apt-mark showhold
   register: held_ros_packages
   changed_when: false

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -57,4 +57,3 @@
   ansible.builtin.debug:
     msg: ROS package 'ros-{{ rosdistro }}-plotjuggler-ros' is apt-mark hold. Skipping installation.
   when: not install_result.changed
-


### PR DESCRIPTION
## Description

This PR implements a similar fix to the one applied in https://github.com/autowarefoundation/autoware/pull/4781
The changes address the handling of the `plotjuggler-ros` installation process, specifically when packages are already pinned.

## Tests performed

### premise
![image](https://github.com/autowarefoundation/autoware/assets/15172687/70652585-470f-4fdd-bcc9-17d4861e49c1)

### before 
![image](https://github.com/autowarefoundation/autoware/assets/15172687/1e2cf51f-ef53-4583-84b9-a1a75f33e3e5)
Errored in `Install plotjuggler`

### after(held packages)
![image](https://github.com/autowarefoundation/autoware/assets/15172687/335973d3-303c-4f0d-aee6-9bb39d37e6b9)
install escaped.

### after (not held packages)
![image](https://github.com/autowarefoundation/autoware/assets/15172687/d8ec1726-1e4f-410c-8430-64e2fc6cf44a)

![image](https://github.com/autowarefoundation/autoware/assets/15172687/f56876fe-8d2a-4600-9d4c-5d2b76b34eff)

update success.

### after(initial setup)
![image](https://github.com/autowarefoundation/autoware/assets/15172687/687b892d-baa0-4424-aa72-b97721592fe9)

![image](https://github.com/autowarefoundation/autoware/assets/15172687/97166a66-1d15-4a49-b47e-fc4f38f056c0)
install success.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
