### PR TITLE
feat(autoware.repos): import `autoware_cmake` and `autoware_utils`

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -17,11 +17,11 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
     version: remove-autoware-cmake-utils
-  autoware_cmake:
+  core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
     version: main
-  autoware_utils:
+  core/autoware_utils:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git
     version: main

--- a/autoware.repos
+++ b/autoware.repos
@@ -15,6 +15,14 @@ repositories:
   core/autoware_common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
+    version: remove-autoware-cmake-utils
+  autoware_cmake:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_cmake.git
+    version: main
+  autoware_utils:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_utils.git
     version: main
   core/autoware_lanelet2_extension:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -12,6 +12,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
     version: main
+  # TODO(youtalk): Remove autoware_common when https://github.com/autowarefoundation/autoware/issues/4911 is closed
   core/autoware_common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git


### PR DESCRIPTION
## Description

This PR is a fix to accommodate both the deprecated `lanelet2_extension` and the new `autoware_lanelet2_extension`. The `autoware_common` repository has been changed to a branch that removes `autoware_cmake`, `autoware_lint_common`, and `autoware_utils`.

ref. https://github.com/autowarefoundation/autoware/issues/4911

## Tests performed

https://github.com/youtalk/autoware/actions/runs/9658261805?pr=56

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
