### PR TITLE
fix(autoware.repos): fix build errors for awsim-stable-update branch

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -40,8 +40,8 @@ repositories:
   # universe
   universe/autoware.universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
-    version: 96dae8d3bcea24b0a63416f07845e79fef5fe6a9
+    url: https://github.com/mackierx111/autoware.universe.git
+    version: awsim-stable
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Improve design/code and transfer to AWF
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
@@ -102,8 +102,8 @@ repositories:
     version: de4bf6be79aa2968cf2f62e0ebe1ff8a5797e6ad
   sensor_component/external/nebula:
     type: git
-    url: https://github.com/tier4/nebula.git
-    version: d9aaefc9a4c06f6dae86cd7ef22f6353f1379e4f
+    url: https://github.com/mackierx111/nebula.git
+    version: awsim-stable
   # Fork of transport_drivers that enables reduction of copy operations
   sensor_component/transport_drivers:
     type: git


### PR DESCRIPTION
## Description

Currently, building on the [awsim-stable-update](https://github.com/autowarefoundation/autoware/tree/awsim-stable-update) branch fails with an error. This PR can improve this.
The following changes have been applied.
- https://github.com/mackierx111/nebula/commit/4cd2f1e51daf59e1e9369d3cdb0c1af2f7591e53
- https://github.com/mackierx111/autoware.universe/commit/815d05b6944fd475f3563414fd8a7aa21356d252

I also forked and modified the referenced repository to minimize changes.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
