### PR TITLE
build(autoware.repos): remove ament_cmake fork repository

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -75,10 +75,6 @@ repositories:
     type: git
     url: https://github.com/MapIV/llh_converter.git
     version: ros2
-  universe/external/ament_cmake: # TODO(mitsudome-r): remove when https://github.com/ament/ament_cmake/pull/448 is merged
-    type: git
-    url: https://github.com/autowarefoundation/ament_cmake.git
-    version: feat/faster_ament_libraries_deduplicate
   universe/external/glog:  # TODO(Horibe): to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git


### PR DESCRIPTION
## Description

When I compiled the Autoware repository, several warnings appeared.
`WARNING:colcon.colcon_core.package_selection:Some selected packages are already built in one or more underlay workspaces:  'ament_cmake_core' is in: /opt/ros/humble ...`

I found the `ament_cmake` has a local version in `src/universe/external/ament_cmake`, and ROS-humble also has another version.

After a period of investigation, I found the following comment in the file `autoware.repos`
`universe/external/ament_cmake: # TODO(mitsudome-r): remove when https://github.com/ament/ament_cmake/pull/448 is merged`.

The [ament_cmake pr/448](https://github.com/ament/ament_cmake/pull/448) has been merged on Mar 30, so the `ament_cmake` local version may need to be removed.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I checked the changed files by  [ament_cmake pr/448](https://github.com/ament/ament_cmake/pull/448), the current ROS-humble distribution has already merged this modification. 

`/opt/ros/humble/share/ament_cmake_libraries/cmake/ament_libraries_deduplicate.cmake` 
`/opt/ros/humble/share/ament_cmake_libraries/cmake/ament_cmake_libraries-extras.cmake`.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The compilation warnings have been eliminated. 

## Interface changes
Nothing changed.
<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
