### PR TITLE
feat(.github): split `docker-build-and-push` step to `no-cuda` and `cuda` steps

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -15,6 +15,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install jq and vcstool
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install jq python3-pip
+        pip install --no-cache-dir vcstool
+      shell: bash
+
+    - name: Run vcs import
+      run: |
+        mkdir src
+        vcs import src < autoware.repos
+      shell: bash
+
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -38,7 +38,7 @@ jobs:
           files: |
             *.env
             *.repos
-            .github/actions/docker-build-and-push/action.yaml
+            .github/actions/docker-build-and-push*/action.yaml
             .github/workflows/docker-build-and-push*.yaml
             ansible-galaxy-requirements.yaml
             ansible/**

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -85,7 +85,7 @@ jobs:
           files: |
             *.env
             *.repos
-            .github/actions/docker-build-and-push/action.yaml
+            .github/actions/docker-build-and-push*/action.yaml
             .github/workflows/docker-build-and-push*.yaml
             ansible-galaxy-requirements.yaml
             ansible/**

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -68,7 +68,7 @@ jobs:
 
   docker-build-and-push-cuda:
     needs: [load-env, docker-build-and-push]
-    runs-on: buildjet-16vcpu-ubuntu-2204-arm
+    runs-on: [self-hosted, linux, ARM64]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -77,6 +77,9 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -61,6 +61,49 @@ jobs:
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:arm64-main
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:arm64-${{ github.ref_name }},mode=max
 
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
+  docker-build-and-push-cuda:
+    needs: [load-env, docker-build-and-push]
+    runs-on: buildjet-16vcpu-ubuntu-2204-arm
+    steps:
+      - name: Check if PR author is the specific user
+        id: author-check
+        run: |
+          PR_AUTHOR=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
+          if [[ "$PR_AUTHOR" == "youtalk" ]]; then
+            echo "$PR_AUTHOR is a target user"
+            echo "author-found=true" >> $GITHUB_OUTPUT
+          else
+            echo "$PR_AUTHOR is not a target user"
+            echo "author-found=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            *.env
+            *.repos
+            .github/actions/docker-build-and-push/action.yaml
+            .github/workflows/docker-build-and-push*.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker/**
+
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -70,19 +70,6 @@ jobs:
     needs: [load-env, docker-build-and-push]
     runs-on: buildjet-16vcpu-ubuntu-2204-arm
     steps:
-      - name: Check if PR author is the specific user
-        id: author-check
-        run: |
-          PR_AUTHOR=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
-          if [[ "$PR_AUTHOR" == "youtalk" ]]; then
-            echo "$PR_AUTHOR is a target user"
-            echo "author-found=true" >> $GITHUB_OUTPUT
-          else
-            echo "$PR_AUTHOR is not a target user"
-            echo "author-found=false" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -70,6 +70,11 @@ jobs:
     needs: [load-env, docker-build-and-push]
     runs-on: [self-hosted, linux, ARM64]
     steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -56,6 +56,36 @@ jobs:
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:amd64-main
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:amd64-${{ github.ref_name }},mode=max
 
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
+  docker-build-and-push-cuda:
+    needs: [load-env, docker-build-and-push]
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            *.env
+            *.repos
+            .github/actions/docker-build-and-push/action.yaml
+            .github/workflows/docker-build-and-push*.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker/**
+
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -63,7 +63,7 @@ jobs:
 
   docker-build-and-push-cuda:
     needs: [load-env, docker-build-and-push]
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -72,6 +72,9 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -80,7 +80,7 @@ jobs:
           files: |
             *.env
             *.repos
-            .github/actions/docker-build-and-push/action.yaml
+            .github/actions/docker-build-and-push*/action.yaml
             .github/workflows/docker-build-and-push*.yaml
             ansible-galaxy-requirements.yaml
             ansible/**

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -33,7 +33,7 @@ jobs:
           files: |
             *.env
             *.repos
-            .github/actions/docker-build-and-push/action.yaml
+            .github/actions/docker-build-and-push*/action.yaml
             .github/workflows/docker-build-and-push*.yaml
             ansible-galaxy-requirements.yaml
             ansible/**


### PR DESCRIPTION
## Description

- [x] https://github.com/autowarefoundation/autoware.universe/pull/9272

This PR divides the `docker-build-and-push` step into two steps to further mitigate disk space issues. Unfortunately, this increases the runtime since actions like `vcs import` need to be performed twice.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/11740552604
https://github.com/autowarefoundation/autoware/actions/runs/11740558218

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
