### PR TITLE
feat(docker,ci): push `autoware` image on "push to main branch" and "push tag" events

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -20,10 +20,6 @@ inputs:
   tag-suffix:
     description: ""
     required: false
-  allow-push:
-    description: ""
-    default: "true"
-    required: false
 
 runs:
   using: composite
@@ -132,7 +128,6 @@ runs:
           suffix=-devel${{ inputs.tag-suffix }}
 
     - name: Docker meta for runtime
-      if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag') }}
       id: meta-runtime
       uses: docker/metadata-action@v5
       with:
@@ -140,11 +135,10 @@ runs:
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-runtime
         flavor: |
-          latest=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+          latest=auto
           suffix=-runtime${{ inputs.tag-suffix }}
 
     - name: Login to GitHub Container Registry
-      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -152,27 +146,9 @@ runs:
         password: ${{ github.token }}
 
     - name: Build and Push to GitHub Container Registry
-      if: ${{ github.event_name == 'push' ||
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.artifacts-destination == 'registry') }}
       uses: docker/bake-action@v5
       with:
-        push: ${{ inputs.allow-push == 'true' }}
-        files: |
-          docker/docker-bake.hcl
-          ${{ steps.meta-base.outputs.bake-file }}
-          ${{ steps.meta-prebuilt.outputs.bake-file }}
-          ${{ steps.meta-devel.outputs.bake-file }}
-          ${{ steps.meta-runtime.outputs.bake-file }}
-        provenance: false
-        set: |
-          ${{ inputs.build-args }}
-
-    - name: Build only
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.artifacts-destination == 'tarball' }}
-      uses: docker/bake-action@v5
-      with:
-        push: false
+        push: true
         files: |
           docker/docker-bake.hcl
           ${{ steps.meta-base.outputs.bake-file }}

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -87,7 +87,7 @@ runs:
             tags+=("$(echo "${{ github.ref }}" | sed -E 's/.*([vV][0-9]+\.[0-9]+\.[0-9]+).*/\1/')")
         fi
 
-        tags+=("{{date 'YYYYMMDD'}}")
+        tags+=("${{ date 'YYYYMMDD' }}")
         tags+=("latest")
         tags+=("latest-${{ inputs.tag-prefix }}")
 

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -83,7 +83,7 @@ runs:
             tags+=("$(echo "${{ github.ref }}" | sed -E 's/.*([vV][0-9]+\.[0-9]+\.[0-9]+).*/\1/')")
         fi
 
-        tags+=("${{ date 'YYYYMMDD' }}")
+        tags+=("{{date 'YYYYMMDD'}}")
         tags+=("latest")
         tags+=("latest-${{ inputs.tag-prefix }}")
 

--- a/.github/workflows/docker-build-and-push-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-self-hosted.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-self-hosted.yaml
@@ -65,7 +65,6 @@ jobs:
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.name }}-${{ matrix.platform }}-${{ github.ref_name }},mode=max
           tag-suffix: ${{ matrix.additional-tag-suffix }}-${{ matrix.platform }}
           tag-prefix: ${{ needs.load-env.outputs.rosdistro }}
-          allow-push: true
 
       - name: Show disk space
         run: |

--- a/.github/workflows/docker-build-and-push-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-self-hosted.yaml
@@ -49,6 +49,19 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            *.env
+            *.repos
+            .github/actions/docker-build-and-push/action.yaml
+            .github/workflows/docker-build-and-push*.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker/**
+
       - name: Build 'Autoware'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/docker-build-and-push-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-self-hosted.yaml
@@ -2,6 +2,8 @@ name: docker-build-and-push-self-hosted
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-self-hosted.yaml
@@ -50,6 +50,9 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/docker-build-and-push
         with:
           name: ${{ matrix.name }}

--- a/.github/workflows/docker-build-and-push-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-self-hosted.yaml
@@ -2,19 +2,7 @@ name: docker-build-and-push-self-hosted
 
 on:
   push:
-    tags:
-      - openadkit-v*.*.*
-  schedule:
-    - cron: 0 0 1,15 * *
   workflow_dispatch:
-    inputs:
-      artifacts-destination:
-        type: choice
-        description: Destination for the artifacts
-        options:
-          - registry
-          - tarball
-        default: tarball
 
 jobs:
   load-env:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -2,19 +2,7 @@ name: docker-build-and-push
 
 on:
   push:
-    tags:
-      - openadkit-v*.*.*
-  schedule:
-    - cron: 0 0 1,15 * *
   workflow_dispatch:
-    inputs:
-      artifacts-destination:
-        type: choice
-        description: Destination for the artifacts
-        options:
-          - registry
-          - tarball
-        default: tarball
 
 jobs:
   load-env:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -2,6 +2,8 @@ name: docker-build-and-push
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -58,7 +58,9 @@ jobs:
             docker/**
 
       - name: Build 'Autoware'
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/docker-build-and-push
         with:
           name: ${{ matrix.name }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -44,7 +44,21 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            *.env
+            *.repos
+            .github/actions/docker-build-and-push/action.yaml
+            .github/workflows/docker-build-and-push*.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker/**
+
       - name: Build 'Autoware'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/docker-build-and-push
         with:
           name: ${{ matrix.name }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -60,7 +60,6 @@ jobs:
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.name }}-${{ matrix.platform }}-${{ github.ref_name }},mode=max
           tag-suffix: ${{ matrix.additional-tag-suffix }}-${{ matrix.platform }}
           tag-prefix: ${{ needs.load-env.outputs.rosdistro }}
-          allow-push: true
 
       - name: Show disk space
         run: |


### PR DESCRIPTION
## Description

Under the current GitHub Actions' workflow configuration, the `autoware` images are only pushed at the following times:

1. On the `openadkit-v*.*.*` tag pushed
2. On the 1st and 15th of each month
3. On a `workflow_dispatch` with `registory` option dispatched

Since 1 and 3 have nerver been executed so far, images have actually only been pushed regularly on the 1st and 15th of each month. However, there is no particular significance to the 1st and 15th of each month.
In order to advance the version control and proceed with container development and operation, it is necessary to always be able to pull the latest container images.

Therefore, this PR revises the image push timings as follows:

1. On the main branch pushed (i.e., on a PR merged)
2. On a tag pushed
3. On a `workflow_dispatch` dispatched

I would like to propose a revision of the naming conventions for the Docker images and tags in a discussions and a separate PR later.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
