### PR TITLE
feat(docker): no longer support `devel` image

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -89,60 +89,49 @@ runs:
         echo "$EOF" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Docker meta for base
+    - name: Docker meta for autoware:base
       id: meta-base
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-base
         flavor: |
           latest=false
           suffix=-base${{ inputs.tag-suffix }}
 
-    - name: Docker meta for autoware-core
-      id: meta-autoware-core
+    - name: Docker meta for autoware:core-devel
+      id: meta-core-devel
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-autoware-core
+        bake-target: docker-metadata-action-core-devel
         flavor: |
           latest=false
-          suffix=-autoware-core${{ inputs.tag-suffix }}
+          suffix=-core-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for autoware-universe
-      id: meta-autoware-universe
+    - name: Docker meta for autoware:universe-devel
+      id: meta-universe-devel
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-autoware-universe
+        bake-target: docker-metadata-action-universe-devel
         flavor: |
           latest=false
-          suffix=-autoware-universe${{ inputs.tag-suffix }}
+          suffix=-universe-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for devel
-      id: meta-devel
+    - name: Docker meta for autoware:universe
+      id: meta-universe
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-devel
+        bake-target: docker-metadata-action-universe
         flavor: |
           latest=false
-          suffix=-devel${{ inputs.tag-suffix }}
-
-    - name: Docker meta for runtime
-      id: meta-runtime
-      uses: docker/metadata-action@v5
-      with:
-        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
-        tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-runtime
-        flavor: |
-          latest=auto
-          suffix=-runtime${{ inputs.tag-suffix }}
+          suffix=-universe${{ inputs.tag-suffix }}
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -158,10 +147,9 @@ runs:
         files: |
           docker/docker-bake.hcl
           ${{ steps.meta-base.outputs.bake-file }}
-          ${{ steps.meta-autoware-core.outputs.bake-file }}
-          ${{ steps.meta-autoware-universe.outputs.bake-file }}
-          ${{ steps.meta-devel.outputs.bake-file }}
-          ${{ steps.meta-runtime.outputs.bake-file }}
+          ${{ steps.meta-core-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-devel.outputs.bake-file }}
+          ${{ steps.meta-universe.outputs.bake-file }}
         provenance: false
         set: |
           ${{ inputs.build-args }}

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -89,7 +89,7 @@ runs:
         echo "$EOF" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Docker meta for base
+    - name: Docker meta for autoware:base
       id: meta-base
       uses: docker/metadata-action@v5
       with:
@@ -100,29 +100,29 @@ runs:
           latest=false
           suffix=-base${{ inputs.tag-suffix }}
 
-    - name: Docker meta for autoware-core
-      id: meta-autoware-core
+    - name: Docker meta for autoware:core-devel
+      id: meta-core-devel
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-autoware-core
+        bake-target: docker-metadata-action-core-devel
         flavor: |
           latest=false
-          suffix=-autoware-core${{ inputs.tag-suffix }}
+          suffix=-core-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for autoware-universe
-      id: meta-autoware-universe
+    - name: Docker meta for autoware:universe-devel
+      id: meta-universe-devel
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-autoware-universe
+        bake-target: docker-metadata-action-universe-devel
         flavor: |
           latest=false
-          suffix=-autoware-universe${{ inputs.tag-suffix }}
+          suffix=-universe-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for devel
+    - name: Docker meta for autoware:devel
       id: meta-devel
       uses: docker/metadata-action@v5
       with:
@@ -133,16 +133,16 @@ runs:
           latest=false
           suffix=-devel${{ inputs.tag-suffix }}
 
-    - name: Docker meta for runtime
-      id: meta-runtime
+    - name: Docker meta for autoware:universe
+      id: meta-universe
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
-        bake-target: docker-metadata-action-runtime
+        bake-target: docker-metadata-action-universe
         flavor: |
           latest=auto
-          suffix=-runtime${{ inputs.tag-suffix }}
+          suffix=-universe${{ inputs.tag-suffix }}
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -158,10 +158,10 @@ runs:
         files: |
           docker/docker-bake.hcl
           ${{ steps.meta-base.outputs.bake-file }}
