### PR TITLE
feat(ci): save cache on `build-main` workflows and only restore cache on `docker-build-and-push-main` workflows

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -1,0 +1,69 @@
+name: docker-build-and-push
+description: ""
+
+inputs:
+  name:
+    description: ""
+    required: true
+  platform:
+    description: ""
+    required: true
+  build-args:
+    description: ""
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Install vcstool
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install python3-pip
+        pip install --no-cache-dir vcstool
+      shell: bash
+
+    - name: Run vcs import
+      run: |
+        mkdir src
+        vcs import src < autoware.repos
+      shell: bash
+
+    - name: Cache
+      uses: actions/cache@v3
+      id: cache
+      with:
+        path: |
+          root-ccache
+        key: cache-${{ inputs.platform }}-${{ inputs.name }}-${{ hashFiles('autoware.repos') }}
+        restore-keys: |
+          cache-${{ inputs.platform }}-${{ inputs.name }}-
+          cache-${{ inputs.platform }}-
+
+    - name: Inject cache into docker
+      uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+      with:
+        cache-map: |
+          {
+            "root-ccache": "/root/.ccache"
+          }
+        skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Run docker build
+      uses: docker/build-push-action@v5
+      with:
+        file: docker/Dockerfile
+        context: .
+        push: false
+        build-args: ${{ inputs.build-args }}
+        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.name }}-${{ inputs.platform }}-main
+        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.name }}-${{ inputs.platform }}-main,mode=max

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -8,6 +8,9 @@ inputs:
   platform:
     description: ""
     required: true
+  cache-tag-suffix:
+    description: ""
+    required: true
   build-args:
     description: ""
     required: true
@@ -65,5 +68,5 @@ runs:
         context: .
         push: false
         build-args: ${{ inputs.build-args }}
-        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.name }}-${{ inputs.platform }}-main
-        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.name }}-${{ inputs.platform }}-main,mode=max
+        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.name }}-${{ inputs.platform }}-${{ inputs.cache-tag-suffix }}
+        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.name }}-${{ inputs.platform }}-${{ inputs.cache-tag-suffix }},mode=max

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -1,4 +1,4 @@
-name: docker-build-and-push
+name: docker-build
 description: ""
 
 inputs:

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -4,13 +4,6 @@ on:
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
-    inputs:
-      artifacts-destination:
-        type: choice
-        description: Built images will be saved as tarball
-        options:
-          - tarball
-        default: tarball
 
 jobs:
   load-env:
@@ -46,9 +39,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
@@ -57,40 +47,16 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
-      - name: Cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            root-ccache
-          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('autoware.repos') }}
-          restore-keys: |
-            cache-${{ matrix.platform }}-${{ matrix.name }}-
-            cache-${{ matrix.platform }}-
-      - name: inject cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
-        with:
-          cache-map: |
-            {
-              "root-ccache": "/root/.ccache"
-            }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
-
       - name: Build 'Autoware'
-        uses: ./.github/actions/docker-build-and-push
+        uses: ./.github/actions/docker-build
         with:
-          bake-target: autoware
+          name: ${{ matrix.name }}
+          platform: ${{ matrix.platform }}
           build-args: |
-            *.platform=linux/${{ matrix.platform }}
-            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            *.args.BASE_IMAGE=${{ needs.load-env.outputs[format('{0}', matrix.base_image_env)] }}
-            *.args.SETUP_ARGS=${{ matrix.setup-args }}
-            *.args.LIB_DIR=${{ matrix.lib_dir }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.name }}-${{ matrix.platform }}-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.name }}-${{ matrix.platform }}-main,mode=max
-          tag-suffix: ${{ matrix.additional-tag-suffix }}-${{ matrix.platform }}
-          tag-prefix: ${{ needs.load-env.outputs.rosdistro }}
-          allow-push: false
+            ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            BASE_IMAGE=${{ needs.load-env.outputs[format('{0}', matrix.base_image_env)] }}
+            SETUP_ARGS=${{ matrix.setup-args }}
+            LIB_DIR=${{ matrix.lib_dir }}
 
       - name: Show disk space
         run: |

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
+  pull_request:
 
 jobs:
   load-env:

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           name: ${{ matrix.name }}
           platform: ${{ matrix.platform }}
+          cache-tag-suffix: main
           build-args: |
             ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             BASE_IMAGE=${{ needs.load-env.outputs[format('{0}', matrix.base_image_env)] }}

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
-  pull_request:
 
 jobs:
   load-env:

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
+  pull_request:
 
 jobs:
   load-env:

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -4,13 +4,6 @@ on:
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
-    inputs:
-      artifacts-destination:
-        type: choice
-        description: Built images will be saved as tarball
-        options:
-          - tarball
-        default: tarball
 
 jobs:
   load-env:
@@ -41,9 +34,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
@@ -52,40 +42,16 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
-      - name: Cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            root-ccache
-          key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('autoware.repos') }}
-          restore-keys: |
-            cache-${{ matrix.platform }}-${{ matrix.name }}-
-            cache-${{ matrix.platform }}-
-      - name: inject cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
-        with:
-          cache-map: |
-            {
-              "root-ccache": "/root/.ccache"
-            }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
-
       - name: Build 'Autoware'
-        uses: ./.github/actions/docker-build-and-push
+        uses: ./.github/actions/docker-build
         with:
