### PR TITLE
feat(docker): rename multi-stages

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -89,7 +89,7 @@ runs:
         echo "$EOF" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Docker meta for base
+    - name: Docker meta for autoware:base
       id: meta-base
       uses: docker/metadata-action@v5
       with:
@@ -100,29 +100,29 @@ runs:
           latest=false
           suffix=-base${{ inputs.tag-suffix }}
 
-    - name: Docker meta for autoware-core
-      id: meta-autoware-core
+    - name: Docker meta for autoware:core-devel
+      id: meta-core-devel
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-autoware-core
+        bake-target: docker-metadata-action-core-devel
         flavor: |
           latest=false
-          suffix=-autoware-core${{ inputs.tag-suffix }}
+          suffix=-core-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for autoware-universe
-      id: meta-autoware-universe
+    - name: Docker meta for autoware:universe-devel
+      id: meta-universe-devel
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-autoware-universe
+        bake-target: docker-metadata-action-universe-devel
         flavor: |
           latest=false
-          suffix=-autoware-universe${{ inputs.tag-suffix }}
+          suffix=-universe-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for devel
+    - name: Docker meta for autoware:devel
       id: meta-devel
       uses: docker/metadata-action@v5
       with:
@@ -133,16 +133,16 @@ runs:
           latest=false
           suffix=-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for runtime
-      id: meta-runtime
+    - name: Docker meta for autoware:universe
+      id: meta-universe
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-runtime
+        bake-target: docker-metadata-action-universe
         flavor: |
           latest=auto
-          suffix=-runtime${{ inputs.tag-suffix }}
+          suffix=-universe${{ inputs.tag-suffix }}
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -158,10 +158,10 @@ runs:
         files: |
           docker/docker-bake.hcl
           ${{ steps.meta-base.outputs.bake-file }}
-          ${{ steps.meta-autoware-core.outputs.bake-file }}
-          ${{ steps.meta-autoware-universe.outputs.bake-file }}
+          ${{ steps.meta-core-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-devel.outputs.bake-file }}
           ${{ steps.meta-devel.outputs.bake-file }}
-          ${{ steps.meta-runtime.outputs.bake-file }}
+          ${{ steps.meta-universe.outputs.bake-file }}
         provenance: false
         set: |
           ${{ inputs.build-args }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,7 +105,7 @@ RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
     > /rosdep-exec-depend-packages.txt \
     && cat /rosdep-exec-depend-packages.txt
 
-FROM base AS autoware-core
+FROM base AS core-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -138,7 +138,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM autoware-core AS autoware-universe-common
+FROM core-devel AS universe-common-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -170,7 +170,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM autoware-universe-common AS autoware-universe-sensing-perception
+FROM universe-common-devel AS universe-sensing-perception
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -201,7 +201,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM autoware-universe-common AS autoware-universe
+FROM universe-common-devel AS universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -214,7 +214,7 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
-COPY --from=autoware-universe-sensing-perception /opt/autoware /opt/autoware
+COPY --from=universe-sensing-perception /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/launcher,target=/autoware/src/launcher \
@@ -246,7 +246,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM autoware-universe AS devel
+FROM universe AS devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
@@ -262,7 +262,7 @@ RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
-FROM base AS runtime
+FROM base AS universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ARG LIB_DIR
@@ -287,7 +287,7 @@ RUN --mount=type=ssh \
     /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
-COPY --from=autoware-universe /opt/autoware /opt/autoware
+COPY --from=universe /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,7 +170,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM universe-common-devel AS universe-sensing-perception
+FROM universe-common-devel AS universe-sensing-perception-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -201,7 +201,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM universe-common-devel AS universe
+FROM universe-common-devel AS universe-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -214,7 +214,7 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
-COPY --from=universe-sensing-perception /opt/autoware /opt/autoware
+COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/launcher,target=/autoware/src/launcher \
@@ -246,7 +246,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM universe AS devel
+FROM universe-devel AS devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
@@ -287,7 +287,7 @@ RUN --mount=type=ssh \
     /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
-COPY --from=universe /opt/autoware /opt/autoware
+COPY --from=universe-devel /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-  targets = ["base", "core", "universe", "devel", "universe"]
+  targets = ["base", "core-devel", "universe-devel", "devel", "universe"]
 }
 
 // For docker/metadata-action

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,13 +1,13 @@
 group "default" {
-  targets = ["base", "autoware-core", "autoware-universe", "devel", "runtime"]
+  targets = ["base", "core", "universe", "devel", "universe"]
 }
 
 // For docker/metadata-action
 target "docker-metadata-action-base" {}
