### PR TITLE
chore(autoware_lidar_transfusion): updated transfusion models

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -169,15 +169,15 @@
 - name: Download lidar_transfusion/transfusion.onnx
   become: true
   ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2/transfusion.onnx
+    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2.1/transfusion.onnx
     dest: "{{ data_dir }}/lidar_transfusion/transfusion.onnx"
     mode: "644"
-    checksum: sha256:ad66a061d61449af671bd0d14c2c407f0d749753f17f3165287857f686c4fd1a
+    checksum: sha256:1d8f0ee6d59ccc3cca914f9892f6ac8f0a9e35082abb91da183c00e3e2c2718a
 
 - name: Download lidar_transfusion/transfusion_ml_package.param.yaml
   become: true
   ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2/transfusion_ml_package.param.yaml
+    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2.1/transfusion_ml_package.param.yaml
     dest: "{{ data_dir }}/lidar_transfusion/transfusion_ml_package.param.yaml"
     mode: "644"
     checksum: sha256:476f7727adc17a823962f2e09ba23d40f3116c50be48361d98179d054cd131b6
@@ -185,7 +185,7 @@
 - name: Download lidar_transfusion/detection_class_remapper.param.yaml
   become: true
   ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2/detection_class_remapper.param.yaml
+    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2.1/detection_class_remapper.param.yaml
     dest: "{{ data_dir }}/lidar_transfusion/detection_class_remapper.param.yaml"
     mode: "644"
     checksum: sha256:c711f8875ece9b527dfe31ffc75f8c0de2e77945ef67860a959a4e04c36772d5


### PR DESCRIPTION
# Description

This PR updates the transfusion models.  The updated models have fixed names of the IO tensors, and produce an interpretable cls_score ([TIER IV Internal Link](https://github.com/tier4/autoware-ml/pull/163)).
Merge and review together with: https://github.com/autowarefoundation/autoware.universe/pull/9057


**It is recommended to re-download the transfusion model artifacts and update the transfusion package after the above universe PR, to get reliable more accurate predictions with transfusion.**