### PR TITLE
fix(ci): fix `ccache` cache key

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -44,6 +44,7 @@ runs:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    # TODO(youtalk): Remove obsolete "cache-" restore-keys
     - name: Restore ccache
       uses: actions/cache/restore@v4
       with:
@@ -53,8 +54,8 @@ runs:
         restore-keys: |
           ccache-${{ inputs.platform }}-${{ inputs.name }}-
           ccache-${{ inputs.platform }}-
-          cache-${{ inputs.platform }}-${{ inputs.name }}-  # TODO(youtalk): Remove obsolete cache key
-          cache-${{ inputs.platform }}-  # TODO(youtalk): Remove obsolete cache key
+          cache-${{ inputs.platform }}-${{ inputs.name }}-
+          cache-${{ inputs.platform }}-
 
     - name: Restore apt-get
       uses: actions/cache/restore@v4

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -41,7 +41,7 @@ runs:
       with:
         path: |
           root-ccache
-        key: cache-${{ inputs.platform }}-${{ inputs.name }}-${{ hashFiles('src/**/*.cpp') }}
+        key: ccache-${{ inputs.platform }}-${{ inputs.name }}-${{ hashFiles('src/**/*.cpp') }}
         restore-keys: |
           ccache-${{ inputs.platform }}-${{ inputs.name }}-
           ccache-${{ inputs.platform }}-

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -34,6 +34,7 @@ runs:
         vcs import src < autoware.repos
       shell: bash
 
+    # TODO(youtalk): Remove obsolete "cache-" restore-keys
     - name: Cache ccache
       uses: actions/cache@v4
       if: ${{ inputs.name == 'no-cuda' }}
@@ -45,8 +46,8 @@ runs:
         restore-keys: |
           ccache-${{ inputs.platform }}-${{ inputs.name }}-
           ccache-${{ inputs.platform }}-
-          cache-${{ inputs.platform }}-${{ inputs.name }}-  # TODO(youtalk): Remove obsolete cache key
-          cache-${{ inputs.platform }}-  # TODO(youtalk): Remove obsolete cache key
+          cache-${{ inputs.platform }}-${{ inputs.name }}-
+          cache-${{ inputs.platform }}-
 
     - name: Cache apt-get
       uses: actions/cache@v4
@@ -61,6 +62,7 @@ runs:
           apt-get-${{ inputs.platform }}-${{ inputs.name }}-
           apt-get-${{ inputs.platform }}-
 
+    # TODO(youtalk): Remove obsolete "cache-" restore-keys
     - name: Restore ccache
       uses: actions/cache/restore@v4
       if: ${{ inputs.name != 'no-cuda' }}
@@ -71,8 +73,8 @@ runs:
         restore-keys: |
           ccache-${{ inputs.platform }}-${{ inputs.name }}-
           ccache-${{ inputs.platform }}-
-          cache-${{ inputs.platform }}-${{ inputs.name }}-  # TODO(youtalk): Remove obsolete cache key
-          cache-${{ inputs.platform }}-  # TODO(youtalk): Remove obsolete cache key
+          cache-${{ inputs.platform }}-${{ inputs.name }}-
+          cache-${{ inputs.platform }}-
 
     - name: Restore apt-get
       uses: actions/cache/restore@v4


### PR DESCRIPTION
## Description

This PR is a correction for forgetting to update the cache key name for `ccache` when introducing `apt-get` cache in the previous PR https://github.com/autowarefoundation/autoware/pull/4971. 

The obsolete cache key is still included in the `restore-keys`, so the cache works as it is, but I would like to distinguish it from the `apt-get` cache.
https://github.com/autowarefoundation/autoware/blob/main/.github/actions/docker-build/action.yaml#L48-L49

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
