### PR TITLE
fix(docker): install CUDA development drivers in development containers

### DIFF
--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -26,16 +26,16 @@
       when: module == 'base'
     - role: autoware.dev_env.pacmod
       when: module == 'base'
-    - role: autoware.dev_env.cuda
-      when: module == 'base' and prompt_install_nvidia=='y'
-    - role: autoware.dev_env.tensorrt
-      when: module == 'base' and prompt_install_nvidia=='y'
     - role: autoware.dev_env.build_tools
       when: module == 'all' and install_devel=='y'
 
     # Module specific dependencies
     - role: autoware.dev_env.geographiclib
       when: module == 'perception-localization' or module == 'all'
+    - role: autoware.dev_env.cuda
+      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
+    - role: autoware.dev_env.tensorrt
+      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
 
     # Development environment
     - role: autoware.dev_env.dev_tools

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -33,9 +33,9 @@
     - role: autoware.dev_env.geographiclib
       when: module == 'perception-localization' or module == 'all'
     - role: autoware.dev_env.cuda
-      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
+      when: (module == 'base' or module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
     - role: autoware.dev_env.tensorrt
-      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
+      when: (module == 'base' or module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
 
     # Development environment
     - role: autoware.dev_env.dev_tools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
+ARG SETUP_ARGS
 
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
@@ -24,7 +25,7 @@ WORKDIR /autoware
 # Set up base environment
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module base --runtime openadkit \
+  ./setup-dev-env.sh -y --module base ${SETUP_ARGS} --no-cuda-drivers --runtime openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,6 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
-ARG SETUP_ARGS
 
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
@@ -25,7 +24,7 @@ WORKDIR /autoware
 # Set up base environment
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module base ${SETUP_ARGS} --no-cuda-drivers --runtime openadkit \
+  ./setup-dev-env.sh -y --module base --runtime openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache \
   && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc
@@ -193,12 +192,13 @@ RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
 FROM base AS core-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
+ARG SETUP_ARGS
 ENV CCACHE_DIR="/root/.ccache"
 
 # Set up development environment and tools
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module all openadkit \
+  ./setup-dev-env.sh -y --module all ${SETUP_ARGS} --no-cuda-drivers openadkit \
   && ./setup-dev-env.sh -y --module dev-tools openadkit \
   && pip uninstall -y ansible ansible-core \
   && apt-get autoremove -y && rm -rf "$HOME"/.cache


### PR DESCRIPTION
## Description

Resolved https://github.com/autowarefoundation/autoware/issues/5219

The cause of #5219 is that due to the changes in #5159, only the CUDA runtime drivers are now being installed in both the development containers and the runtime containers. Though the development containers are required to install the CUDA development drivers.
https://github.com/autowarefoundation/autoware/blob/main/ansible/roles/cuda/tasks/main.yaml#L28-L50

This PR installs CUDA development drivers on development containers.

cc @marioney

## Tests performed

https://github.com/youtalk/autoware/actions/runs/11288251647
https://github.com/youtalk/autoware/actions/runs/11288252539

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
