### PR TITLE
ci(sync-files): make use of sync-files-templates repo

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -14,18 +14,8 @@
       dest: .github/stale.yml
     - source: sources/.github/workflows/cancel-previous-workflows.yaml
       dest: .github/workflows/cancel-previous-workflows.yaml
-    - source: sources/.github/workflows/check-build-depends.yaml
-      dest: .github/workflows/check-build-depends.yaml
-    - source: sources/.github/workflows/clang-tidy-pr-comments.yaml
-      dest: .github/workflows/clang-tidy-pr-comments.yaml
-    - source: sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
-      dest: .github/workflows/clang-tidy-pr-comments-manually.yaml
     - source: sources/.github/workflows/comment-on-pr.yaml
       dest: .github/workflows/comment-on-pr.yaml
-    - source: sources/.github/workflows/delete-closed-pr-docs.yaml
-      dest: .github/workflows/delete-closed-pr-docs.yaml
-    - source: sources/.github/workflows/deploy-docs.yaml
-      dest: .github/workflows/deploy-docs.yaml
     - source: sources/.github/workflows/github-release.yaml
       dest: .github/workflows/github-release.yaml
     - source: sources/.github/workflows/pr-agent.yaml
@@ -34,8 +24,6 @@
       dest: .github/workflows/pre-commit-optional.yaml
     - source: sources/.github/workflows/pre-commit-optional-autoupdate.yaml
       dest: .github/workflows/pre-commit-optional-autoupdate.yaml
-    - source: sources/.github/workflows/pre-commit.yaml
-      dest: .github/workflows/pre-commit.yaml
     - source: sources/.github/workflows/pre-commit-autoupdate.yaml
       dest: .github/workflows/pre-commit-autoupdate.yaml
     - source: sources/.github/workflows/semantic-pull-request.yaml
@@ -46,8 +34,6 @@
       dest: .github/workflows/spell-check-daily.yaml
     - source: sources/.github/workflows/sync-files.yaml
       dest: .github/workflows/sync-files.yaml
-    - source: sources/.github/workflows/update-codeowners-from-packages.yaml
-      dest: .github/workflows/update-codeowners-from-packages.yaml
     - source: sources/.clang-format
       dest: .clang-format
     - source: sources/.clang-tidy
@@ -68,8 +54,6 @@
       dest: .yamllint.yaml
     - source: sources/CODE_OF_CONDUCT.md
       dest: CODE_OF_CONDUCT.md
-    - source: sources/codecov.yaml
-      dest: codecov.yaml
     - source: sources/CONTRIBUTING.md
       dest: CONTRIBUTING.md
     - source: sources/CPPLINT.cfg

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -18,8 +18,6 @@
       dest: .github/workflows/comment-on-pr.yaml
     - source: sources/.github/workflows/github-release.yaml
       dest: .github/workflows/github-release.yaml
-    - source: sources/.github/workflows/pr-agent.yaml
-      dest: .github/workflows/pr-agent.yaml
     - source: sources/.github/workflows/pre-commit-optional.yaml
       dest: .github/workflows/pre-commit-optional.yaml
     - source: sources/.github/workflows/pre-commit-optional-autoupdate.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -1,0 +1,82 @@
