### PR TITLE
ci: use AWS CodeBuild to run docker-build-and-push-cuda (#5475)

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -65,7 +65,7 @@ jobs:
 
   docker-build-and-push-cuda:
     needs: [load-env, docker-build-and-push]
-    runs-on: ubuntu-22.04
+    runs-on: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

The handling of the APT cache was improved in https://github.com/autowarefoundation/autoware/pull/5497, freeing up disk space and allowing us to stop using the CodeBuild which was introduced in https://github.com/autowarefoundation/autoware/pull/5475. However, it became apparent that disk errors can still occur depending on the state of the Docker build cache.

Therefore, this PR resumes using the CodeBuild until the disk size issue is fundamentally resolved.

## Related links

- Using `ubuntu-22.04`: https://github.com/autowarefoundation/autoware/actions/runs/12069154954
- Using `CodeBuild`: https://github.com/autowarefoundation/autoware/actions/runs/12078829156

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
