### PR TITLE
feat(docker): introduce `autoware-base` images

### DIFF
--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -1,0 +1,63 @@
+name: docker-build-and-push-base
+description: Composite action to build and push base images to registry.
+
+inputs:
+  target-image:
+    description: Target docker image name in the registry.
+    required: true
+  build-args:
+    description: Additional build args.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Docker meta for autoware-base:latest
+      id: meta-base
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=${{ steps.date.outputs.date }}
+        bake-target: docker-metadata-action-base
+        flavor: |
+          latest=true
+
+    - name: Docker meta for autoware-base:latest-cuda
+      id: meta-base-cuda
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=latest-cuda
+          type=raw,value=cuda-${{ steps.date.outputs.date }}
+        bake-target: docker-metadata-action-base-cuda
+        flavor: |
+          latest=false
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+
+    - name: Build and Push to GitHub Container Registry
+      uses: docker/bake-action@v5
+      with:
+        push: true
+        files: |
+          docker/docker-bake.hcl
+          ${{ steps.meta-base.outputs.bake-file }}
+          ${{ steps.meta-base-cuda.outputs.bake-file }}
+        provenance: false
+        set: |
+          ${{ inputs.build-args }}

--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -55,7 +55,7 @@ runs:
       with:
         push: true
         files: |
-          docker/docker-bake.hcl
+          docker/docker-bake-base.hcl
           ${{ steps.meta-base.outputs.bake-file }}
           ${{ steps.meta-base-cuda.outputs.bake-file }}
         provenance: false

--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -31,7 +31,7 @@ runs:
         flavor: |
           latest=true
 
-    - name: Docker meta for autoware-base:latest-cuda
+    - name: Docker meta for autoware-base:cuda-latest
       id: meta-base-cuda
       uses: docker/metadata-action@v5
       with:

--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -37,7 +37,7 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=latest-cuda
+          type=raw,value=cuda-latest
           type=raw,value=cuda-${{ steps.date.outputs.date }}
         bake-target: docker-metadata-action-base-cuda
         flavor: |

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -14,7 +14,7 @@ jobs:
 
   docker-build-and-push-base:
     needs: load-env
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Check out this repository
         uses: actions/checkout@v4

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -11,7 +11,7 @@ jobs:
 
   docker-build-and-push-base:
     needs: load-env
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out this repository
         uses: actions/checkout@v4

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -1,10 +1,8 @@
 name: autoware-base
 
 on:
-  push:
-    branches:
-      - main
-    tags:
+  schedule:
+    - cron: 0 0 15 * *  # every 15th of the month
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -33,5 +33,6 @@ jobs:
         with:
           target-image: autoware-base
           build-args: |
+            *.platform=linux/amd64,linux/arm64
             *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -1,0 +1,38 @@
+name: autoware-base
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+  workflow_dispatch:
+
+jobs:
+  load-env:
+    uses: ./.github/workflows/load-env.yaml
+
+  docker-build-and-push:
+    needs: load-env
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out this repository
+        uses: actions/checkout@v4
+
+      - name: Check out autowarefoundation/autoware repository
+        uses: actions/checkout@v4
+        with:
+          repository: autowarefoundation/autoware
+          path: 'autoware'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build Autoware's base images
+        uses: ./.github/actions/docker-build-and-push-base
+        with:
+          name: autoware-base
+          target-image: docker-bake-base.hcl
+          build-args: |
+            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
+          tag-prefix: ${{ needs.load-env.outputs.rosdistro }}

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -31,9 +31,7 @@ jobs:
       - name: Build Autoware's base images
         uses: ./.github/actions/docker-build-and-push-base
         with:
-          name: autoware-base
-          target-image: docker-bake-base.hcl
+          target-image: autoware-base
           build-args: |
             *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
-          tag-prefix: ${{ needs.load-env.outputs.rosdistro }}

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -2,7 +2,7 @@ name: autoware-base
 
 on:
   schedule:
