### PR TITLE
feat(ci,docker): save `RUN --mount=type=cache` ccache on GitHub Actions cache

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -22,9 +22,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
     - name: Install jq and vcstool
       run: |
         sudo apt-get -y update
@@ -59,7 +56,7 @@ runs:
 
     - name: Docker meta for prebuilt
       id: meta-prebuilt
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
@@ -70,7 +67,7 @@ runs:
 
     - name: Docker meta for devel
       id: meta-devel
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
@@ -82,7 +79,7 @@ runs:
     - name: Docker meta for runtime
       if: ${{ github.event_name == 'workflow_dispatch' }} || ${{ (github.event_name == 'push' && github.ref_type == 'tag') }}
       id: meta-runtime
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
@@ -101,7 +98,7 @@ runs:
 
     - name: Build and Push to GitHub Container Registry
       if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || ( github.event_name == 'workflow_dispatch' && github.event.inputs.artifacts-destination == 'registry') }}
-      uses: docker/bake-action@v3
+      uses: docker/bake-action@v4
       with:
         push: ${{ inputs.allow-push == 'true' }}
         files: |
@@ -115,7 +112,7 @@ runs:
 
     - name: Build only
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.artifacts-destination == 'tarball' }}
-      uses: docker/bake-action@v3
+      uses: docker/bake-action@v4
       with:
         push: false
         files: |

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -57,6 +57,25 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            root-ccache
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          restore-keys: |
+            cache-${{ matrix.platform }}-${{ matrix.name }}-
+            cache-${{ matrix.platform }}-
+      - name: inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-map: |
+            {
+              "root-ccache": "/root/.ccache"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
       - name: Build 'Autoware'
         uses: ./.github/actions/docker-build-and-push
         with:

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           path: |
             root-ccache
-          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('autoware.repos') }}
           restore-keys: |
             cache-${{ matrix.platform }}-${{ matrix.name }}-
             cache-${{ matrix.platform }}-

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -52,6 +52,25 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            root-ccache
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          restore-keys: |
+            cache-${{ matrix.platform }}-${{ matrix.name }}-
+            cache-${{ matrix.platform }}-
+      - name: inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-map: |
+            {
+              "root-ccache": "/root/.ccache"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
       - name: Build 'Autoware'
         uses: ./.github/actions/docker-build-and-push
         with:

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           path: |
             root-ccache
-          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('autoware.repos') }}
           restore-keys: |
             cache-${{ matrix.platform }}-${{ matrix.name }}-
             cache-${{ matrix.platform }}-

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -69,6 +69,25 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            root-ccache
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          restore-keys: |
+            cache-${{ matrix.platform }}-${{ matrix.name }}-
+            cache-${{ matrix.platform }}-
+      - name: inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-map: |
+            {
+              "root-ccache": "/root/.ccache"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
       - name: Build 'Autoware'
         uses: ./.github/actions/docker-build-and-push
         with:

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           path: |
             root-ccache
-          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('autoware.repos') }}
           restore-keys: |
             cache-${{ matrix.platform }}-${{ matrix.name }}-
             cache-${{ matrix.platform }}-

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -53,6 +53,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -64,6 +64,25 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            root-ccache
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          restore-keys: |
+            cache-${{ matrix.platform }}-${{ matrix.name }}-
+            cache-${{ matrix.platform }}-
+      - name: inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-map: |
+            {
+              "root-ccache": "/root/.ccache"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
       - name: Build 'Autoware'
         uses: ./.github/actions/docker-build-and-push
         with:

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           path: |
             root-ccache
-          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('docker/Dockerfile') }}
+          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('autoware.repos') }}
           restore-keys: |
             cache-${{ matrix.platform }}-${{ matrix.name }}-
             cache-${{ matrix.platform }}-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,8 +66,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ARG SETUP_ARGS
 ENV CCACHE_DIR="/var/tmp/ccache"
-ENV CC="/usr/lib/ccache/gcc"
-ENV CXX="/usr/lib/ccache/g++"
 
 # cspell: ignore libcu libnv
 # Set up development environment
@@ -91,10 +89,9 @@ COPY --from=src-imported /autoware/src /autoware/src
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && colcon build --cmake-args \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     " -Wno-dev" \
     " --no-warn-unused-cli" \
+    --mixin release compile-commands ccache \
   && find /autoware/install -type d -exec chmod 777 {} \; \
   && chmod -R 777 /var/tmp/ccache \
   && rm -rf /autoware/build /autoware/src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,11 +90,11 @@ RUN --mount=type=ssh \
 COPY --from=src-imported /autoware/src /autoware/src
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
-  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --cmake-args \
-    " -Wno-dev" \
-    " --no-warn-unused-cli" \
+  && colcon build --cmake-args \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    " -Wno-dev" \
+    " --no-warn-unused-cli" \
   && find /autoware/install -type d -exec chmod 777 {} \; \
   && chmod -R 777 /var/tmp/ccache \
   && rm -rf /autoware/build /autoware/src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,12 +88,13 @@ RUN --mount=type=ssh \
 COPY --from=src-imported /autoware/src /autoware/src
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && du -sh ${CCACHE_DIR} && ccache -s \
   && colcon build --cmake-args \
     " -Wno-dev" \
     " --no-warn-unused-cli" \
     --mixin release compile-commands ccache \
+  && du -sh ${CCACHE_DIR} && ccache -s \
   && find /autoware/install -type d -exec chmod 777 {} \; \
-  && chmod -R 777 /var/tmp/ccache \
   && rm -rf /autoware/build /autoware/src
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description

- [ ] https://github.com/autowarefoundation/autoware/pull/4842

I've finally understood the BuildKit doesn't preserve cache mounts in the GitHub Actions cache by default. If we wish to put our cache mounts into GitHub Actions cache and reuse it between builds, we can use a workaround provided by [reproducible-containers/buildkit-cache-dance](https://github.com/reproducible-containers/buildkit-cache-dance)

https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts

I found that the `buildkit-cache-dance` action does not work effectively unless the `setup-buildx-action` action is executed beforehand, so it was temporarily moved from `docker-build-and-push/action.yaml` to the beginning of each workflow file. This will be improved in the next PR.

## Tests performed

~Currently, as part of [`autoware.universe` is broken](https://github.com/autowarefoundation/autoware.universe/pull/7444),~ I show the build results of only the core module.
https://github.com/youtalk/autoware/actions/runs/9462979885?pr=44

- 1st try (no cache):
  - [docker-build-and-push-main (no-cuda)](https://github.com/youtalk/autoware/runs/26067149845?check_suite_focus=true) 10m 7s
  - [docker-build-and-push-main (cuda)](https://github.com/youtalk/autoware/runs/26067150245?check_suite_focus=true) 16m 9s
- 2nd try (with cache):
  - [docker-build-and-push-main (no-cuda)](https://github.com/youtalk/autoware/runs/26072876509?check_suite_focus=true) 4m 17s
  - [docker-build-and-push-main (cuda)](https://github.com/youtalk/autoware/runs/26072876816?check_suite_focus=true) 5m 27s

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
