### PR TITLE
refactor(ci): remove obsolete ccache `restore-keys`

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -44,18 +44,15 @@ runs:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    # TODO(youtalk): Remove obsolete "cache-" restore-keys
     - name: Restore ccache
       uses: actions/cache/restore@v4
       with:
         path: |
           root-ccache
-        key: cache-${{ inputs.platform }}-${{ inputs.name }}-${{ hashFiles('src/**/*.cpp') }}
+        key: ccache-${{ inputs.platform }}-${{ inputs.name }}-${{ hashFiles('src/**/*.cpp') }}
         restore-keys: |
           ccache-${{ inputs.platform }}-${{ inputs.name }}-
           ccache-${{ inputs.platform }}-
-          cache-${{ inputs.platform }}-${{ inputs.name }}-
-          cache-${{ inputs.platform }}-
 
     - name: Restore apt-get
       uses: actions/cache/restore@v4

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -34,7 +34,6 @@ runs:
         vcs import src < autoware.repos
       shell: bash
 
-    # TODO(youtalk): Remove obsolete "cache-" restore-keys
     - name: Cache ccache
       uses: actions/cache@v4
       if: ${{ inputs.name == 'no-cuda' && github.ref == 'refs/heads/main' }}
@@ -46,8 +45,6 @@ runs:
         restore-keys: |
           ccache-${{ inputs.platform }}-${{ inputs.name }}-
           ccache-${{ inputs.platform }}-
-          cache-${{ inputs.platform }}-${{ inputs.name }}-
-          cache-${{ inputs.platform }}-
 
     - name: Cache apt-get
       uses: actions/cache@v4
@@ -62,7 +59,6 @@ runs:
           apt-get-${{ inputs.platform }}-${{ inputs.name }}-
           apt-get-${{ inputs.platform }}-
 
-    # TODO(youtalk): Remove obsolete "cache-" restore-keys
     - name: Restore ccache
       uses: actions/cache/restore@v4
       if: ${{ inputs.name != 'no-cuda' || github.ref != 'refs/heads/main' }}
@@ -73,8 +69,6 @@ runs:
         restore-keys: |
           ccache-${{ inputs.platform }}-${{ inputs.name }}-
           ccache-${{ inputs.platform }}-
-          cache-${{ inputs.platform }}-${{ inputs.name }}-
-          cache-${{ inputs.platform }}-
 
     - name: Restore apt-get
       uses: actions/cache/restore@v4


### PR DESCRIPTION
## Description

Since there are already new `ccache-` cache in the GitHub Actions' Caches https://github.com/autowarefoundation/autoware/actions/caches, this PR removes obsolete `cache-` `restore-keys` from `action.yaml`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
