### PR TITLE
feat(autoware.repos): install ament_cmake from official ros packages

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -74,10 +74,6 @@ repositories:
     type: git
     url: https://github.com/MapIV/llh_converter.git
     version: ros2
-  universe/external/ament_cmake: # TODO(mitsudome-r): remove when https://github.com/ament/ament_cmake/pull/448 is merged
-    type: git
-    url: https://github.com/autowarefoundation/ament_cmake.git
-    version: feat/faster_ament_libraries_deduplicate
   universe/external/glog:  # TODO(Horibe): to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,6 +124,7 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
+# TODO(youtalk): Remove this when https://github.com/autowarefoundation/autoware/issues/5089 is resolved
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,6 +124,13 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ros-"$ROS_DISTRO"-rosbag2-storage \
+    ros-"$ROS_DISTRO"-rosbag2-storage-mcap \
+  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
+
 # Build Autoware
 RUN --mount=type=bind,from=rosdep-depend,source=/autoware/src,target=/autoware/src \
   --mount=type=cache,target=${CCACHE_DIR} \


### PR DESCRIPTION
## Description

- [ ] https://github.com/autowarefoundation/autoware/pull/5092

https://github.com/ament/ament_cmake/pull/530 was merged and the updated `ament_cmake` was already released from official ROS package list.
https://discourse.ros.org/t/new-packages-and-patch-release-for-humble-hawksbill-2024-08-07/38978

So this PR removes the forked `ament_cmake` from `autoware.repos`

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
