### PR TITLE
fix(.github): fix non `-cuda` tag names

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -78,8 +78,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=base${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=base${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=base$${{ inputs.tag-suffix }}
+          type=raw,value=base$${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-base
         flavor: |
           latest=false
@@ -90,8 +90,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=core-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=core-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=core-devel${{ inputs.tag-suffix }}
+          type=raw,value=core-devel${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-core-devel
         flavor: |
           latest=false
@@ -102,8 +102,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe-sensing-perception-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe-sensing-perception-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe-sensing-perception-devel${{ inputs.tag-suffix }}
+          type=raw,value=universe-sensing-perception-devel${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe-sensing-perception-devel
         flavor: |
           latest=false
@@ -114,8 +114,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe-sensing-perception${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe-sensing-perception${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe-sensing-perception${{ inputs.tag-suffix }}
+          type=raw,value=universe-sensing-perception${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe-sensing-perception
         flavor: |
           latest=false
@@ -126,8 +126,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe-localization-mapping-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe-localization-mapping-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe-localization-mapping-devel${{ inputs.tag-suffix }}
+          type=raw,value=universe-localization-mapping-devel${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe-localization-mapping-devel
         flavor: |
           latest=false
@@ -138,8 +138,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe-localization-mapping${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe-localization-mapping${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe-localization-mapping${{ inputs.tag-suffix }}
+          type=raw,value=universe-localization-mapping${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe-localization-mapping
         flavor: |
           latest=false
@@ -150,8 +150,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe-planning-control-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe-planning-control-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe-planning-control-devel${{ inputs.tag-suffix }}
+          type=raw,value=universe-planning-control-devel${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe-planning-control-devel
         flavor: |
           latest=false
@@ -162,8 +162,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe-planning-control${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe-planning-control${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe-planning-control${{ inputs.tag-suffix }}
+          type=raw,value=universe-planning-control${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe-planning-control
         flavor: |
           latest=false
@@ -174,8 +174,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe-devel${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe-devel${{ inputs.tag-suffix }}
+          type=raw,value=universe-devel${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe-devel
         flavor: |
           latest=false
@@ -186,8 +186,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=universe${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}
-          type=raw,value=universe${{ inputs.tag-suffix && '-' }}${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
+          type=raw,value=universe${{ inputs.tag-suffix }}
+          type=raw,value=universe${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-universe
         flavor: |
           latest=auto

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -31,7 +31,7 @@ jobs:
             platform: arm64
             base_image_env: base_image
             lib_dir: aarch64
-            additional-tag-suffix: cuda
+            additional-tag-suffix: -cuda
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -31,7 +31,7 @@ jobs:
             platform: amd64
             base_image_env: base_image
             lib_dir: x86_64
-            additional-tag-suffix: cuda
+            additional-tag-suffix: -cuda
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/health-check-arm64.yaml
+++ b/.github/workflows/health-check-arm64.yaml
@@ -24,12 +24,10 @@ jobs:
             base_image_env: base_image
             lib_dir: aarch64
             setup-args: --no-nvidia
-            additional-tag-suffix: ""
           - name: cuda
             platform: arm64
             base_image_env: base_image
             lib_dir: aarch64
-            additional-tag-suffix: -cuda
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -39,12 +39,10 @@ jobs:
             base_image_env: base_image
             lib_dir: x86_64
             setup-args: --no-nvidia
-            additional-tag-suffix: ""
           - name: cuda
             platform: amd64
             base_image_env: base_image
             lib_dir: x86_64
-            additional-tag-suffix: -cuda
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Due to the previous PR https://github.com/autowarefoundation/autoware/pull/5216, an unnecessary `-` has been included in image tag names that do not contain the `cuda` suffix.

<img width="999" alt="Screenshot 2024-09-20 at 11 32 01" src="https://github.com/user-attachments/assets/62992ba8-adc8-4997-8707-60d89cb7d536">

This PR fixes the problem.

## Tests performed

https://github.com/youtalk/autoware/actions/runs/10952296658
https://hub.docker.com/repository/docker/youtalk/autoware/tags

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
