### PR TITLE
feat(docker): add `universe-localization-mapping` runtime image

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -133,6 +133,28 @@ runs:
           latest=false
           suffix=-universe-sensing-perception${{ inputs.tag-suffix }}
 
+    - name: Docker meta for autoware:universe-localization-mapping-devel
+      id: meta-universe-localization-mapping-devel
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        tags: ${{ steps.set-docker-tags.outputs.tags }}
+        bake-target: docker-metadata-action-universe-localization-mapping-devel
+        flavor: |
+          latest=false
+          suffix=-universe-localization-mapping-devel${{ inputs.tag-suffix }}
+
+    - name: Docker meta for autoware:universe-localization-mapping
+      id: meta-universe-localization-mapping
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        tags: ${{ steps.set-docker-tags.outputs.tags }}
+        bake-target: docker-metadata-action-universe-localization-mapping
+        flavor: |
+          latest=false
+          suffix=-universe-localization-mapping${{ inputs.tag-suffix }}
+
     - name: Docker meta for autoware:universe-devel
       id: meta-universe-devel
       uses: docker/metadata-action@v5
@@ -172,6 +194,8 @@ runs:
           ${{ steps.meta-core-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception.outputs.bake-file }}
+          ${{ steps.meta-universe-localization-mapping-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-localization-mapping.outputs.bake-file }}
           ${{ steps.meta-universe-devel.outputs.bake-file }}
           ${{ steps.meta-universe.outputs.bake-file }}
         provenance: false

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -137,7 +137,7 @@ runs:
       id: meta-universe-localization-mapping-devel
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-universe-localization-mapping-devel
         flavor: |
@@ -148,7 +148,7 @@ runs:
       id: meta-universe-localization-mapping
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.bake-target }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: ${{ steps.set-docker-tags.outputs.tags }}
         bake-target: docker-metadata-action-universe-localization-mapping
         flavor: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,6 +110,13 @@ RUN rosdep keys --ignore-src --from-paths src \
     | sort \
     > /rosdep-universe-localization-mapping-depend-packages.txt \
     && cat /rosdep-universe-localization-mapping-depend-packages.txt
+RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
+    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
+    | grep -v '^#' \
+    | sed 's/ \+/\n/g'\
+    | sort \
+    > /rosdep-universe-localization-mapping-exec-depend-packages.txt \
+    && cat /rosdep-universe-localization-mapping-exec-depend-packages.txt
 
 FROM rosdep-depend AS rosdep-universe-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -344,6 +351,40 @@ RUN --mount=type=ssh \
     /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
 
 COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
+
+# Copy bash aliases
+COPY docker/etc/.bash_aliases /root/.bash_aliases
+RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
+FROM base AS universe-localization-mapping
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ARG LIB_DIR
+ARG SETUP_ARGS
+
+# Set up runtime environment and artifacts
+COPY --from=rosdep-universe-localization-mapping-depend /rosdep-universe-localization-mapping-exec-depend-packages.txt /tmp/rosdep-universe-localization-mapping-exec-depend-packages.txt
+# hadolint ignore=SC2002
+RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --download-artifacts --no-cuda-drivers --runtime openadkit \
+  && pip uninstall -y ansible ansible-core \
+  && apt-get update \
+  && cat /tmp/rosdep-universe-localization-mapping-exec-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
+  && apt-get autoremove -y && rm -rf "$HOME"/.cache \
+  && find /usr/lib/$LIB_DIR-linux-gnu -name "*.a" -type f -delete \
+  && find / -name "*.o" -type f -delete \
+  && find / -name "*.h" -type f -delete \
+  && find / -name "*.hpp" -type f -delete \
+  && rm -rf /autoware/ansible \
+    /root/.local/pipx /opt/ros/"$ROS_DISTRO"/include /etc/apt/sources.list.d/cuda*.list \
+    /etc/apt/sources.list.d/docker.list /etc/apt/sources.list.d/nvidia-docker.list \
+    /usr/include /usr/share/doc /usr/lib/gcc /usr/lib/jvm /usr/lib/llvm*
+
+COPY --from=universe-localization-mapping-devel /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -370,7 +370,7 @@ COPY --from=rosdep-universe-localization-mapping-depend /rosdep-universe-localiz
 # hadolint ignore=SC2002
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --download-artifacts --no-cuda-drivers --runtime openadkit \
+  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers --runtime openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get update \
   && cat /tmp/rosdep-universe-localization-mapping-exec-depend-packages.txt | xargs apt-get install -y --no-install-recommends \

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,6 +61,10 @@ This stage installs the dependency packages based on `/rosdep-universe-localizat
 - `universe/autoware.universe/localization`
 - `universe/autoware.universe/map`
 
+### `universe-localization-mapping`
+
+This stage is a Autoware Universe Localization/Mapping runtime container. It only includes the dependencies given by `/rosdep-universe-localization-mapping-exec-depend-packages.txt` and the binaries built in the `universe-localization-mapping-devel` stage.
+
 ### `universe-devel`
 
 This stage installs the dependency packages based on `/rosdep-universe-depend-packages.txt` and build the remaining packages of `autoware.repos`:

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -4,6 +4,8 @@ group "default" {
     "core-devel",
     "universe-sensing-perception-devel",
     "universe-sensing-perception",
+    "universe-localization-mapping-devel",
+    "universe-localization-mapping",
     "universe-devel",
     "universe"
   ]
@@ -14,6 +16,8 @@ target "docker-metadata-action-base" {}
 target "docker-metadata-action-core-devel" {}
 target "docker-metadata-action-universe-sensing-perception-devel" {}
 target "docker-metadata-action-universe-sensing-perception" {}
+target "docker-metadata-action-universe-localization-mapping-devel" {}
+target "docker-metadata-action-universe-localization-mapping" {}
 target "docker-metadata-action-universe-devel" {}
 target "docker-metadata-action-universe" {}
 
@@ -39,6 +43,18 @@ target "universe-sensing-perception" {
   inherits = ["docker-metadata-action-universe-sensing-perception"]
   dockerfile = "docker/Dockerfile"
   target = "universe-sensing-perception"
+}
+
+target "universe-localization-mapping-devel" {
+  inherits = ["docker-metadata-action-universe-localization-mapping-devel"]
+  dockerfile = "docker/Dockerfile"
+  target = "universe-localization-mapping-devel"
+}
+
+target "universe-localization-mapping" {
+  inherits = ["docker-metadata-action-universe-localization-mapping"]
+  dockerfile = "docker/Dockerfile"
+  target = "universe-localization-mapping"
 }
 
 target "universe-devel" {


### PR DESCRIPTION
## Description

This PR adds `universe-localization-mapping` runtime stage and generates the image.
Since the `universe-localization-mapping` image does not depend on CUDA, improvements will be made in a separate PR to skip building with the `-cuda` suffix.

## Tests performed

https://github.com/youtalk/autoware/pull/108
https://github.com/youtalk/autoware/actions/runs/10745734514

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