-    - cron: 0 0 15 * *  # every 15th of the month
+    - cron: 0 0 15 * * # every 15th of the month
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -19,12 +19,6 @@ jobs:
       - name: Check out this repository
         uses: actions/checkout@v4
 
-      - name: Check out autowarefoundation/autoware repository
-        uses: actions/checkout@v4
-        with:
-          repository: autowarefoundation/autoware
-          path: 'autoware'
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -1,7 +1,6 @@
 name: autoware-base
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -12,7 +12,7 @@ jobs:
   load-env:
     uses: ./.github/workflows/load-env.yaml
 
-  docker-build-and-push:
+  docker-build-and-push-base:
     needs: load-env
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -1,6 +1,7 @@
 name: autoware-base
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,6 @@ RUN --mount=type=ssh \
 # Create entrypoint
 COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
 RUN chmod +x /ros_entrypoint.sh
-ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
 FROM base AS base-cuda

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -34,7 +34,6 @@ RUN --mount=type=ssh \
 # Create entrypoint
 COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
 RUN chmod +x /ros_entrypoint.sh
-ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
 FROM base AS base-cuda

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,48 @@
+ARG BASE_IMAGE
+
+# hadolint ignore=DL3006
+FROM $BASE_IMAGE AS base
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+
+# Copy files
+COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /autoware/
+COPY ansible/ /autoware/ansible/
+COPY docker/scripts/cleanup_apt.sh /autoware/cleanup_apt.sh
+RUN chmod +x /autoware/cleanup_apt.sh
+WORKDIR /autoware
+
+# Install apt packages and add GitHub to known hosts for private repositories
+RUN rm -f /etc/apt/apt.conf.d/docker-clean \
+  && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  gosu \
+  ssh \
+  && /autoware/cleanup_apt.sh \
+  && mkdir -p ~/.ssh \
+  && ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# Set up base environment
+RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  ./setup-dev-env.sh -y --module base --no-nvidia --no-cuda-drivers --runtime openadkit \
+  && pip uninstall -y ansible ansible-core \
+  && /autoware/cleanup_apt.sh \
+  && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc
+
+# Create entrypoint
+COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
+RUN chmod +x /ros_entrypoint.sh
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
+FROM base AS base-cuda
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set up CUDA runtime environment and artifacts
+# hadolint ignore=SC2002
+RUN --mount=type=ssh \
+  ./setup-dev-env.sh -y --module base --download-artifacts --no-cuda-drivers --runtime openadkit \
+  && pip uninstall -y ansible ansible-core \
+  && /autoware/cleanup_apt.sh true

--- a/docker/docker-bake-base.hcl
+++ b/docker/docker-bake-base.hcl
@@ -1,0 +1,22 @@
+group "default" {
+  targets = [
+    "base",
+    "base-cuda"
+  ]
+}
+
+// For docker/metadata-action
+target "docker-metadata-action-base" {}
+target "docker-metadata-action-base-cuda" {}
+
+target "base" {
+  inherits = ["docker-metadata-action-base"]
+  dockerfile = "docker/Dockerfile.base"
+  target = "base"
+}
+
+target "base-cuda" {
+  inherits = ["docker-metadata-action-base-cuda"]
+  dockerfile = "docker/Dockerfile.base"
+  target = "base-cuda"
+}


### PR DESCRIPTION
## Description

To improve the efficiency of container builds and enhance readability in the `Dockerfile`, this PR is introducing the `autoware-base` images as the base image for the `autoware` images.
The `autoware-base` image is scheduled to be updated only once a month.

The resulting images will be as follows:
https://github.com/youtalk/autoware/pkgs/container/autoware-base

However, the `autoware-base` image has not yet been configured to be used for building the `autoware` image, so there are no side effects at this point. This will be implemented in the next PR.

## Tests performed

https://github.com/youtalk/autoware/actions/runs/11971168497/job/33375410665

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
