### PR TITLE
chore(docker): remove `/autoware/log` after `colcon build`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -222,7 +222,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s \
-  && rm -rf /autoware/build
+  && rm -rf /autoware/build /autoware/log
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
@@ -254,7 +254,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s \
-  && rm -rf /autoware/build
+  && rm -rf /autoware/build /autoware/log
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
@@ -286,7 +286,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s \
-  && rm -rf /autoware/build
+  && rm -rf /autoware/build /autoware/log
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
@@ -318,7 +318,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s \
-  && rm -rf /autoware/build
+  && rm -rf /autoware/build /autoware/log
 
 FROM universe-common-devel AS universe-planning-control-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -352,7 +352,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s \
-  && rm -rf /autoware/build
+  && rm -rf /autoware/build /autoware/log
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
@@ -386,7 +386,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s \
-  && rm -rf /autoware/build
+  && rm -rf /autoware/build /autoware/log
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
@@ -429,7 +429,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
     --install-base /opt/autoware \
     --mixin release compile-commands ccache \
   && du -sh ${CCACHE_DIR} && ccache -s \
-  && rm -rf /autoware/build
+  && rm -rf /autoware/build /autoware/log
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description

This PR removes not only `/autoware/build` but also `/autoware/log` directories on the spot after executing `colcon build`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
