### PR TITLE
fix(ansible/artifacts): update transfusion model

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -169,23 +169,23 @@
 - name: Download lidar_transfusion/transfusion.onnx
   become: true
   ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/v1/transfusion.onnx
+    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2/transfusion.onnx
     dest: "{{ data_dir }}/lidar_transfusion/transfusion.onnx"
     mode: "644"
-    checksum: sha256:8938999cf03770ffd3301027300ea2cbcf471c180450e0434121d7294c42aa0b
+    checksum: sha256:ad66a061d61449af671bd0d14c2c407f0d749753f17f3165287857f686c4fd1a
 
 - name: Download lidar_transfusion/transfusion.param.yaml
   become: true
   ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/v1/transfusion.param.yaml
+    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2/transfusion.param.yaml
     dest: "{{ data_dir }}/lidar_transfusion/transfusion.param.yaml"
     mode: "644"
-    checksum: sha256:0e18776040f14e380037ef6ecb500d1d1d151f21ff7d5c890606673f7e100e14
+    checksum: sha256:fdd8dd21b7c1c0f9a15119fa6a79565f927ce8f6bac4ddf095cb7e27672cb3d8
 
 - name: Download lidar_transfusion/detection_class_remapper.param.yaml
   become: true
   ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/v1/detection_class_remapper.param.yaml
+    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2/detection_class_remapper.param.yaml
     dest: "{{ data_dir }}/lidar_transfusion/detection_class_remapper.param.yaml"
     mode: "644"
     checksum: sha256:c711f8875ece9b527dfe31ffc75f8c0de2e77945ef67860a959a4e04c36772d5


### PR DESCRIPTION
## Description

This PR update `lidar_tranfusion` artifacts (3D detection component).
Related to https://github.com/autowarefoundation/autoware.universe/pull/7890

## Related links

## Tests performed

- Tested by command as below

```
ansible-playbook autoware.dev_env.download_artifacts -e "data_dir=$HOME/autoware_data" --ask-become-pass
```

```
TASK [autoware.dev_env.artifacts : Create lidar_transfusion directory inside /home/scepter914/autoware_data] ***
ok: [localhost]

TASK [autoware.dev_env.artifacts : Download lidar_transfusion/transfusion.onnx] *************************
ok: [localhost]

TASK [autoware.dev_env.artifacts : Download lidar_transfusion/transfusion.param.yaml] *******************
ok: [localhost]
```

## Notes for reviewers

## Interface changes

None.

### ROS Topic Changes

None.

### ROS Parameter Changes

None.

## Effects on system behavior

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
