### PR TITLE
fix: change the organization of `awsim_sensor_kit_launch` from RobotecAI to tier4

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -110,7 +110,7 @@ repositories:
     version: main
   sensor_kit/external/awsim_sensor_kit_launch: # TODO: Integrate into sample_sensor_kit_launch
     type: git
-    url: https://github.com/RobotecAI/awsim_sensor_kit_launch.git
+    url: https://github.com/tier4/awsim_sensor_kit_launch.git
     version: main
   sensor_kit/awsim_labs_sensor_kit_launch:
     type: git


### PR DESCRIPTION
## Description

`awsim_sensor_kit_launch` was created by RobotecAI and is currently maintained by TIER IV. 
The repository organization was updated on 2024/11/06. 

This pull request updates the URL in autoware.repos from RobotecAI to TIER IV to reflect this change.
(The URL automatically redirects to the new repository, so current autoware.repos also works correctly)

## Tests performed

- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `logging_simulator` with [awsim_gt_data(TIER IV INTERNAL)](https://drive.google.com/file/d/1BtH3Ry5lu-h85GHM-sYq_jNJLw-s0re6/view?usp=drive_link)
- [x] `e2e_simulator` with [AWSIM v1.3.0](https://github.com/tier4/AWSIM/releases/tag/v1.3.0)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

None

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
