### PR TITLE
feat(docker): manually install `rosbag2-storage`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,6 +124,7 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
+# TODO(youtalk): Remove this when https://github.com/autowarefoundation/autoware/issues/5089 is resolved
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,6 +124,13 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ros-"$ROS_DISTRO"-rosbag2-storage \
+    ros-"$ROS_DISTRO"-rosbag2-storage-mcap \
+  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
+
 # Build Autoware
 RUN --mount=type=bind,from=rosdep-depend,source=/autoware/src,target=/autoware/src \
   --mount=type=cache,target=${CCACHE_DIR} \


### PR DESCRIPTION
## Description

Related:
-  https://github.com/autowarefoundation/autoware/issues/5089

As a workaround for the above issue, I will manually install `rosbag2-storage` and `rosbag2-storage-mcap`. 
I will revert this once the relevant packages in each repository add dependencies on those packages.

## Tests performed

https://github.com/youtalk/autoware/actions/runs/10380074411?pr=88

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
