### PR TITLE
feat(ci): make sure `tag:run-health-check` tag is present on PR to run `health-check` CI

### DIFF
--- a/.github/workflows/health-check-self-hosted.yaml
+++ b/.github/workflows/health-check-self-hosted.yaml
@@ -1,12 +1,24 @@
 name: health-check-self-hosted
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:
+  label-check:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+    with:
+      label: tag:run-health-check
+
   load-env:
+    needs: label-check
     uses: ./.github/workflows/load-env.yaml
 
   docker-build:

--- a/.github/workflows/health-check-self-hosted.yaml
+++ b/.github/workflows/health-check-self-hosted.yaml
@@ -1,24 +1,12 @@
 name: health-check-self-hosted
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:
-  label-check:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
-    with:
-      label: tag:run-health-check
-
   load-env:
-    needs: label-check
     uses: ./.github/workflows/load-env.yaml
 
   docker-build:

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -19,6 +19,7 @@ jobs:
 
   load-env:
     needs: label-check
+    if: ${{ needs.label-check.outputs.result == 'true' }}
     uses: ./.github/workflows/load-env.yaml
 
   docker-build:

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -1,12 +1,24 @@
 name: health-check
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   schedule:
     - cron: 0 12 * * *
   workflow_dispatch:
 
 jobs:
+  label-check:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+    with:
+      label: tag:run-health-check
+
   load-env:
+    needs: label-check
     uses: ./.github/workflows/load-env.yaml
 
   docker-build:


### PR DESCRIPTION
## Description


The `health-check` workflow, formerly known as `build-main`, now consistently completes in an hour and a half thanks to the activation of GitHub Actions cache. By further utilizing the multi-containerization and the docker layer cache, it could become even faster.
https://autowarefoundation.github.io/autoware-ci-metrics/

Therefore, to ensure the code quality of Autoware, I would like to add the `health-check` check as a merge condition for PRs.
This PR will make the `health-check` run when the `tag:run-health-check` tag is attached.

## Tests performed

Before attaching `tag:run-health-check`
![Screenshot from 2024-07-10 15-48-31](https://github.com/autowarefoundation/autoware/assets/579333/2de6317d-468c-4280-b4c5-af218893837c)

After attaching `tag:run-health-check`
![Screenshot from 2024-07-10 15-49-43](https://github.com/autowarefoundation/autoware/assets/579333/b24d9e5b-0880-4996-92a2-71f4fe667228)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
