### PR TITLE
fix(docker): fix `cleanup_apt.sh`

### DIFF
--- a/docker/scripts/cleanup_apt.sh
+++ b/docker/scripts/cleanup_apt.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 function cleanup_apt() {
-    local remove_var_lib_apt_lists=false
+    local remove_var_lib_apt_lists=$1
     apt-get autoremove -y && rm -rf "$HOME"/.cache
-    if "$remove_var_lib_apt_lists"; then
+    if [[ "$remove_var_lib_apt_lists" = true ]]; then
         echo "----------------------------------------"
         echo "Removing /var/lib/apt/lists/*"
         echo "----------------------------------------"

--- a/docker/scripts/cleanup_apt.sh
+++ b/docker/scripts/cleanup_apt.sh
@@ -4,9 +4,6 @@ function cleanup_apt() {
     local remove_var_lib_apt_lists=$1
     apt-get autoremove -y && rm -rf "$HOME"/.cache
     if [[ "$remove_var_lib_apt_lists" = true ]]; then
-        echo "----------------------------------------"
-        echo "Removing /var/lib/apt/lists/*"
-        echo "----------------------------------------"
         rm -rf /var/lib/apt/lists/*
     fi
 }

--- a/docker/scripts/cleanup_apt.sh
+++ b/docker/scripts/cleanup_apt.sh
@@ -3,7 +3,7 @@
 function cleanup_apt() {
     local remove_var_lib_apt_lists=$1
     apt-get autoremove -y && rm -rf "$HOME"/.cache
-    if [[ "$remove_var_lib_apt_lists" = true ]]; then
+    if [[ $remove_var_lib_apt_lists == true ]]; then
         rm -rf /var/lib/apt/lists/*
     fi
 }

--- a/docker/scripts/cleanup_apt.sh
+++ b/docker/scripts/cleanup_apt.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-function cleanup() {
+function cleanup_apt() {
     local remove_var_lib_apt_lists=false
     apt-get autoremove -y && rm -rf "$HOME"/.cache
     if "$remove_var_lib_apt_lists"; then
+        echo "----------------------------------------"
+        echo "Removing /var/lib/apt/lists/*"
+        echo "----------------------------------------"
         rm -rf /var/lib/apt/lists/*
     fi
 }
 
-cleanup "$@"
+cleanup_apt "$@"


### PR DESCRIPTION
## Description

There was a bug in the handling of arguments in `cleanup_apt.sh` in https://github.com/autowarefoundation/autoware/pull/5447. This PR fixes it.
This resolves the unintended increase in container image sizes.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
