### PR TITLE
feat(docker): copy `src` by `--mount=type=bind` instead of `COPY`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,8 +100,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && cat /tmp/rosdep-core-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
-COPY src/core /autoware/src/core
-RUN --mount=type=cache,target=${CCACHE_DIR} \
+RUN --mount=type=bind,from=rosdep-depend,source=/autoware/src/core,target=/autoware/src/core \
+  --mount=type=cache,target=${CCACHE_DIR} \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && colcon build --cmake-args \
@@ -125,13 +125,8 @@ RUN --mount=type=ssh \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
 # Build Autoware
-COPY src/launcher /autoware/src/launcher
-COPY src/param /autoware/src/param
-COPY src/sensor_component /autoware/src/sensor_component
-COPY src/sensor_kit /autoware/src/sensor_kit
-COPY src/universe /autoware/src/universe
-COPY src/vehicle /autoware/src/vehicle
-RUN --mount=type=cache,target=${CCACHE_DIR} \
+RUN --mount=type=bind,from=rosdep-depend,source=/autoware/src,target=/autoware/src \
+  --mount=type=cache,target=${CCACHE_DIR} \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && colcon build --cmake-args \
@@ -152,6 +147,7 @@ RUN --mount=type=ssh \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
+COPY src /autoware/src
 # Create entrypoint
 COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
 RUN chmod +x /ros_entrypoint.sh


### PR DESCRIPTION
## Description

Following the discussion https://github.com/orgs/autowarefoundation/discussions/5007#discussioncomment-10126509, this PR changes not to include `src` in the `autoware-universe` image, and only include it in the `devel` image. 
However, due to the effects of previous PR https://github.com/autowarefoundation/autoware/pull/5009, the amount of `src` copied has already been minimized, resulting in a reduction of only **18.69MB** in the image size.

@xmfcx As a result, I think it would be convenient to keep `src` copied in the `autoware-universe` image and not merge this PR, as it would make using the `autoware-universe` as a development container easier. 

## Tests performed

Before this PR merged:
- `autoware-universe`: https://hub.docker.com/layers/youtalk/autoware/20240723-autoware-universe-amd64/images/sha256-b9cf2acf7d466d257acffbd9c11f2c9317d091e24b1ee20cdfd1af615038bca0?context=repo
- `devel`: https://hub.docker.com/layers/youtalk/autoware/20240723-devel-amd64/images/sha256-006a5022b3838781ba7ed875a948046663362b87a51eae3bd598734cc8e8180f?context=repo

After this PR merged:
- `autoware-universe`: https://hub.docker.com/layers/youtalk/autoware/20240724-autoware-universe-amd64/images/sha256-ec2ecad973ba87421fba188aed60abd383b7e3b5ca68a07df85beaca716b949c?context=repo
- `devel`: https://hub.docker.com/layers/youtalk/autoware/20240724-devel-amd64/images/sha256-64fe8d87607dad2145e9b6e48f05cada9689a13eba13725b870edf9fd1480631?context=repo

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