-          ${{ steps.meta-autoware-core.outputs.bake-file }}
-          ${{ steps.meta-autoware-universe.outputs.bake-file }}
+          ${{ steps.meta-core-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-devel.outputs.bake-file }}
           ${{ steps.meta-devel.outputs.bake-file }}
-          ${{ steps.meta-runtime.outputs.bake-file }}
+          ${{ steps.meta-universe.outputs.bake-file }}
         provenance: false
         set: |
           ${{ inputs.build-args }}

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -93,7 +93,7 @@ runs:
       id: meta-base
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-base
         flavor: |
@@ -104,7 +104,7 @@ runs:
       id: meta-core-devel
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-core-devel
         flavor: |
@@ -115,7 +115,7 @@ runs:
       id: meta-universe-devel
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-universe-devel
         flavor: |
@@ -126,7 +126,7 @@ runs:
       id: meta-universe
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-universe
         flavor: |

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -130,7 +130,7 @@ runs:
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-universe
         flavor: |
-          latest=false
+          latest=auto
           suffix=-universe${{ inputs.tag-suffix }}
 
     - name: Login to GitHub Container Registry

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -180,7 +180,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
-FROM universe-common AS universe-sensing-perception-devel
+FROM universe-common-devel AS universe-sensing-perception-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,9 @@ RUN --mount=type=ssh \
   && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc
 
 # Create entrypoint
+COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
+RUN chmod +x /ros_entrypoint.sh
+ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
 # hadolint ignore=DL3006
@@ -105,15 +108,16 @@ RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
     > /rosdep-exec-depend-packages.txt \
     && cat /rosdep-exec-depend-packages.txt
 
-FROM base AS autoware-core
+FROM base AS core-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
 
-# Set up development environment
+# Set up development environment and tools
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   ./setup-dev-env.sh -y --module all openadkit \
+  && ./setup-dev-env.sh -y --module dev-tools openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache
 
@@ -138,7 +142,10 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM autoware-core AS autoware-universe-common
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
+FROM core-devel AS universe-common-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -170,7 +177,10 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM autoware-universe-common AS autoware-universe-sensing-perception
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
+FROM universe-common AS universe-sensing-perception-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -201,7 +211,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM autoware-universe-common AS autoware-universe
+FROM universe-common-devel AS universe-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -214,7 +224,7 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
-COPY --from=autoware-universe-sensing-perception /opt/autoware /opt/autoware
+COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/launcher,target=/autoware/src/launcher \
@@ -244,25 +254,10 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-CMD ["/bin/bash"]
-
-FROM autoware-universe AS devel
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# Install development tools and artifacts
-RUN --mount=type=ssh \
-  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module dev-tools openadkit \
-  && pip uninstall -y ansible ansible-core \
-  && apt-get autoremove -y && rm -rf "$HOME"/.cache
-
-# Create entrypoint
-COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
-RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
-FROM base AS runtime
+FROM base AS universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ARG LIB_DIR
@@ -287,14 +282,12 @@ RUN --mount=type=ssh \
     /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
-COPY --from=autoware-universe /opt/autoware /opt/autoware
+COPY --from=universe-devel /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases
 RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
 
 # Create entrypoint
-COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
-RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -209,6 +209,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
+ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
 FROM universe-common-devel AS universe-devel
@@ -288,6 +289,5 @@ COPY --from=universe-devel /opt/autoware /opt/autoware
 COPY docker/etc/.bash_aliases /root/.bash_aliases
 RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
 
-# Create entrypoint
 ENTRYPOINT ["/ros_entrypoint.sh"]
-CMD ["bash"]
+CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,7 +105,7 @@ RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
     > /rosdep-exec-depend-packages.txt \
     && cat /rosdep-exec-depend-packages.txt
 
