### PR TITLE
feat(docker): no longer download artifacts on `devel` image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,7 +148,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install development tools and artifacts
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module dev-tools --download-artifacts openadkit \
+  ./setup-dev-env.sh -y --module dev-tools openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 


### PR DESCRIPTION
## Description

https://github.com/orgs/autowarefoundation/discussions/5007#discussioncomment-10086717
> Considering these, I would propose to have an image without artifacts for development and CI purposes.
Version with artifacts can be something that derives from this light image.

Based on this opinion, this PR excludes the artifacts from the `devel` image. The artifacts still continues to be included in the `runtime` image.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/10052443863

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
