### PR TITLE
feat(.github): disable cache mode with `mode=max` for CUDA jobs only

### DIFF
--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -109,7 +109,7 @@ jobs:
             *.args.LIB_DIR=aarch64
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:arm64-${{ github.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:arm64-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:arm64-${{ github.ref_name }},mode=max
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:arm64-${{ github.ref_name }}
 
       - name: Show disk space
         if: always()

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -104,7 +104,7 @@ jobs:
             *.args.LIB_DIR=x86_64
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:amd64-${{ github.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:amd64-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:amd64-${{ github.ref_name }},mode=max
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:amd64-${{ github.ref_name }}
 
       - name: Show disk space
         if: always()


### PR DESCRIPTION
## Description

Recently, `arm64` self-hosted runners have increased disk size, making builds more reliably successful, but `amd64` GitHub runners have started failing due to disk exhaustion.
https://github.com/autowarefoundation/autoware/actions/workflows/docker-build-and-push.yaml
https://github.com/autowarefoundation/autoware/actions/workflows/docker-build-and-push-arm64.yaml

This is thought to be due to the docker build cache bloating, especially because layers containing CUDA libraries consume significant disk space during compression and decompression. 
Therefore, this PR removes the `mode=max` mode from the `cache-to` option for CUDA jobs only. As a result, the entire image layers will no longer be cached, and only the final layer will be cached.
https://docs.docker.com/build/cache/backends/#cache-mode

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/11965483510
https://github.com/autowarefoundation/autoware/actions/runs/11965490279

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