-FROM base AS autoware-core
+FROM base AS core-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -138,7 +138,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM autoware-core AS autoware-universe-common
+FROM core-devel AS universe-common-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -170,7 +170,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM autoware-universe-common AS autoware-universe-sensing-perception
+FROM universe-common-devel AS universe-sensing-perception
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -201,7 +201,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM autoware-universe-common AS autoware-universe
+FROM universe-common-devel AS universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -214,7 +214,7 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
-COPY --from=autoware-universe-sensing-perception /opt/autoware /opt/autoware
+COPY --from=universe-sensing-perception /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/launcher,target=/autoware/src/launcher \
@@ -246,7 +246,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM autoware-universe AS devel
+FROM universe AS devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
@@ -262,7 +262,7 @@ RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
-FROM base AS runtime
+FROM base AS universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ARG LIB_DIR
@@ -287,7 +287,7 @@ RUN --mount=type=ssh \
     /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
-COPY --from=autoware-universe /opt/autoware /opt/autoware
+COPY --from=universe /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,7 +170,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   && du -sh ${CCACHE_DIR} && ccache -s \
   && rm -rf /autoware/build
 
-FROM universe-common-devel AS universe-sensing-perception
+FROM universe-common-devel AS universe-sensing-perception-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -201,7 +201,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM universe-common-devel AS universe
+FROM universe-common-devel AS universe-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -214,7 +214,7 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
 
-COPY --from=universe-sensing-perception /opt/autoware /opt/autoware
+COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/launcher,target=/autoware/src/launcher \
@@ -246,7 +246,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 
 CMD ["/bin/bash"]
 
-FROM universe AS devel
+FROM universe-devel AS devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools and artifacts
@@ -287,7 +287,7 @@ RUN --mount=type=ssh \
     /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
-COPY --from=universe /opt/autoware /opt/autoware
+COPY --from=universe-devel /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -15,19 +15,19 @@ target "base" {
 }
 
 target "core-devel" {
-  inherits = ["docker-metadata-action-autoware-core-devel"]
+  inherits = ["docker-metadata-action-core-devel"]
   dockerfile = "docker/Dockerfile"
   target = "core-devel"
 }
 
 target "universe-devel" {
-  inherits = ["docker-metadata-action-autoware-universe-devel"]
+  inherits = ["docker-metadata-action-universe-devel"]
   dockerfile = "docker/Dockerfile"
   target = "universe-devel"
 }
 
 target "universe" {
-  inherits = ["docker-metadata-action-autoware-universe"]
+  inherits = ["docker-metadata-action-universe"]
   dockerfile = "docker/Dockerfile"
   target = "universe"
 }

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,13 +1,12 @@
 group "default" {
-  targets = ["base", "autoware-core", "autoware-universe", "devel", "runtime"]
+  targets = ["base", "core-devel", "universe-devel", "universe"]
 }
 
 // For docker/metadata-action
 target "docker-metadata-action-base" {}