-          bake-target: autoware
+          name: ${{ matrix.name }}
+          platform: ${{ matrix.platform }}
           build-args: |
-            *.platform=linux/${{ matrix.platform }}
-            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            *.args.BASE_IMAGE=${{ needs.load-env.outputs[format('{0}', matrix.base_image_env)] }}
-            *.args.SETUP_ARGS=${{ matrix.setup-args }}
-            *.args.LIB_DIR=${{ matrix.lib_dir }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.name }}-${{ matrix.platform }}-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.name }}-${{ matrix.platform }}-main,mode=max
-          tag-suffix: ${{ matrix.additional-tag-suffix }}-${{ matrix.platform }}
-          tag-prefix: ${{ needs.load-env.outputs.rosdistro }}
-          allow-push: false
+            ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            BASE_IMAGE=${{ needs.load-env.outputs[format('{0}', matrix.base_image_env)] }}
+            SETUP_ARGS=${{ matrix.setup-args }}
+            LIB_DIR=${{ matrix.lib_dir }}
 
       - name: Show disk space
         run: |

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -48,6 +48,7 @@ jobs:
         with:
           name: ${{ matrix.name }}
           platform: ${{ matrix.platform }}
+          cache-tag-suffix: main
           build-args: |
             ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             BASE_IMAGE=${{ needs.load-env.outputs[format('{0}', matrix.base_image_env)] }}

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
-  pull_request:
 
 jobs:
   load-env:

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -69,9 +69,8 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
-      - name: Cache
-        uses: actions/cache@v3
-        id: cache
+      - name: Restore cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             root-ccache
@@ -79,14 +78,15 @@ jobs:
           restore-keys: |
             cache-${{ matrix.platform }}-${{ matrix.name }}-
             cache-${{ matrix.platform }}-
-      - name: inject cache into docker
+
+      - name: Inject cache into docker
         uses: reproducible-containers/buildkit-cache-dance@v3.1.0
         with:
           cache-map: |
             {
               "root-ccache": "/root/.ccache"
             }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+          skip-extraction: true
 
       - name: Build 'Autoware'
         uses: ./.github/actions/docker-build-and-push

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -39,14 +39,14 @@ jobs:
           - cuda
         include:
           - name: no-cuda
-            base_image_env: base_image
             platform: amd64
+            base_image_env: base_image
             lib_dir: x86_64
             setup-args: --no-nvidia
             additional-tag-suffix: ""
           - name: cuda
-            base_image_env: base_image
             platform: amd64
+            base_image_env: base_image
             lib_dir: x86_64
             additional-tag-suffix: -cuda
     steps:

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -64,9 +64,8 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
-      - name: Cache
-        uses: actions/cache@v3
-        id: cache
+      - name: Restore cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             root-ccache
@@ -74,14 +73,15 @@ jobs:
           restore-keys: |
             cache-${{ matrix.platform }}-${{ matrix.name }}-
             cache-${{ matrix.platform }}-
-      - name: inject cache into docker
+
+      - name: Inject cache into docker
         uses: reproducible-containers/buildkit-cache-dance@v3.1.0
         with:
           cache-map: |
             {
               "root-ccache": "/root/.ccache"
             }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+          skip-extraction: true
 
       - name: Build 'Autoware'
         uses: ./.github/actions/docker-build-and-push

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ FROM base as prebuilt
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ARG SETUP_ARGS
-ENV CCACHE_DIR="/var/tmp/ccache"
+ENV CCACHE_DIR="/root/.ccache"
 
 # cspell: ignore libcu libnv
 # Set up development environment


### PR DESCRIPTION
## Description

- [ ] #4863 

The `reproducible-containers/buildkit-cache-dance` action introduced in https://github.com/autowarefoundation/autoware/pull/4854, unfortunately, might not support extracting the cache from the `docker buildx bake` and only supports `docker build`.

I confirmed that replacing `docker/bake-action` with `docker/build-and-push-action` as per the official sample code does indeed enable the cache to work.
https://github.com/reproducible-containers/buildkit-cache-dance?tab=readme-ov-file#examples

Therefore, in this PR, we will create a cache by running `docker/build-and-push-action` in the `build-main` and `build-main-self-hosted` workflows, which are scheduled to run daily, and in the sequentially executed `docker-build-and-push-main` and `docker-build-and-push-main-self-hosted` workflows, we will run `docker/bake-action` as in the past and only load the cache.

It turns out that the cache was effective in https://github.com/autowarefoundation/autoware/pull/4854 because I forgot to delete the cache from the commit during my experiment, which caused the cache to be effective. I apologize for the oversight.

## Tests performed

Using [this commit](https://github.com/autowarefoundation/autoware/pull/4865/commits/adced0dc54fd73e82994c830c68116f232efe46e) to temporarily run the `build-main` workflows in this PR, we confirmed that the execution time from the second run onwards was drastically reduced from the previous **2.5 hours to 1 hour**.

- first try (without cache): https://github.com/autowarefoundation/autoware/actions/runs/9495072771/usage
- second try (with cache): https://github.com/autowarefoundation/autoware/actions/runs/9506736727/usage

https://autowarefoundation.github.io/autoware-ci-metrics/

<img width="686" alt="Screenshot 2024-06-14 at 8 49 33" src="https://github.com/autowarefoundation/autoware/assets/579333/c2b3dbd2-d0e6-4aeb-9834-7b765be63057">

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
