### PR TITLE
refactor(docker): refine CUDA related packages build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -272,21 +272,11 @@ COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  # TODO(youtalk): Move CUDA related packages into a dedicated directory
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_bytetrack,target=/autoware/src/universe/autoware.universe/perception/autoware_bytetrack \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_lidar_apollo_instance_segmentation,target=/autoware/src/universe/autoware.universe/perception/autoware_lidar_apollo_instance_segmentation \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_lidar_centerpoint,target=/autoware/src/universe/autoware.universe/perception/autoware_lidar_centerpoint \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_lidar_transfusion,target=/autoware/src/universe/autoware.universe/perception/autoware_lidar_transfusion \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_shape_estimation,target=/autoware/src/universe/autoware.universe/perception/autoware_shape_estimation \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_classifier,target=/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_classifier \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_common,target=/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_common \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_yolox,target=/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_yolox \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_traffic_light_classifier,target=/autoware/src/universe/autoware.universe/perception/autoware_traffic_light_classifier \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception/autoware_traffic_light_fine_detector,target=/autoware/src/universe/autoware.universe/perception/autoware_traffic_light_fine_detector \
-  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/sensing/autoware_cuda_utils,target=/autoware/src/universe/autoware.universe/sensing/autoware_cuda_utils \
+  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/perception,target=/autoware/src/universe/autoware.universe/perception \
+  --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/sensing,target=/autoware/src/universe/autoware.universe/sensing \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
+  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware "--packages-up-to autoware_tensorrt_common"
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -276,7 +276,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-universe-sensing-perception-depend,source=/autoware/src/universe/autoware.universe/sensing,target=/autoware/src/universe/autoware.universe/sensing \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware "--packages-up-to autoware_tensorrt_common"
+  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware "--packages-above-and-dependencies autoware_tensorrt_common"
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -5,6 +5,7 @@ function build_and_clean() {
     local install_base=$2
     local colcon_build_args=$3
 
+    # shellcheck disable=SC2086
     du -sh "$ccache_dir" && ccache -s &&
         colcon build --cmake-args \
             " -Wno-dev" \

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -3,6 +3,7 @@
 function build_and_clean() {
     local ccache_dir=$1
     local install_base=$2
+    local colcon_build_args=$3
 
     du -sh "$ccache_dir" && ccache -s &&
         colcon build --cmake-args \
@@ -10,7 +11,8 @@ function build_and_clean() {
             " --no-warn-unused-cli" \
             --merge-install \
             --install-base "$install_base" \
-            --mixin release compile-commands ccache &&
+            --mixin release compile-commands ccache \
+            "$colcon_build_args" &&
         du -sh "$ccache_dir" && ccache -s &&
         rm -rf /autoware/build /autoware/log
 }

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -12,7 +12,7 @@ function build_and_clean() {
             --merge-install \
             --install-base "$install_base" \
             --mixin release compile-commands ccache \
-            "$colcon_build_args" &&
+            $colcon_build_args &&
         du -sh "$ccache_dir" && ccache -s &&
         rm -rf /autoware/build /autoware/log
 }


### PR DESCRIPTION
## Description

This PR is more refined approach than https://github.com/autowarefoundation/autoware/pull/5454.

This PR can build only the CUDA related packages and their dependencies by using `colcon build --packages-above-and-dependencies`. This approach eliminates the need to hard-code and enumerate the `--mount` options. ￼

https://colcon.readthedocs.io/en/released/reference/package-selection-arguments.html

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
