### PR TITLE
fix: fix to import and build

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -94,11 +94,11 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: 2314f61a76e75838a507e78e42cd9ad41c923fb3
+    version: 18af521fc3a3ab1ce9c17ec94c2a0a8633317de4
   sensor_component/transport_drivers:
     type: git
     url: https://github.com/autowarefoundation/transport_drivers
-    version: abf8aa8e171f33e0acd6d845c3d795192c964e9c
+    version: 39ebd8afe1bb9760a6cd6272e428468480f6de90
   sensor_component/ros2_socketcan:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan


### PR DESCRIPTION
## Description

This pull request fixed two problems in ***release/2024.09***.

### (1) Missing commit

In the `transport_drivers` repository, the commit with the id "abf8aa8e171f33e0acd6d845c3d795192c964e9c" is missing.

> This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.

https://github.com/autowarefoundation/transport_drivers/tree/abf8aa8e171f33e0acd6d845c3d795192c964e9c

To resolve this, I have updated the commit ID to the latest on the `main` branch.

### (2) Nebula build error
In this version I get the following build error:

```
--- stderr: nebula_hw_interfaces                                                                                          
** WARNING ** io features related to pcap will be disabled
In file included from /home/shintarosakoda/autoware_build_test/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp:19,
                 from /home/shintarosakoda/autoware_build_test/src/sensor_component/external/nebula/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp:1:
/home/shintarosakoda/autoware_build_test/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp: In function 'std::ostream& nebula::operator<<(std::ostream&, const nebula::HesaiInventory&)':
/home/shintarosakoda/autoware_build_test/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:200:30: error: 'setfill' is not a member of 'std'; did you mean 'fill'?
  200 |       ss << std::hex << std::setfill('0') << std::setw(2) << (static_cast<int>(arg.mac[i]) & 0xff)
      |                              ^~~~~~~
      |                              fill
/home/shintarosakoda/autoware_build_test/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:200:51: error: 'setw' is not a member of 'std'; did you mean 'set'?
  200 |       ss << std::hex << std::setfill('0') << std::setw(2) << (static_cast<int>(arg.mac[i]) & 0xff)
      |                                                   ^~~~
      |                                                   set
/home/shintarosakoda/autoware_build_test/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:203:28: error: 'setfill' is not a member of 'std'; did you mean 'fill'?
  203 |     ss << std::hex << std::setfill('0') << std::setw(2)
      |                            ^~~~~~~
      |                            fill
/home/shintarosakoda/autoware_build_test/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:203:49: error: 'setw' is not a member of 'std'; did you mean 'set'?
  203 |     ss << std::hex << std::setfill('0') << std::setw(2)
      |                                                 ^~~~
      |                                                 set
gmake[2]: *** [CMakeFiles/nebula_hw_interfaces_hesai.dir/build.make:76: CMakeFiles/nebula_hw_interfaces_hesai.dir/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp.o] エラー 1
gmake[1]: *** [CMakeFiles/Makefile2:143: CMakeFiles/nebula_hw_interfaces_hesai.dir/all] エラー 2
gmake: *** [Makefile:146: all] エラー 2
---
Failed   <<< nebula_hw_interfaces [29.6s, exited with code 2]
```

This has been fixed in

* https://github.com/tier4/nebula/pull/196

I have updated the commit ID to this.

## Tests performed

* `planning_simulator`
* `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
* `e2e_simulator` with [AWSIM v1.3.0](https://github.com/tier4/AWSIM/releases/tag/v1.3.0)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
