### PR TITLE
fix(autoware.repos): use main branch of ros2_socketcan

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -110,7 +110,7 @@ repositories:
   sensor_component/ros2_socketcan:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan
-    version: feat/continental_fd
+    version: main
   # sensor_kit
   sensor_kit/sample_sensor_kit_launch:
     type: git


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/ros2_socketcan/pull/50

is merged, and the branch was auto-removed. We can now use the main branch of the repository.

In the future, we should do a quick release and use it from the tag.

But right now the `autoware.repos` points to a branch that doesn't exist.

We should quickly merge this.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
