### PR TITLE
feat(autoware.repos): no longer import `autoware_auto_msgs`

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -20,10 +20,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
     version: main
-  core/external/autoware_auto_msgs: # TODO(mfc): Remove when autoware_msgs is merged
-    type: git
-    url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
   # universe
   universe/autoware.universe:
     type: git


### PR DESCRIPTION
## Description

The migration from `autoware_auto_msgs` to` autoware_msgs` was complete, so this PR removes `autoware_auto_msgs` from `autoware.repos`.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/9639700166

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
