### PR TITLE
fix(docker): not install `nvidia` and `cuda` runtime on base image

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -75,11 +75,12 @@ runs:
     - name: Docker meta for autoware:base
       id: meta-base
       uses: docker/metadata-action@v5
+      if: ${{ inputs.name == 'no-cuda' }}
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |
-          type=raw,value=base${{ inputs.tag-suffix }}-${{ inputs.platform }}
-          type=raw,value=base${{ inputs.tag-suffix }}-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=raw,value=base-${{ inputs.platform }}
+          type=raw,value=base-${{ steps.date.outputs.date }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-base
         flavor: |
           latest=false

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -75,7 +75,6 @@ runs:
     - name: Docker meta for autoware:base
       id: meta-base
       uses: docker/metadata-action@v5
-      if: ${{ inputs.name == 'no-cuda' }}
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.bake-target }}
         tags: |

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -33,9 +33,9 @@
     - role: autoware.dev_env.geographiclib
       when: module == 'perception-localization' or module == 'all'
     - role: autoware.dev_env.cuda
-      when: (module == 'base' or module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
+      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
     - role: autoware.dev_env.tensorrt
-      when: (module == 'base' or module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
+      when: (module == 'perception-localization' or module == 'all') and prompt_install_nvidia=='y'
 
     # Development environment
     - role: autoware.dev_env.dev_tools


### PR DESCRIPTION
## Description

We had been installing the runtime version of the CUDA drivers in the `base` image for caching purposes in these PRs: 

- https://github.com/autowarefoundation/autoware/pull/5159
- https://github.com/autowarefoundation/autoware/pull/5332

But these have led to frequent issues of disk image full on `docker-build-and-push-arm64` jobs. Additionally, installing it in the base image caused the runtime version of the CUDA drivers to be installed not only in the runtime containers but also in the development containers. Therefore this PR stops installing the runtime version of the CUDA driver in the `base` image for the time being.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/11432044778

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
