### PR TITLE
fix(ci): run `health-check` on schedule and workflow_dispatch events

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -19,7 +19,9 @@ jobs:
 
   load-env:
     needs: label-check
-    if: ${{ needs.label-check.outputs.result == 'true' }}
+    if: ${{ needs.label-check.outputs.result == 'true' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/load-env.yaml
 
   docker-build:


### PR DESCRIPTION
## Description

In the previous PR https://github.com/autowarefoundation/autoware/pull/4962, the `tag:run-health-check`label was checked to execute the `health-check` workflow, but the `health-check` is also executed not only on pull requests but also on schedule and `workflow_dispatch` events. 
Therefore, this PR modified to execute without the label check for the schedule and `workflow_dispatch` events.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
