### PR TITLE
chore(docker): add `-DFORCE_CUDA=1` option to strictly build CUDA related packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -277,7 +277,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/sensing/autoware_cuda_utils,target=/autoware/src/universe/autoware.universe/sensing/autoware_cuda_utils \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
+  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware true
 
 COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
 

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -7,6 +7,7 @@ function build_and_clean() {
 
     local cmake_args=" -Wno-dev --no-warn-unused-cli"
     if [ "$cuda_image" = true ]; then
+        # cspell: ignore DFORCE
         cmake_args="$cmake_args -DFORCE_CUDA=1"
     fi
 

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -3,11 +3,15 @@
 function build_and_clean() {
     local ccache_dir=$1
     local install_base=$2
+    local cuda_image=$3
+
+    local cmake_args=" -Wno-dev --no-warn-unused-cli"
+    if [ "$cuda_image" = true ]; then
+        cmake_args="$cmake_args -DFORCE_CUDA=1"
+    fi
 
     du -sh "$ccache_dir" && ccache -s &&
-        colcon build --cmake-args \
-            " -Wno-dev" \
-            " --no-warn-unused-cli" \
+        colcon build --cmake-args "$cmake_args" \
             --merge-install \
             --install-base "$install_base" \
             --mixin release compile-commands ccache &&


### PR DESCRIPTION
## Description

- [ ] https://github.com/autowarefoundation/autoware/pull/5446

Following https://github.com/autowarefoundation/autoware/pull/5446#pullrequestreview-2441317201, this PR adds the `-DFORCE_CUDA=1` option when performing the `colcon build` for `universe-sensing-perception-devel-cuda`, ensuring that the build is not skipped and always executed. This guarantees that the `-devel-cuda` image has the CUDA development libraries installed.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
