### PR TITLE
chore(autoware.repos): fix `autoware.universe` and `autoware_launch` versions to `0.39.0`

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -38,7 +38,7 @@ runs:
     - name: Import additional repositories
       if: ${{ inputs.additional-repos != '' }}
       run: |
-        vcs import src < ${{ inputs.additional-repos }}
+        vcs import --force src < ${{ inputs.additional-repos }}
       shell: bash
 
     - name: Cache ccache

--- a/autoware.repos
+++ b/autoware.repos
@@ -37,6 +37,7 @@ repositories:
   # universe
   universe/autoware.universe:
     type: git
+    # TODO(youtalk): MUST REVERT
     url: https://github.com/youtalk/autoware.universe.git
     version: release-0.39.0
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
@@ -79,6 +80,7 @@ repositories:
   # launcher
   launcher/autoware_launch:
     type: git
+    # TODO(youtalk): MUST REVERT
     url: https://github.com/youtalk/autoware_launch.git
     version: release-0.39.0
   # sensor_component

--- a/autoware.repos
+++ b/autoware.repos
@@ -37,9 +37,8 @@ repositories:
   # universe
   universe/autoware.universe:
     type: git
-    # TODO(youtalk): MUST REVERT
-    url: https://github.com/youtalk/autoware.universe.git
-    version: release-0.39.0
+    url: https://github.com/autowarefoundation/autoware.universe.git
+    version: 0.39.0
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
@@ -80,9 +79,8 @@ repositories:
   # launcher
   launcher/autoware_launch:
     type: git
-    # TODO(youtalk): MUST REVERT
-    url: https://github.com/youtalk/autoware_launch.git
-    version: release-0.39.0
+    url: https://github.com/autowarefoundation/autoware_launch.git
+    version: 0.39.0
   # sensor_component
   sensor_component/external/sensor_component_description:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -37,8 +37,8 @@ repositories:
   # universe
   universe/autoware.universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
-    version: main
+    url: https://github.com/youtalk/autoware.universe.git
+    version: release-0.39.0
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
@@ -79,8 +79,8 @@ repositories:
   # launcher
   launcher/autoware_launch:
     type: git
-    url: https://github.com/autowarefoundation/autoware_launch.git
-    version: main
+    url: https://github.com/youtalk/autoware_launch.git
+    version: release-0.39.0
   # sensor_component
   sensor_component/external/sensor_component_description:
     type: git


### PR DESCRIPTION
## Description

This PR is the `0.39.0` version of https://github.com/autowarefoundation/autoware/pull/5435

- [x] https://github.com/autowarefoundation/autoware.universe/pull/9435
- [x] https://github.com/autowarefoundation/autoware_launch/pull/1248
- [x] https://github.com/autowarefoundation/autoware/pull/5478

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
