### PR TITLE
feat(ci): save GitHub Actions cache only on the `main` branch

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -36,7 +36,7 @@ runs:
 
     - name: Cache ccache
       uses: actions/cache@v4
-      if: ${{ inputs.name == 'no-cuda' }}
+      if: ${{ inputs.name == 'no-cuda' && github.ref == 'refs/heads/main' }}
       id: cache-ccahce
       with:
         path: |
@@ -50,7 +50,7 @@ runs:
 
     - name: Cache apt-get
       uses: actions/cache@v4
-      if: ${{ inputs.name == 'no-cuda' }}
+      if: ${{ inputs.name == 'no-cuda' && github.ref == 'refs/heads/main' }}
       id: cache-apt-get
       with:
         path: |
@@ -63,7 +63,7 @@ runs:
 
     - name: Restore ccache
       uses: actions/cache/restore@v4
-      if: ${{ inputs.name != 'no-cuda' }}
+      if: ${{ inputs.name != 'no-cuda' || github.ref != 'refs/heads/main' }}
       with:
         path: |
           root-ccache
@@ -76,7 +76,7 @@ runs:
 
     - name: Restore apt-get
       uses: actions/cache/restore@v4
-      if: ${{ inputs.name != 'no-cuda' }}
+      if: ${{ inputs.name != 'no-cuda' || github.ref != 'refs/heads/main' }}
       with:
         path: |
           var-cache-apt


### PR DESCRIPTION
## Description

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

> Access restrictions provide cache isolation and security by creating a logical boundary between different branches or tags. Workflow runs can restore caches created in either the current branch or the default branch (usually main).

Saving cache in the PR branch can waste the maximum capacity of 10GB of the GitHub Actions cache. Therefore, this PR modifies the `health-check` workflow to save cache only when it is executed on the `main` branch.

## Tests performed

Both `no-cuda` and `cuda` jobs on this PR's branch were executed `actions/cache/restore` action only.
https://github.com/autowarefoundation/autoware/actions/runs/9892642537/job/27325824034?pr=4975#step:5:477
https://github.com/autowarefoundation/autoware/actions/runs/9892642537/job/27325823707?pr=4975#step:5:477

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
