### PR TITLE
feat(docker,ansible): revert "feat(docker,ansible): download artifacts at runtime (#4771)"

### DIFF
--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -24,7 +24,3 @@
       when: prompt_install_nvidia == 'y'
     - role: autoware.dev_env.docker_engine
     - role: autoware.dev_env.nvidia_container_toolkit
-
-    # ONNX files and other artifacts
-    - role: autoware.dev_env.artifacts
-      when: prompt_download_artifacts == 'y'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,7 +104,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
 RUN --mount=type=ssh \
-  ./setup-dev-env.sh -y --module dev-tools openadkit \
+  ./setup-dev-env.sh -y --module dev-tools --download-artifacts openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
@@ -124,7 +124,7 @@ ARG SETUP_ARGS
 COPY --from=src-imported /rosdep-exec-depend-packages.txt /tmp/rosdep-exec-depend-packages.txt
 # hadolint ignore=SC2002
 RUN --mount=type=ssh \
-  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers --runtime openadkit \
+  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --download-artifacts --no-cuda-drivers --runtime openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get update \
   && cat /tmp/rosdep-exec-depend-packages.txt | xargs apt-get install -y --no-install-recommends \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,12 +20,11 @@ fi
 option_no_nvidia=false
 option_devel=false
 option_headless=false
-DATA_PATH="${HOME}/autoware_data"
 MAP_PATH=""
 WORKSPACE_PATH=""
 USER_ID=""
 WORKSPACE=""
-DEFAULT_LAUNCH_CMD="ros2 launch autoware_launch autoware.launch.xml data_path:=/autoware_data map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit"
+DEFAULT_LAUNCH_CMD="ros2 launch autoware_launch autoware.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit"
 
 # Function to print help message
 print_help() {
@@ -36,7 +35,6 @@ print_help() {
     echo -e "${RED}Usage:${NC} run.sh [OPTIONS] [LAUNCH_CMD](optional)"
     echo -e "Options:"
     echo -e "  ${GREEN}--help/-h${NC}       Display this help message"
-    echo -e "  ${GREEN}--data-path${NC}     Specify to mount data files into /autoware_data"
     echo -e "  ${GREEN}--map-path${NC}      Specify to mount map files into /autoware_map (mandatory if no custom launch command is provided)"
     echo -e "  ${GREEN}--no-nvidia${NC}     Disable NVIDIA GPU support"
     echo -e "  ${GREEN}--devel${NC}         Use the latest development version of Autoware"
@@ -64,10 +62,6 @@ parse_arguments() {
             ;;
         --workspace)
             WORKSPACE_PATH="$2"
-            shift
-            ;;
-        --data-path)
-            DATA_PATH="$2"
             shift
             ;;
         --map-path)
@@ -100,9 +94,6 @@ set_variables() {
         print_help
         exit 1
     fi
-
-    # Mount data path
-    DATA="-v ${DATA_PATH}:/autoware_data:ro"
 
     # Mount map path if provided
     MAP="-v ${MAP_PATH}:/autoware_map:ro"
@@ -159,7 +150,6 @@ main() {
 
     echo -e "${GREEN}\n-----------------------LAUNCHING CONTAINER-----------------------"
     echo -e "${GREEN}IMAGE:${NC} ${IMAGE}"
-    echo -e "${GREEN}DATA PATH(mounted):${NC} ${DATA_PATH}:/autoware_data"
     echo -e "${GREEN}MAP PATH(mounted):${NC} ${MAP_PATH}:/autoware_map"
     echo -e "${GREEN}WORKSPACE(mounted):${NC} ${WORKSPACE_PATH}:/workspace"
     echo -e "${GREEN}LAUNCH CMD:${NC} ${LAUNCH_CMD}"
@@ -169,7 +159,7 @@ main() {
     set -x
     docker run -it --rm --net=host ${GPU_FLAG} ${USER_ID} ${MOUNT_X} \
         -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -v /etc/localtime:/etc/localtime:ro \
-        ${WORKSPACE} ${DATA} ${MAP} ${IMAGE} \
+        ${WORKSPACE} ${MAP} ${IMAGE} \
         ${LAUNCH_CMD}
 }
 

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -133,7 +133,7 @@ if [ "$option_yes" = "true" ] || [ "$option_download_artifacts" = "true" ]; then
 fi
 
 # Check downloading artifacts
-if [ "$target_playbook" = "autoware.dev_env.docker" ] || [ "$target_playbook" = "autoware.dev_env.openadk" ]; then
+if [ "$target_playbook" = "autoware.dev_env.openadk" ]; then
     if [ "$option_download_artifacts" = "true" ]; then
         echo -e "\e[36mArtifacts will be downloaded to $option_data_dir\e[m"
         ansible_args+=("--extra-vars" "prompt_download_artifacts=y")


### PR DESCRIPTION
This reverts #4771 according to https://github.com/autowarefoundation/autoware/pull/4849#issuecomment-2160597264.

> > It's even better than before! We can review it easier and faster.
> > Do you have an actual reason to re-add `--download-artifacts` at build time? ref. #4771
> 
> I think we should keep our images as complete as possible. Since we don't have any disk usage problem anymore, we can re-add those artifacts to simplify container usage. Because the original intention was to save space.
> 
> And also think about a scenario in which user just downloads the image and go on a field test where there is no sufficient internet connection to download all artifacts. IMHO, devel and runtime images should be self-sufficient. Moreover these artifacts are mandatory to run essential parts of the Autoware(perception, localization) that means user will always need to download them so why not just keep them inside the image ?