### PR TITLE
feat(ci): save cache on `no-cuda` jobs and restore cache only on `cuda` jobs

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -36,6 +36,7 @@ runs:
 
     - name: Cache
       uses: actions/cache@v3
+      if: ${{ inputs.name == 'no-cuda' }}
       id: cache
       with:
         path: |
@@ -44,6 +45,17 @@ runs:
         restore-keys: |
           cache-${{ inputs.platform }}-${{ inputs.name }}-
           cache-${{ inputs.platform }}-
+
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      if: ${{ inputs.name != 'no-cuda' }}
+      with:
+        path: |
+          root-ccache
+        key: cache-${{ matrix.platform }}-${{ matrix.name }}-${{ hashFiles('autoware.repos') }}
+        restore-keys: |
+          cache-${{ matrix.platform }}-${{ matrix.name }}-
+          cache-${{ matrix.platform }}-
 
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.0

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -58,7 +58,7 @@ runs:
           cache-${{ matrix.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
         cache-map: |
           {

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -35,7 +35,7 @@ runs:
       shell: bash
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: ${{ inputs.name == 'no-cuda' }}
       id: cache
       with:


### PR DESCRIPTION
## Description

Resolves https://github.com/autowarefoundation/autoware/issues/4944

This PR saves the `buildkit-cache-dance` cache only on `no-cuda` jobs and only restore the cache on `cuda` jobs.

## Tests performed

https://github.com/youtalk/autoware/actions/runs/9786429625
- `actions/cache` was called on `no-cuda` job: https://github.com/youtalk/autoware/actions/runs/9786429625/job/27021289733#step:5:374
- `actions/cache/restore` was called on `cuda` job: https://github.com/youtalk/autoware/actions/runs/9786429625/job/27021289893#step:5:374

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
