### PR TITLE
chore!: upgrade to Nebula v0.2.1

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -100,12 +100,12 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: v0.0.1
+    version: v0.2.0
   # Fork of transport_drivers that enables reduction of copy operations
   sensor_component/transport_drivers:
     type: git
     url: https://github.com/autowarefoundation/transport_drivers
-    version: mutable-buffer-in-udp-callback
+    version: main
   # Continental compatible version of ROS 2 socket CAN
   sensor_component/ros2_socketcan:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -100,7 +100,7 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: v0.2.0
+    version: v0.2.1
   # Fork of transport_drivers that enables reduction of copy operations
   sensor_component/transport_drivers:
     type: git


### PR DESCRIPTION
## Description

This PR changes the Nebula version to [v0.2.0](https://github.com/tier4/nebula/releases/tag/v0.2.0).

This is a breaking change for the way Nebula is launched, and thus, this PR has to be merged in tandem with
- https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/106
- https://github.com/autowarefoundation/single_lidar_sensor_kit_launch/pull/2

Similar PRs have been made to TIER IV's internal repos, for example:
- [TIER IV INTERNAL LINK](https://github.com/tier4/pilot-auto.x2/pull/953)

**I will merge all PRs in tandem once all of them get approved and have passing CI.**
**Please do not merge them independently.**

## Tests performed

Logging simulator with sample_sensor_kit succeeded, all pointclouds were being published:
![Screenshot from 2024-09-24 16-53-02](https://github.com/user-attachments/assets/9c3bca02-4f9a-4cb2-b127-6ed3f70cd798)

The logs are looking fine too:
[sample_sensor_kit.log](https://github.com/user-attachments/files/17112124/sample_sensor_kit.log)

As for `single_lidar_sensor_kit`, it failed with an unrelated error:
```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): executed command failed. Command: xacro /home/maxschmeller/autoware/install/tier4_vehicle_launch/share/tier4_vehicle_launch/urdf/vehicle.xacro vehicle_model:=sample_vehicle sensor_model:=single_lidar_sensor_kit config_dir:=/home/maxschmeller/autoware/install/individual_params/share/individual_params/config/default/single_lidar_sensor_kit
Captured stderr output: error: [Errno 2] No such file or directory: '/home/maxschmeller/autoware/install/individual_params/share/individual_params/config/default/single_lidar_sensor_kit/sensors_calibration.yaml' 
when evaluating expression 'xacro.load_yaml('$(arg config_dir)/sensors_calibration.yaml')' 
when evaluating expression 'calibration['base_link']['sensor_kit_base_link']['x']'
when instantiating macro: sensor_kit_macro (/home/maxschmeller/autoware/install/single_lidar_sensor_kit_description/share/single_lidar_sensor_kit_description/urdf/sensor_kit.xacro)
```

If anyone knows how to properly launch it (I didn't find any documentation on that), please let me know.

## Effects on system behavior

Nebula pointclouds will experience less packet loss and Nebula should be more stable.

## Interface changes

- Nebula now always publishes to `/diagnostics` when `launch_driver` is enabled.
- Nebula only accepts `/<vendor>_packets` when `launch_driver` is disabled (= no real sensor is connected)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
