### PR TITLE
refactor(docker): replace the multiple `rosdep` commands with `resolve_rosdep_keys.sh`.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 # Ignore Docker files
 docker
 !docker/etc
+!docker/scripts
 
 # Ignore a part of files under src
 src/**/.*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /autoware/
 COPY ansible/ /autoware/ansible/
 COPY docker/scripts/resolve_rosdep_keys.sh /autoware/resolve_rosdep_keys.sh
+RUN chmod +x /autoware/resolve_rosdep_keys.sh
 WORKDIR /autoware
 
 # Set up base environment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Copy files
 COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /autoware/
 COPY ansible/ /autoware/ansible/
+COPY docker/scripts/resolve_rosdep_keys.sh /autoware/resolve_rosdep_keys.sh
 WORKDIR /autoware
 
 # Set up base environment
@@ -64,21 +65,13 @@ RUN --mount=type=ssh \
 
 # Generate install package lists
 COPY src/core /autoware/src/core
-RUN rosdep update && rosdep keys --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN rosdep update && /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-core-depend-packages.txt \
     && cat /rosdep-core-depend-packages.txt
 
 COPY src/universe/external /autoware/src/universe/external
 COPY src/universe/autoware.universe/common /autoware/src/universe/autoware.universe/common
-RUN rosdep keys --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-common-depend-packages.txt \
     && cat /rosdep-universe-common-depend-packages.txt
 
@@ -88,18 +81,10 @@ ARG ROS_DISTRO
 
 COPY src/universe/autoware.universe/perception /autoware/src/universe/autoware.universe/perception
 COPY src/universe/autoware.universe/sensing /autoware/src/universe/autoware.universe/sensing
-RUN rosdep keys --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-sensing-perception-depend-packages.txt \
     && cat /rosdep-universe-sensing-perception-depend-packages.txt
-RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-sensing-perception-exec-depend-packages.txt \
     && cat /rosdep-universe-sensing-perception-exec-depend-packages.txt
 
@@ -109,18 +94,10 @@ ARG ROS_DISTRO
 
 COPY src/universe/autoware.universe/localization /autoware/src/universe/autoware.universe/localization
 COPY src/universe/autoware.universe/map /autoware/src/universe/autoware.universe/map
-RUN rosdep keys --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-localization-mapping-depend-packages.txt \
     && cat /rosdep-universe-localization-mapping-depend-packages.txt
-RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-localization-mapping-exec-depend-packages.txt \
     && cat /rosdep-universe-localization-mapping-exec-depend-packages.txt
 
@@ -135,18 +112,10 @@ COPY src/universe/autoware.universe/map/map_loader /autoware/src/universe/autowa
 COPY src/universe/autoware.universe/map/autoware_map_projection_loader /autoware/src/universe/autoware.universe/map/autoware_map_projection_loader
 COPY src/universe/autoware.universe/sensing/autoware_pcl_extensions /autoware/src/universe/autoware.universe/sensing/autoware_pcl_extensions
 COPY src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor /autoware/src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor
-RUN rosdep keys --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-planning-control-depend-packages.txt \
     && cat /rosdep-universe-planning-control-depend-packages.txt
-RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-planning-control-exec-depend-packages.txt \
     && cat /rosdep-universe-planning-control-exec-depend-packages.txt
 
@@ -158,18 +127,10 @@ COPY src/universe/autoware.universe/vehicle /autoware/src/universe/autoware.univ
 COPY src/universe/autoware.universe/system /autoware/src/universe/autoware.universe/system
 COPY src/universe/autoware.universe/map/autoware_map_height_fitter /autoware/src/universe/autoware.universe/map/autoware_map_height_fitter
 COPY src/universe/autoware.universe/localization/autoware_pose2twist /autoware/src/universe/autoware.universe/localization/autoware_pose2twist
-RUN rosdep keys --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-vehicle-system-depend-packages.txt \
     && cat /rosdep-universe-vehicle-system-depend-packages.txt
-RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-vehicle-system-exec-depend-packages.txt \
     && cat /rosdep-universe-vehicle-system-exec-depend-packages.txt
 
@@ -183,19 +144,11 @@ COPY src/sensor_component /autoware/src/sensor_component
 COPY src/sensor_kit /autoware/src/sensor_kit
 COPY src/universe /autoware/src/universe
 COPY src/vehicle /autoware/src/vehicle
-RUN rosdep keys --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-universe-depend-packages.txt \
     && cat /rosdep-universe-depend-packages.txt
 
-RUN rosdep keys --dependency-types=exec --ignore-src --from-paths src \
-    | xargs rosdep resolve --rosdistro ${ROS_DISTRO} \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g'\
-    | sort \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
     > /rosdep-exec-depend-packages.txt \
     && cat /rosdep-exec-depend-packages.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,8 +19,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Copy files
 COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /autoware/
 COPY ansible/ /autoware/ansible/
-COPY docker/scripts/resolve_rosdep_keys.sh /autoware/resolve_rosdep_keys.sh
-RUN chmod +x /autoware/resolve_rosdep_keys.sh
 WORKDIR /autoware
 
 # Set up base environment
@@ -54,6 +52,8 @@ ARG ROS_DISTRO
 
 COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /autoware/
 COPY ansible/ /autoware/ansible/
+COPY docker/scripts/resolve_rosdep_keys.sh /autoware/resolve_rosdep_keys.sh
+RUN chmod +x /autoware/resolve_rosdep_keys.sh
 WORKDIR /autoware
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function resolve_rosdep_keys() {
+  local src_path=$1
+  local ros_distro=$2
+
+  rosdep update && rosdep keys --ignore-src --from-paths "$src_path" \
+    | xargs rosdep resolve --rosdistro "$ros_distro" \
+    | grep -v '^#' \
+    | sed 's/ \+/\n/g' \
+    | sort
+}
+
+resolve_rosdep_keys "$@"

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 function resolve_rosdep_keys() {
-  local src_path=$1
-  local ros_distro=$2
+    local src_path=$1
+    local ros_distro=$2
 
-  rosdep update && rosdep keys --ignore-src --from-paths "$src_path" \
-    | xargs rosdep resolve --rosdistro "$ros_distro" \
-    | grep -v '^#' \
-    | sed 's/ \+/\n/g' \
-    | sort
+    rosdep update && rosdep keys --ignore-src --from-paths "$src_path" |
+        xargs rosdep resolve --rosdistro "$ros_distro" |
+        grep -v '^#' |
+        sed 's/ \+/\n/g' |
+        sort
 }
 
 resolve_rosdep_keys "$@"

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -4,7 +4,7 @@ function resolve_rosdep_keys() {
     local src_path=$1
     local ros_distro=$2
 
-    rosdep update && rosdep keys --ignore-src --from-paths "$src_path" |
+    rosdep keys --ignore-src --from-paths "$src_path" |
         xargs rosdep resolve --rosdistro "$ros_distro" |
         grep -v '^#' |
         sed 's/ \+/\n/g' |


### PR DESCRIPTION
## Description

This PR replaces the multiple `rosdep` commands in the `Dockerfile` with a shell script, `resolve_rosdep_keys.sh`, to improve the readability of the `Dockerfile`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
