### PR TITLE
feat(.github): run `free-disk-space` action on `autoware-base` workflow

### DIFF
--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Check out this repository
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -10,6 +10,8 @@ COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /auto
 COPY ansible/ /autoware/ansible/
 COPY docker/scripts/cleanup_apt.sh /autoware/cleanup_apt.sh
 RUN chmod +x /autoware/cleanup_apt.sh
+COPY docker/scripts/cleanup_system.sh /autoware/cleanup_system.sh
+RUN chmod +x /autoware/cleanup_system.sh
 WORKDIR /autoware
 
 # Install apt packages and add GitHub to known hosts for private repositories


### PR DESCRIPTION
## Description

- [ ] https://github.com/autowarefoundation/autoware/pull/5482

Unfortunately, it was found that multi-architecture builds using QEMU with Docker Buildx Bake caused disk exhaustion on GitHub runners. https://github.com/autowarefoundation/autoware/actions/runs/12005064895
Therefore, this PR runs `free-disk-space` action before building the images.

## Tests performed

https://github.com/autowarefoundation/autoware/actions/runs/12022618607

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
