### PR TITLE
feat(docker): change base_image to `ros:humble-ros-core-jammy`

### DIFF
--- a/amd64.env
+++ b/amd64.env
@@ -1,6 +1,6 @@
 rosdistro=humble
 rmw_implementation=rmw_cyclonedds_cpp
-base_image=ros:humble-ros-base-jammy
+base_image=ros:humble-ros-core-jammy
 cuda_version=12.3
 cudnn_version=8.9.5.29-1+cuda12.2
 tensorrt_version=8.6.1.6-1+cuda12.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   gosu \
+  python3-rosdep \
   ssh \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && mkdir -p ~/.ssh \
@@ -97,6 +98,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt-get update \
   && cat /tmp/rosdep-all-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
+  && apt-get install -y --no-install-recommends \
+    python3-colcon-common-extensions \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
 # Build Autoware

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   gosu \
-  python3-rosdep \
   ssh \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && mkdir -p ~/.ssh \
@@ -57,7 +56,11 @@ RUN --mount=type=ssh \
 COPY src /autoware/src
 
 # Generate install package lists
-RUN rosdep update && rosdep keys --ignore-src --from-paths src \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    python3-rosdep \
+  && rosdep update \
+  && rosdep keys --ignore-src --from-paths src \
     | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
     | grep -v '^#' \
     | sed 's/ \+/\n/g'\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,6 +59,7 @@ COPY src /autoware/src
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     python3-rosdep \
+  && rosdep init \
   && rosdep update \
   && rosdep keys --ignore-src --from-paths src \
     | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \


### PR DESCRIPTION
## Description

This PR changes `base_image` of the Dockerfile from `ros:humble-ros-base-jammy` to `ros:humble-ros-core-jammy` to decrease the image size.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/9359817720

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
