### PR TITLE
fix: remove `ndt_omp`

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -55,10 +55,6 @@ repositories:
     type: git
     url: https://github.com/tier4/muSSP.git
     version: tier4/main
-  universe/external/ndt_omp:
-    type: git
-    url: https://github.com/tier4/ndt_omp.git
-    version: tier4/main
   universe/external/pointcloud_to_laserscan:
     type: git
     url: https://github.com/tier4/pointcloud_to_laserscan.git


### PR DESCRIPTION
## Description

`ndt_omp` is merged into autoware.universe https://github.com/autowarefoundation/autoware.universe/pull/8912

Since it is no longer needed, remove it from autoware.repos.

## Tests performed

- [x] build
- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `e2e_simulator` with [AWSIM v1.3.0](https://github.com/tier4/AWSIM/releases/tag/v1.3.0)

## Effects on system behavior

None

## Interface changes

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
