### PR TITLE
feat(.github): separate `autoware-base` jobs

### DIFF
--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -9,8 +9,24 @@ jobs:
   load-env:
     uses: ./.github/workflows/load-env.yaml
 
-  docker-build-and-push-base:
+  autoware-base-amd64:
     needs: load-env
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out this repository
+        uses: actions/checkout@v4
+
+      - name: Build Autoware's base images
+        uses: ./.github/actions/docker-build-and-push-base
+        with:
+          target-image: autoware-base
+          build-args: |
+            *.platform=linux/amd64
+            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
+
+  autoware-base-arm64:
+    needs: [load-env, autoware-base-amd64]
     runs-on: ubuntu-22.04
     steps:
       - name: Check out this repository
@@ -24,6 +40,6 @@ jobs:
         with:
           target-image: autoware-base
           build-args: |
-            *.platform=linux/amd64,linux/arm64
+            *.platform=linux/arm64
             *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Check out this repository
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Build Autoware's base images
         uses: ./.github/actions/docker-build-and-push-base
         with:
@@ -31,6 +34,9 @@ jobs:
     steps:
       - name: Check out this repository
         uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -10,6 +10,8 @@ COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /auto
 COPY ansible/ /autoware/ansible/
 COPY docker/scripts/cleanup_apt.sh /autoware/cleanup_apt.sh
 RUN chmod +x /autoware/cleanup_apt.sh
+COPY docker/scripts/cleanup_system.sh /autoware/cleanup_system.sh
+RUN chmod +x /autoware/cleanup_system.sh
 WORKDIR /autoware
 
 # Install apt packages and add GitHub to known hosts for private repositories


### PR DESCRIPTION
## Description

- [x] https://github.com/autowarefoundation/autoware/pull/5482

Unfortunately, it was found that multi-architecture builds using QEMU with Docker Buildx Bake caused disk exhaustion on GitHub runners. https://github.com/autowarefoundation/autoware/actions/runs/12005064895
Therefore, instead of building in parallel, this PR changed the process to build `amd64` images in the first job and then build `arm64` images in the next job.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/12022444110

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
