### PR TITLE
feat(ci): update `docker/bake-action` and `docker/build-push-action` versions to enable GitHub Actions build summary

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -111,7 +111,7 @@ runs:
       if: ${{ github.event_name == 'push' ||
         github.event_name == 'schedule' ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.artifacts-destination == 'registry') }}
-      uses: docker/bake-action@v4
+      uses: docker/bake-action@v5
       with:
         push: ${{ inputs.allow-push == 'true' }}
         files: |
@@ -126,7 +126,7 @@ runs:
 
     - name: Build only
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.artifacts-destination == 'tarball' }}
-      uses: docker/bake-action@v4
+      uses: docker/bake-action@v5
       with:
         push: false
         files: |

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -62,7 +62,7 @@ runs:
         password: ${{ github.token }}
 
     - name: Run docker build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         file: docker/Dockerfile
         context: .


### PR DESCRIPTION
## Description

This PR updates docker actions for GitHub Actions to enable `GitHub Actions build summary` by `docker build`.
https://docs.docker.com/build/ci/github-actions/build-summary/

## Tests performed

I tried it in my forked repository, and it was easy to check the cache usage, build time, and bake definitions.
https://github.com/youtalk/autoware/actions/runs/9607362250?pr=52

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