+- repository: autowarefoundation/sync-file-templates
+  files:
+    - source: sources/.github/ISSUE_TEMPLATE/bug.yaml
+      dest: .github/ISSUE_TEMPLATE/bug.yaml
+    - source: sources/.github/ISSUE_TEMPLATE/config.yml
+      dest: .github/ISSUE_TEMPLATE/config.yml
+    - source: sources/.github/ISSUE_TEMPLATE/task.yaml
+      dest: .github/ISSUE_TEMPLATE/task.yaml
+    - source: sources/.github/dependabot.yaml
+      dest: .github/dependabot.yaml
+    - source: sources/.github/pull_request_template.md
+      dest: .github/pull_request_template.md
+    - source: sources/.github/stale.yml
+      dest: .github/stale.yml
+    - source: sources/.github/workflows/cancel-previous-workflows.yaml
+      dest: .github/workflows/cancel-previous-workflows.yaml
+    - source: sources/.github/workflows/check-build-depends.yaml
+      dest: .github/workflows/check-build-depends.yaml
+    - source: sources/.github/workflows/clang-tidy-pr-comments.yaml
+      dest: .github/workflows/clang-tidy-pr-comments.yaml
+    - source: sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
+      dest: .github/workflows/clang-tidy-pr-comments-manually.yaml
+    - source: sources/.github/workflows/comment-on-pr.yaml
+      dest: .github/workflows/comment-on-pr.yaml
+    - source: sources/.github/workflows/delete-closed-pr-docs.yaml
+      dest: .github/workflows/delete-closed-pr-docs.yaml
+    - source: sources/.github/workflows/deploy-docs.yaml
+      dest: .github/workflows/deploy-docs.yaml
+    - source: sources/.github/workflows/github-release.yaml
+      dest: .github/workflows/github-release.yaml
+    - source: sources/.github/workflows/pr-agent.yaml
+      dest: .github/workflows/pr-agent.yaml
+    - source: sources/.github/workflows/pre-commit-optional.yaml
+      dest: .github/workflows/pre-commit-optional.yaml
+    - source: sources/.github/workflows/pre-commit-optional-autoupdate.yaml
+      dest: .github/workflows/pre-commit-optional-autoupdate.yaml
+    - source: sources/.github/workflows/pre-commit.yaml
+      dest: .github/workflows/pre-commit.yaml
+    - source: sources/.github/workflows/pre-commit-autoupdate.yaml
+      dest: .github/workflows/pre-commit-autoupdate.yaml
+    - source: sources/.github/workflows/semantic-pull-request.yaml
+      dest: .github/workflows/semantic-pull-request.yaml
+    - source: sources/.github/workflows/spell-check-differential.yaml
+      dest: .github/workflows/spell-check-differential.yaml
+    - source: sources/.github/workflows/spell-check-daily.yaml
+      dest: .github/workflows/spell-check-daily.yaml
+    - source: sources/.github/workflows/sync-files.yaml
+      dest: .github/workflows/sync-files.yaml
+    - source: sources/.github/workflows/update-codeowners-from-packages.yaml
+      dest: .github/workflows/update-codeowners-from-packages.yaml
+    - source: sources/.clang-format
+      dest: .clang-format
+    - source: sources/.clang-tidy
+      dest: .clang-tidy
+    - source: sources/.markdown-link-check.json
+      dest: .markdown-link-check.json
+    - source: sources/.markdownlint.yaml
+      dest: .markdownlint.yaml
+    - source: sources/.pre-commit-config-optional.yaml
+      dest: .pre-commit-config-optional.yaml
+    - source: sources/.pre-commit-config.yaml
+      dest: .pre-commit-config.yaml
+    - source: sources/.prettierignore
+      dest: .prettierignore
+    - source: sources/.prettierrc.yaml
+      dest: .prettierrc.yaml
+    - source: sources/.yamllint.yaml
+      dest: .yamllint.yaml
+    - source: sources/CODE_OF_CONDUCT.md
+      dest: CODE_OF_CONDUCT.md
+    - source: sources/codecov.yaml
+      dest: codecov.yaml
+    - source: sources/CONTRIBUTING.md
+      dest: CONTRIBUTING.md
+    - source: sources/CPPLINT.cfg
+      dest: CPPLINT.cfg
+    - source: sources/DISCLAIMER.md
+      dest: DISCLAIMER.md
+    - source: sources/LICENSE
+      dest: LICENSE
+    - source: sources/setup.cfg
+      dest: setup.cfg


### PR DESCRIPTION
## Description

Parent issue:
- https://github.com/autowarefoundation/autoware/issues/4058

**Reference:** https://github.com/autowarefoundation/sync-file-templates

Before this PR, many sync-file configs make use of this [autoware](https://github.com/autowarefoundation/autoware), archived [autoware_common](https://github.com/autowarefoundation/autoware_common) and [autoware-documentation](https://github.com/autowarefoundation/autoware-documentation) repositories as the source of their basic files.

Starting with this PR, I plan to make use of only a single source file for the sync-files called https://github.com/autowarefoundation/sync-file-templates
This repository was created by @isamu-takagi -san for this purpose.
I've updated it and want to keep using across autoware repositories.

### Changes

This PR specifically generates the following changes:

#### PR template

![image](https://github.com/user-attachments/assets/8899b902-eff2-464e-96df-7af9db31ce69)

Simplifies it by using the basic version. The contributors can just add the links under the description, no need to clutter.

#### Spell check daily

We already had a spell-check-differential.

This adds the daily version, taken from https://github.com/autowarefoundation/autoware.universe/blob/main/.github/workflows/spell-check-daily.yaml but with updated dictionaries.

Should be useful for assessing the overall spell-check coverage.

#### pre-commit configs

Mainly taken from autoware.universe, but including the hadolint from this repository.

It removes the `.svg` file exclusion from the config file.

Past blame: https://github.com/autowarefoundation/autoware_core_universe_prototype/pull/5/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R93

I don't see a reason to exclude .svg files from pre-commit, it makes svg files more readable. I've looked for why it was excluded but it has been like this since first 5th PR to this repository. Most of the changes are just reformatted svg files.

## How was this PR tested?

- https://github.com/autowarefoundation/autoware/pull/5505
  - https://github.com/autowarefoundation/autoware/pull/5505/files

## Notes for reviewers

None.

## Effects on system behavior

None.
