### PR TITLE
feat(autoware.repos): use `autoware_cmake`, `autoware_utils` and `autoware_lanelet2_extension` instead of `autoware_common`

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -22,7 +22,7 @@ repositories:
     version: main
   core/autoware_lanelet2_extension:
     type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
+    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
     version: main
   core/autoware.core:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -24,10 +24,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
     version: main
-  core/autoware_lanelet2_extension:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: main
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -37,11 +37,10 @@ repositories:
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
   # universe
-  # TODO(youtalk): Revert after https://github.com/autowarefoundation/autoware.universe/pull/7640 merged
   universe/autoware.universe:
     type: git
-    url: https://github.com/youtalk/autoware.universe.git
-    version: use-autoware-lanelet2-extension
+    url: https://github.com/autowarefoundation/autoware.universe.git
+    version: main
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Improve design/code and transfer to AWF
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -33,10 +33,11 @@ repositories:
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
   # universe
+  # TODO(youtalk): Revert after https://github.com/autowarefoundation/autoware.universe/pull/7640 merged
   universe/autoware.universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
-    version: main
+    url: https://github.com/youtalk/autoware.universe.git
+    version: use-autoware-lanelet2-extension
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Improve design/code and transfer to AWF
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -12,9 +12,17 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
     version: main
-  core/autoware_common:
+  core/autoware_cmake:
     type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
+    url: https://github.com/autowarefoundation/autoware_cmake.git
+    version: main
+  core/autoware_utils:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_utils.git
+    version: main
+  core/autoware_lanelet2_extension:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main
   core/autoware.core:
     type: git


### PR DESCRIPTION
## Description

- [x] https://github.com/autowarefoundation/autoware/pull/4912
- [ ] https://github.com/autowarefoundation/autoware.universe/pull/7640
- [ ] https://github.com/tier4/scenario_simulator_v2/pull/1300

The migration from `autoware_common` to `autoware_cmake`, `autoware_utils` and `autoware_lanelet2_extension` was complete, so this PR replaces `autoware_common` to `autoware_cmake`, `autoware_utils` and `autoware_lanelet2_extension` in `autoware.repos`.

Note that I will revert the commit https://github.com/autowarefoundation/autoware/pull/4909/commits/9956221d3ba0567e6a55e990f72e51af7a446fba as soon as https://github.com/autowarefoundation/autoware.universe/pull/7640 is merged. 

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/9640839041

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