-target "docker-metadata-action-autoware-core" {}
-target "docker-metadata-action-autoware-universe" {}
+target "docker-metadata-action-core-devel" {}
+target "docker-metadata-action-universe-devel" {}
 target "docker-metadata-action-devel" {}
-target "docker-metadata-action-runtime" {}
+target "docker-metadata-action-universe" {}
 
 target "base" {
   inherits = ["docker-metadata-action-base"]
@@ -15,16 +15,16 @@ target "base" {
   target = "base"
 }
 
-target "autoware-core" {
-  inherits = ["docker-metadata-action-autoware-core"]
+target "core-devel" {
+  inherits = ["docker-metadata-action-core-devel"]
   dockerfile = "docker/Dockerfile"
-  target = "autoware-core"
+  target = "core-devel"
 }
 
-target "autoware-universe" {
-  inherits = ["docker-metadata-action-autoware-universe"]
+target "universe-devel" {
+  inherits = ["docker-metadata-action-universe-devel"]
   dockerfile = "docker/Dockerfile"
-  target = "autoware-universe"
+  target = "universe-devel"
 }
 
 target "devel" {
@@ -33,8 +33,8 @@ target "devel" {
   target = "devel"
 }
 
-target "runtime" {
-  inherits = ["docker-metadata-action-runtime"]
+target "universe" {
+  inherits = ["docker-metadata-action-universe"]
   dockerfile = "docker/Dockerfile"
-  target = "runtime"
+  target = "universe"
 }


### PR DESCRIPTION
## Description

As mentioned in this opinion https://github.com/autowarefoundation/autoware/pull/5164#pullrequestreview-2280527751 by @oguzkaganozt, the `Dockerfile` is becoming increasingly complex for the following reasons:

- It's unclear from the stage names which stage is the development container and which stage is the runtime container.
- Since the image name is "autoware," adding "autoware" to the stage names (tag names) is redundant.

Therefore, this PR introduces the following naming conventions to make it easier to maintain a one-to-one correspondence between development and runtime containers, even as multi-container setups become more prevalent:

- Containers with the suffix `-devel` are development containers, while those without the suffix are runtime containers.
- The prefix `autoware-` is no longer used.

The generated images will have names like the following.

| Before | After |
|-|-|
| `autoware:latest-base` | `autoware:latest-base` |
| `autoware:latest-autoware-core` | `autoware:latest-core-devel` |
| `autoware:latest-autoware-universe` | `autoware:latest-universe-devel` |
| `autoware:latest-devel` | `autoware:latest-devel` |
| `autoware:latest-runtime` | `autoware:latest-universe` |

Before:
![Dockerfile](https://github.com/user-attachments/assets/08ac4a5f-0f8c-4e9e-9dfd-c5c480f79f6e)
After:
![Dockerfile](https://github.com/user-attachments/assets/4899e074-8b91-447d-96ce-e5b165a7be30)

## Tests performed

https://github.com/youtalk/autoware/pull/102
https://github.com/youtalk/autoware/actions/runs/10712585980

## Effects on system behavior

Documentation, shell scripts, and the GitHub Actions settings in the `autoware.universe` repository also need to be updated.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
