### PR TITLE
fix(.github): change `runs-on` value from `ubuntu-latest` to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cancel-previous-workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/create-prs-to-update-vcs-repositories.yaml
+++ b/.github/workflows/create-prs-to-update-vcs-repositories.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-version-update-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   dco:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -13,7 +13,7 @@ jobs:
 
   docker-build-and-push:
     needs: load-env
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   github-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set tag name
         id: set-tag-name

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -26,7 +26,7 @@ jobs:
 
   docker-build:
     needs: load-env
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/load-env.yaml
+++ b/.github/workflows/load-env.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   load-env:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       base_image: ${{ steps.set-env.outputs.base_image }}
       rosdistro: ${{ steps.set-env.outputs.rosdistro }}

--- a/.github/workflows/mirror-main-branch.yaml
+++ b/.github/workflows/mirror-main-branch.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   mirror-main-branch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: zofrex/mirror-branch@v1
         with:

--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -14,7 +14,7 @@ jobs:
   pre-commit-ansible-autoupdate:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre-commit-ansible:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -14,7 +14,7 @@ jobs:
   pre-commit-autoupdate:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -14,7 +14,7 @@ jobs:
   pre-commit-optional-autoupdate:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/setup-docker.yaml
+++ b/.github/workflows/setup-docker.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   setup-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   setup-universe:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -14,7 +14,7 @@ jobs:
   sync-files:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-docker-manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-tool-versions.yaml
+++ b/.github/workflows/update-tool-versions.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-tool-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Description

It seems that the version of Ubuntu of GitHub Runner used when `runs-on: ubuntu-latest` has been gradually switching from Ubuntu 22.04 to Ubuntu 24.04 toward the end of October. 
https://github.com/actions/runner-images/issues/10636

This has caused some CI checks to start failing. 
https://github.com/autowarefoundation/autoware/actions/runs/11254191077/job/31291276368?pr=5319

This PR changes the `runs-on` value to `ubuntu-22.04` instead of `ubuntu-latest`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
