### PR TITLE
ci(spell-check-diff): add explicit dict-packages

### DIFF
--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -14,3 +14,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
           cspell-json-url: https://raw.githubusercontent.com/autowarefoundation/autoware-spell-check-dict/main/.cspell.json
+          dict-packages: |
+            https://github.com/autowarefoundation/autoware-spell-check-dict
+            https://github.com/tier4/cspell-dicts
+            https://github.com/streetsidesoftware/cspell-dicts

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -17,7 +17,3 @@ jobs:
           dict-packages: |
             https://github.com/autowarefoundation/autoware-spell-check-dict
             https://github.com/tier4/cspell-dicts
-            @cspell/dict-cpp
-            @cspell/dict-en_gb
-            @cspell/dict-en_us
-            @cspell/dict-software-terms

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -17,7 +17,7 @@ jobs:
           dict-packages: |
             https://github.com/autowarefoundation/autoware-spell-check-dict
             https://github.com/tier4/cspell-dicts
-            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/cpp
-            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en_GB
-            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en_US
-            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/software-terms
+            @cspell/dict-cpp
+            @cspell/dict-en_gb
+            @cspell/dict-en_us
+            @cspell/dict-software-terms

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -17,4 +17,7 @@ jobs:
           dict-packages: |
             https://github.com/autowarefoundation/autoware-spell-check-dict
             https://github.com/tier4/cspell-dicts
-            https://github.com/streetsidesoftware/cspell-dicts
+            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/cpp
+            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en_GB
+            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/en_US
+            https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/software-terms


### PR DESCRIPTION
## Description

Related section:

https://github.com/autowarefoundation/autoware-github-actions/blob/196ca1d50eef0fc7b898d85f7ccfe17b3c0e97b4/spell-check/action.yaml#L12-L17

> ```yaml
>   dict-packages:
>     description: ""
>     required: false
>     default: |
>       https://github.com/tier4/autoware-spell-check-dict
>       https://github.com/tier4/cspell-dicts
> ```

These packages are being installed by https://github.com/autowarefoundation/autoware-github-actions/blob/196ca1d50eef0fc7b898d85f7ccfe17b3c0e97b4/spell-check/action.yaml#L32 as npm packages.

This PR adds the correct repository links.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
