### PR TITLE
chore(clang-tidy): remove deprecated/unsupported AnalyzeTemporaryDtors setting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -202,8 +202,6 @@ WarningsAsErrors: "
 
 HeaderFilterRegex: ^(?!\/usr)(?!\/opt)
 
-AnalyzeTemporaryDtors: false
-
 FormatStyle: none
 
 CheckOptions:


### PR DESCRIPTION
## Description

This PR aims to make Clang-Tidy usable in IDEs, e.g. with Clangd as a language server. For VS Code, the default Clangd version is 18, which does not support the `AnalyzeTemporaryDtors` option anymore, which was deprecated in version 16.

This PR removes the setting which, according to the Clang 16 release notes is no longer in use:
> Deprecate the global configuration file option AnalyzeTemporaryDtors, which is no longer in use. The option will be fully removed in clang-tidy version 18.

Related links:
* [LLVM GitHub: Discussion about removal of the option](https://github.com/llvm/llvm-project/issues/62020)
* [Clang 16 Release Notes: Deprecation message](https://releases.llvm.org/16.0.0/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy)

## Tests performed

Before the change, Clangd 18 would show errors when parsing `.clang-tidy`:
```
E[10:48:30.356] tidy-config error at /home/.../autoware/.clang-tidy:205:0: unknown key 'AnalyzeTemporaryDtors'
E[10:48:30.356] Error parsing clang-tidy configuration in /home/.../autoware/.clang-tidy: Invalid argument
```

After the change, the errors are gone.

## Effects on system behavior

Not applicable.

## Interface changes

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
