### PR TITLE
fix(docker): copy all `.csv` and `.png` files to images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,14 +13,10 @@ docker
 # Ignore a part of files under src
 src/**/.*
 src/**/*.asc
-src/**/*.csv
 src/**/*.gif
 src/**/*.md
 src/**/*.pcd
-src/**/*.png
 src/**/*.svg
-!src/universe/autoware.universe/common/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/assets
-!src/universe/autoware.universe/vehicle/autoware_raw_vehicle_cmd_converter/data/default
 
 # Ignore generated files by colcon
 build


### PR DESCRIPTION
## Description

Fixed https://github.com/autowarefoundation/autoware/issues/5180

The previous PR https://github.com/autowarefoundation/autoware/pull/5187 couldn't fix the issue https://github.com/autowarefoundation/autoware/issues/5180.
This PR copies all `.csv` and `.png` files to images. 
It affects the image size, but for now, I prioritize solving the issue. I would like to minimize the amount of copying in a separate PR.

## Tests performed

https://github.com/youtalk/autoware/pull/114
https://github.com/youtalk/autoware/actions/runs/10953443398

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
