### PR TITLE
feat(docker): install CUDA drivers in `autoware:base` image

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -98,7 +98,7 @@ runs:
         bake-target: docker-metadata-action-base
         flavor: |
           latest=false
-          suffix=-base
+          suffix=-base${{ inputs.tag-suffix }}
 
     - name: Docker meta for autoware-core
       id: meta-autoware-core

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -26,16 +26,16 @@
       when: module == 'base'
     - role: autoware.dev_env.pacmod
       when: module == 'base'
+    - role: autoware.dev_env.cuda
+      when: module == 'base' and prompt_install_nvidia=='y'
+    - role: autoware.dev_env.tensorrt
+      when: module == 'base' and prompt_install_nvidia=='y'
     - role: autoware.dev_env.build_tools
       when: module == 'all' and install_devel=='y'
 
     # Module specific dependencies
     - role: autoware.dev_env.geographiclib
       when: module == 'perception-localization' or module == 'all'
-    - role: autoware.dev_env.cuda
-      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
-    - role: autoware.dev_env.tensorrt
-      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
 
     # Development environment
     - role: autoware.dev_env.dev_tools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
+ARG SETUP_ARGS
 
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
@@ -24,7 +25,7 @@ WORKDIR /autoware
 # Set up base environment
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module base --runtime openadkit \
+  ./setup-dev-env.sh -y --module base ${SETUP_ARGS} --no-cuda-drivers --runtime openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc
@@ -82,13 +83,12 @@ RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
 FROM base AS autoware-core
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
-ARG SETUP_ARGS
 ENV CCACHE_DIR="/root/.ccache"
 
 # Set up development environment
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers openadkit \
+  ./setup-dev-env.sh -y --module all openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
@@ -116,7 +116,6 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 FROM autoware-core AS autoware-universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
-ARG SETUP_ARGS
 ENV CCACHE_DIR="/root/.ccache"
 
 # Install rosdep dependencies


### PR DESCRIPTION
## Description

Based on the feedback from https://github.com/orgs/autowarefoundation/discussions/5110#discussioncomment-10469371, this PR will create an `autoware:base-cuda` image that installs the CUDA drivers on the `base` stage. By installing several gigabytes of CUDA drivers in the top stage of the Dockerfile, the build cache will be utilized more effectively, making the `docker pull` cache easier to leverage.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/10667352309

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