-target "docker-metadata-action-autoware-core" {}
-target "docker-metadata-action-autoware-universe" {}
-target "docker-metadata-action-devel" {}
-target "docker-metadata-action-runtime" {}
+target "docker-metadata-action-core-devel" {}
+target "docker-metadata-action-universe-devel" {}
+target "docker-metadata-action-universe" {}
 
 target "base" {
   inherits = ["docker-metadata-action-base"]
@@ -15,26 +14,20 @@ target "base" {
   target = "base"
 }
 
-target "autoware-core" {
-  inherits = ["docker-metadata-action-autoware-core"]
+target "autoware-core-devel" {
+  inherits = ["docker-metadata-action-autoware-core-devel"]
   dockerfile = "docker/Dockerfile"
-  target = "autoware-core"
+  target = "core-devel"
+}
+
+target "autoware-universe-devel" {
+  inherits = ["docker-metadata-action-autoware-universe-devel"]
+  dockerfile = "docker/Dockerfile"
+  target = "universe-devel"
 }
 
 target "autoware-universe" {
   inherits = ["docker-metadata-action-autoware-universe"]
   dockerfile = "docker/Dockerfile"
-  target = "autoware-universe"
-}
-
-target "devel" {
-  inherits = ["docker-metadata-action-devel"]
-  dockerfile = "docker/Dockerfile"
-  target = "devel"
-}
-
-target "runtime" {
-  inherits = ["docker-metadata-action-runtime"]
-  dockerfile = "docker/Dockerfile"
-  target = "runtime"
+  target = "universe"
 }

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-  targets = ["base", "core", "universe", "devel", "universe"]
+  targets = ["base", "core-devel", "universe-devel", "devel", "universe"]
 }
 
 // For docker/metadata-action

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -14,19 +14,19 @@ target "base" {
   target = "base"
 }
 
-target "autoware-core-devel" {
+target "core-devel" {
   inherits = ["docker-metadata-action-autoware-core-devel"]
   dockerfile = "docker/Dockerfile"
   target = "core-devel"
 }
 
-target "autoware-universe-devel" {
+target "universe-devel" {
   inherits = ["docker-metadata-action-autoware-universe-devel"]
   dockerfile = "docker/Dockerfile"
   target = "universe-devel"
 }
 
-target "autoware-universe" {
+target "universe" {
   inherits = ["docker-metadata-action-autoware-universe"]
   dockerfile = "docker/Dockerfile"
   target = "universe"

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,13 +1,13 @@
 group "default" {
-  targets = ["base", "autoware-core", "autoware-universe", "devel", "runtime"]
+  targets = ["base", "core", "universe", "devel", "universe"]
 }
 
 // For docker/metadata-action
 target "docker-metadata-action-base" {}
-target "docker-metadata-action-autoware-core" {}
-target "docker-metadata-action-autoware-universe" {}
+target "docker-metadata-action-core-devel" {}
+target "docker-metadata-action-universe-devel" {}
 target "docker-metadata-action-devel" {}
-target "docker-metadata-action-runtime" {}
+target "docker-metadata-action-universe" {}
 
 target "base" {
   inherits = ["docker-metadata-action-base"]
@@ -15,16 +15,16 @@ target "base" {
   target = "base"
 }
 
-target "autoware-core" {
-  inherits = ["docker-metadata-action-autoware-core"]
+target "core-devel" {
+  inherits = ["docker-metadata-action-core-devel"]
   dockerfile = "docker/Dockerfile"
-  target = "autoware-core"
+  target = "core-devel"
 }
 
-target "autoware-universe" {
-  inherits = ["docker-metadata-action-autoware-universe"]
+target "universe-devel" {
+  inherits = ["docker-metadata-action-universe-devel"]
   dockerfile = "docker/Dockerfile"
-  target = "autoware-universe"
+  target = "universe-devel"
 }
 
 target "devel" {
@@ -33,8 +33,8 @@ target "devel" {
   target = "devel"
 }
 
-target "runtime" {
-  inherits = ["docker-metadata-action-runtime"]
+target "universe" {
+  inherits = ["docker-metadata-action-universe"]
   dockerfile = "docker/Dockerfile"
-  target = "runtime"
+  target = "universe"
 }


### PR DESCRIPTION
## Description

- [x] #5170 

Thanks to these PRs, the size difference between the `devel` image and the `autoware-universe` image (which is planned to be renamed to `universe-devel`) has now become negligible.

- https://github.com/autowarefoundation/autoware/pull/5023
- https://github.com/autowarefoundation/autoware/pull/5027

![Screenshot from 2024-09-05 13-35-08](https://github.com/user-attachments/assets/6b160458-6ef7-4f75-be6e-bcd2c6b92e6c)

Therefore, the `dev-tools` will be installed in images with the suffix `-devel`, and the `devel` image will be deprecated. This will further clarify the one-to-one correspondence between development and runtime containers.

## Tests performed

https://github.com/youtalk/autoware/pull/102
https://github.com/youtalk/autoware/actions/runs/10712585980

## Effects on system behavior

Documentation, shell scripts, and the GitHub Actions settings in the `autoware.universe` repository also need to be updated.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
