### PR TITLE
feat(docker): install `colcon build` artifacts to `/opt/autoware` instead of `/autoware/install`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,13 +128,14 @@ RUN --mount=type=ssh \
 
 # Build Autoware
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
-  --mount=type=bind,source=src/param,target=/autoware/src/param \
-  --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
-  --mount=type=bind,source=src/sensor_kit,target=/autoware/src/sensor_kit \
-  --mount=type=bind,source=src/universe,target=/autoware/src/universe \
-  --mount=type=bind,source=src/vehicle,target=/autoware/src/vehicle \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/launcher,target=/autoware/src/launcher \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/param,target=/autoware/src/param \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/sensor_component,target=/autoware/src/sensor_component \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/sensor_kit,target=/autoware/src/sensor_kit \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/universe,target=/autoware/src/universe \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/vehicle,target=/autoware/src/vehicle \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && colcon build --cmake-args \
     " -Wno-dev" \
@@ -156,7 +157,6 @@ RUN --mount=type=ssh \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
-COPY src /autoware/src
 # Create entrypoint
 COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
 RUN chmod +x /ros_entrypoint.sh
@@ -188,11 +188,11 @@ RUN --mount=type=ssh \
     /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
-COPY --from=autoware-universe /autoware/install/ /autoware/install/
+COPY --from=autoware-universe /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases
-RUN echo "source /autoware/install/setup.bash" > /etc/bash.bashrc
+RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
 
 # Create entrypoint
 COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,13 +100,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && cat /tmp/rosdep-core-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
-RUN --mount=type=bind,from=rosdep-depend,source=/autoware/src/core,target=/autoware/src/core \
-  --mount=type=cache,target=${CCACHE_DIR} \
+RUN --mount=type=cache,target=${CCACHE_DIR} \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/core,target=/autoware/src/core \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && colcon build --cmake-args \
     " -Wno-dev" \
     " --no-warn-unused-cli" \
+    --merge-install \
+    --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s
 
@@ -125,13 +127,20 @@ RUN --mount=type=ssh \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
 # Build Autoware
-RUN --mount=type=bind,from=rosdep-depend,source=/autoware/src,target=/autoware/src \
-  --mount=type=cache,target=${CCACHE_DIR} \
+RUN --mount=type=cache,target=${CCACHE_DIR} \
+  --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
+  --mount=type=bind,source=src/param,target=/autoware/src/param \
+  --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
+  --mount=type=bind,source=src/sensor_kit,target=/autoware/src/sensor_kit \
+  --mount=type=bind,source=src/universe,target=/autoware/src/universe \
+  --mount=type=bind,source=src/vehicle,target=/autoware/src/vehicle \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && colcon build --cmake-args \
     " -Wno-dev" \
     " --no-warn-unused-cli" \
+    --merge-install \
+    --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,7 +110,8 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --merge-install \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
-  && du -sh ${CCACHE_DIR} && ccache -s
+  && du -sh ${CCACHE_DIR} && ccache -s \
+  && rm -rf /autoware/build
 
 FROM autoware-core AS autoware-universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -144,7 +145,8 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --merge-install \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
-  && du -sh ${CCACHE_DIR} && ccache -s
+  && du -sh ${CCACHE_DIR} && ccache -s \
+  && rm -rf /autoware/build
 
 CMD ["/bin/bash"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,6 +127,7 @@ RUN --mount=type=ssh \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
 # Build Autoware
+# hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/launcher,target=/autoware/src/launcher \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/param,target=/autoware/src/param \

--- a/docker/etc/ros_entrypoint.sh
+++ b/docker/etc/ros_entrypoint.sh
@@ -10,7 +10,7 @@ GROUP_NAME=${LOCAL_GROUP}
 # Check if any of the variables are empty
 if [[ -z $USER_ID || -z $USER_NAME || -z $GROUP_ID || -z $GROUP_NAME ]]; then
     source "/opt/ros/$ROS_DISTRO/setup.bash"
-    source /autoware/install/setup.bash
+    source /opt/autoware/setup.bash
     exec "$@"
 else
     echo "Starting with user: $USER_NAME >> UID $USER_ID, GID: $GROUP_ID"
@@ -25,7 +25,7 @@ else
     # Source ROS2
     # hadolint ignore=SC1090
     source "/opt/ros/$ROS_DISTRO/setup.bash"
-    source /autoware/install/setup.bash
+    source /opt/autoware/setup.bash
 
     # Execute the command as the user
     exec /usr/sbin/gosu "$USER_NAME" "$@"


### PR DESCRIPTION
## Description



This PR implements the approach mentioned in https://github.com/autowarefoundation/autoware/pull/5045#issuecomment-2300083846. Instead of installing the outputs of `colcon build` to `/autoware/install`, it installs them to `/opt/autoware`. 

@oguzkaganozt @VRichardJP I hope this change makes it possible for users to achieve a "lightweight" setup, as there will no longer be any `src`, `build`, or `install` directories under `/autoware` in the development container. Note that no stages are added, nor is any redundant work executed. 

Additionally, by executing `/opt/autoware/setup.bash` with an overlay, developers can efficiently build by volume mounting only a portion of the Autoware source code to `/autoware/src`.

## Tests performed

- Before: youtalk/autoware:20240821-autoware-universe-amd64 **2.43 GB** https://hub.docker.com/layers/youtalk/autoware/20240821-autoware-universe-amd64/images/sha256-9d947b5b4295f3f6c4949e4a2a564329257c07f92dcfc06b8cb9de31238a76c2?context=explore
- After: youtalk/autoware:20240822-autoware-universe-amd64 **2.07 GB** https://hub.docker.com/layers/youtalk/autoware/20240822-autoware-universe-amd64/images/sha256-2401e7263f7408a2be0ee69d029ec6731c2fb584ec07488bf6ec47fc9634bd5a?context=explore

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
