### PR TITLE
fix(ci): fix inline expansion of `date` tag

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -86,7 +86,7 @@ runs:
             tags+=("$(echo "${{ github.ref }}" | sed -E 's/.*([vV][0-9]+\.[0-9]+\.[0-9]+).*/\1/')")
         fi
 
-        tags+=("{{date 'YYYYMMDD'}}")
+        tags+=("${{ date 'YYYYMMDD' }}")
         tags+=("latest")
         tags+=("latest-${{ inputs.tag-prefix }}")
 


### PR DESCRIPTION
## Description

This PR fixes the bug where the `date` tag is not expanded inline due to the lack of writing `$` prefix.

https://github.com/youtalk/autoware/actions/runs/9886057164/job/27305134747#step:5:480
```
Run docker/metadata-action@v5
  with:
    images: ghcr.io/youtalk/autoware
    tags: {{date 'YYYYMMDD'}}
  latest
  latest-humble
    bake-target: docker-metadata-action-base
    flavor: latest=false
  suffix=-base
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
