### PR TITLE
fix(autoware.repos): fix the `morai_msgs` version 

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -46,10 +46,11 @@ repositories:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: tier4/universe
+  # Fix the version not to merge https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9
   universe/external/morai_msgs:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
-    version: main
+    version: e2e75fc
   universe/external/muSSP:
     type: git
     url: https://github.com/tier4/muSSP.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -50,7 +50,7 @@ repositories:
   universe/external/morai_msgs:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
-    version: e2e75fc
+    version: e2e75fc1603a9798773e467a679edf68b448e705
   universe/external/muSSP:
     type: git
     url: https://github.com/tier4/muSSP.git


### PR DESCRIPTION
## Description

Due to this modification https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9 in `morai_msgs`, the `health-check` of autoware started to fail. Therefore, this PR fixes `morai_msgs` to the commit before the modification.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/10448616149?pr=5105

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
