### PR TITLE
fix(ci): fix Docker image organization

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -121,7 +121,7 @@ runs:
       id: meta-autoware-universe
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.actor }}/${{ inputs.bake-target }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-autoware-universe
         flavor: |

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -97,7 +97,7 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ github.token }}
 
     - name: Run docker build


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware/pull/4865 and https://github.com/autowarefoundation/autoware/pull/4961 mistakenly replaced parts of what should have been `github.repository_owner` with `github.actor`. As a result, the `docker-build-and-push` workflow is failing. 

> ERROR: failed to solve: failed to push ghcr.io/youtalk/autoware:20240717-autoware-universe-cuda-amd64: unexpected status from POST request to https://ghcr.io/v2/youtalk/autoware/blobs/uploads/: 403 Forbidden

https://github.com/autowarefoundation/autoware/actions/runs/9969218788/job/27545808443#step:5:9436

This PR reverts those changes.

https://github.com/autowarefoundation/autoware/actions/runs/9974064666

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
