### PR TITLE
ci(docker-build-and-push-main): don't push to registry on commit to main

### DIFF
--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -10,8 +10,6 @@ on:
   push:
     tags:
       - openadkit-v*.*.*
-    branches:
-      - main
   schedule:
     - cron: 0 0 1,15 * *
   workflow_dispatch:

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -10,8 +10,6 @@ on:
   push:
     tags:
       - openadkit-v*.*.*
-    branches:
-      - main
   schedule:
     - cron: 0 0 1,15 * *
   workflow_dispatch:


### PR DESCRIPTION
## Description

Resolves:
- https://github.com/autowarefoundation/autoware/issues/4878

⚠️⚠️⚠️
**Please merge after:**
- https://github.com/autowarefoundation/autoware/pull/4886 is merged to keep things simple.

## Tests performed

No need, it's just a condition.

## Effects on system behavior

Will stop running on push to main.

## Interface changes

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
