### PR TITLE
feat(simulator.repos): use autoware_msgs_support branch for scenario_simulator

### DIFF
--- a/simulator.repos
+++ b/simulator.repos
@@ -2,4 +2,4 @@ repositories:
   simulator/scenario_simulator:
     type: git
     url: https://github.com/tier4/scenario_simulator_v2.git
-    version: RJD-736/autoware_msgs_support  # switch back to master once this branch is merged
+    version: RJD-736/autoware_msgs_support  # TODO(mitsudome-r): switch back to master once this branch is merged

--- a/simulator.repos
+++ b/simulator.repos
@@ -2,4 +2,4 @@ repositories:
   simulator/scenario_simulator:
     type: git
     url: https://github.com/tier4/scenario_simulator_v2.git
-    version: master
+    version: RJD-736/autoware_msgs_support  # switch back to master once this branch is merged


### PR DESCRIPTION
## Description
Use [RJD-736/autoware_msgs_support](https://github.com/tier4/scenario_simulator_v2/tree/RJD-736/autoware_msgs_support) until the branch is merged to master.

Related link: https://github.com/orgs/autowarefoundation/discussions/3862

## Tests performed

I have confirmed that the scenario results doesn't change with this branch after migration to autoware_msgs
* Before (442/617 passing): https://evaluation.tier4.jp/evaluation/reports/95a837bd-c785-55d6-90e7-1eeed9376ed4?project_id=awf
* After (443/617 passing): https://evaluation.tier4.jp/evaluation/reports/4187dcf0-f1a6-561a-9e1d-98c361cce3d0?project_id=awf

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
