### PR TITLE
refactor(deps): awsim_sensor_kit_launch repo path update

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -114,7 +114,7 @@ repositories:
     version: main
   sensor_kit/external/awsim_sensor_kit_launch: # TODO: Integrate into sample_sensor_kit_launch
     type: git
-    url: https://github.com/RobotecAI/awsim_sensor_kit_launch.git
+    url: https://github.com/tier4/awsim_sensor_kit_launch.git
     version: main
   sensor_kit/awsim_labs_sensor_kit_launch:
     type: git


### PR DESCRIPTION
## Description

This PR updates `awsim_sensor_kit_launch` repo path after transfer to TIER IV's organization. Before it was in Robotec.AI's organization scope.

`awsim_sensor_kit_launch` pulling using vcs still works even without this PR due to [GitHub transfer mechanics details](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) (it automatically redirects from an old URL to a new one), but to keep order this PR updates the URL in the `autoware.repos` file.

## Tests performed

I manually tested whether the new path was correctly pulled from the new location.

## Effects on system behavior

Not applicable.

## Interface changes

None changed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
