### PR TITLE
feat(.github): push version tag images

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -72,6 +72,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-devel-cuda-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-devel-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-sensing-perception-devel-cuda-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-devel-cuda
         flavor: |
           latest=false
@@ -84,6 +85,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-cuda-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-sensing-perception-cuda-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-cuda
         flavor: |
           latest=false
@@ -96,6 +98,7 @@ runs:
         tags: |
           type=raw,value=universe-devel-cuda-${{ inputs.platform }}
           type=raw,value=universe-devel-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-devel-cuda-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-devel-cuda
         flavor: |
           latest=false
@@ -108,6 +111,7 @@ runs:
         tags: |
           type=raw,value=universe-cuda-${{ inputs.platform }}
           type=raw,value=universe-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-cuda-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-cuda
         flavor: |
           latest=auto

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -72,7 +72,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-devel-cuda-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-devel-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-sensing-perception-devel-cuda-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception-devel-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-devel-cuda
         flavor: |
           latest=false
@@ -85,7 +85,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-cuda-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-sensing-perception-cuda-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-cuda
         flavor: |
           latest=false
@@ -98,7 +98,7 @@ runs:
         tags: |
           type=raw,value=universe-devel-cuda-${{ inputs.platform }}
           type=raw,value=universe-devel-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-devel-cuda-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-devel-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-devel-cuda
         flavor: |
           latest=false
@@ -111,10 +111,10 @@ runs:
         tags: |
           type=raw,value=universe-cuda-${{ inputs.platform }}
           type=raw,value=universe-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-cuda-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-cuda
         flavor: |
-          latest=auto
+          latest=false
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -72,7 +72,7 @@ runs:
         tags: |
           type=raw,value=core-devel-${{ inputs.platform }}
           type=raw,value=core-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=core-devel-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=core-devel-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-core-devel
         flavor: |
           latest=false
@@ -85,7 +85,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-devel-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-sensing-perception-devel-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception-devel-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-devel
         flavor: |
           latest=false
@@ -98,7 +98,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-sensing-perception-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception
         flavor: |
           latest=false
@@ -111,7 +111,7 @@ runs:
         tags: |
           type=raw,value=universe-localization-mapping-devel-${{ inputs.platform }}
           type=raw,value=universe-localization-mapping-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-localization-mapping-devel-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-localization-mapping-devel-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-localization-mapping-devel
         flavor: |
           latest=false
@@ -124,7 +124,7 @@ runs:
         tags: |
           type=raw,value=universe-localization-mapping-${{ inputs.platform }}
           type=raw,value=universe-localization-mapping-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-localization-mapping-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-localization-mapping-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-localization-mapping
         flavor: |
           latest=false
@@ -137,7 +137,7 @@ runs:
         tags: |
           type=raw,value=universe-planning-control-devel-${{ inputs.platform }}
           type=raw,value=universe-planning-control-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-planning-control-devel-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-planning-control-devel-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-planning-control-devel
         flavor: |
           latest=false
@@ -150,7 +150,7 @@ runs:
         tags: |
           type=raw,value=universe-planning-control-${{ inputs.platform }}
           type=raw,value=universe-planning-control-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-planning-control-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-planning-control-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-planning-control
         flavor: |
           latest=false
@@ -163,7 +163,7 @@ runs:
         tags: |
           type=raw,value=universe-vehicle-system-devel-${{ inputs.platform }}
           type=raw,value=universe-vehicle-system-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-vehicle-system-devel-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-vehicle-system-devel-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-vehicle-system-devel
         flavor: |
           latest=false
@@ -176,7 +176,7 @@ runs:
         tags: |
           type=raw,value=universe-vehicle-system-${{ inputs.platform }}
           type=raw,value=universe-vehicle-system-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-vehicle-system-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-vehicle-system-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-vehicle-system
         flavor: |
           latest=false
@@ -189,7 +189,7 @@ runs:
         tags: |
           type=raw,value=universe-devel-${{ inputs.platform }}
           type=raw,value=universe-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-devel-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-devel-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-devel
         flavor: |
           latest=false
@@ -202,7 +202,7 @@ runs:
         tags: |
           type=raw,value=universe-${{ inputs.platform }}
           type=raw,value=universe-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,value=universe-${{ github.ref_name }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe
         flavor: |
           latest=auto

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -72,6 +72,7 @@ runs:
         tags: |
           type=raw,value=core-devel-${{ inputs.platform }}
           type=raw,value=core-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=core-devel-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-core-devel
         flavor: |
           latest=false
@@ -84,6 +85,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-devel-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-sensing-perception-devel-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-devel
         flavor: |
           latest=false
@@ -96,6 +98,7 @@ runs:
         tags: |
           type=raw,value=universe-sensing-perception-${{ inputs.platform }}
           type=raw,value=universe-sensing-perception-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-sensing-perception-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception
         flavor: |
           latest=false
@@ -108,6 +111,7 @@ runs:
         tags: |
           type=raw,value=universe-localization-mapping-devel-${{ inputs.platform }}
           type=raw,value=universe-localization-mapping-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-localization-mapping-devel-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-localization-mapping-devel
         flavor: |
           latest=false
@@ -120,6 +124,7 @@ runs:
         tags: |
           type=raw,value=universe-localization-mapping-${{ inputs.platform }}
           type=raw,value=universe-localization-mapping-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-localization-mapping-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-localization-mapping
         flavor: |
           latest=false
@@ -132,6 +137,7 @@ runs:
         tags: |
           type=raw,value=universe-planning-control-devel-${{ inputs.platform }}
           type=raw,value=universe-planning-control-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-planning-control-devel-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-planning-control-devel
         flavor: |
           latest=false
@@ -144,6 +150,7 @@ runs:
         tags: |
           type=raw,value=universe-planning-control-${{ inputs.platform }}
           type=raw,value=universe-planning-control-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-planning-control-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-planning-control
         flavor: |
           latest=false
@@ -156,6 +163,7 @@ runs:
         tags: |
           type=raw,value=universe-vehicle-system-devel-${{ inputs.platform }}
           type=raw,value=universe-vehicle-system-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-vehicle-system-devel-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-vehicle-system-devel
         flavor: |
           latest=false
@@ -168,6 +176,7 @@ runs:
         tags: |
           type=raw,value=universe-vehicle-system-${{ inputs.platform }}
           type=raw,value=universe-vehicle-system-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-vehicle-system-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-vehicle-system
         flavor: |
           latest=false
@@ -180,6 +189,7 @@ runs:
         tags: |
           type=raw,value=universe-devel-${{ inputs.platform }}
           type=raw,value=universe-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-devel-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-devel
         flavor: |
           latest=false
@@ -192,6 +202,7 @@ runs:
         tags: |
           type=raw,value=universe-${{ inputs.platform }}
           type=raw,value=universe-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,value=universe-${{ github.ref_name }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe
         flavor: |
           latest=auto

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - *.*.*
+      - "*.*.*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     tags:
+      - *.*.*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - *.*.*
+      - "*.*.*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     tags:
+      - *.*.*
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

This PR creates container images tagged with the version tag instead of the date when the `*.*.*` version tag is pushed.

## How was this PR tested?

- https://github.com/youtalk/autoware/pull/150
- https://github.com/youtalk/autoware/actions/runs/12114386401
- https://hub.docker.com/repository/docker/youtalk/autoware/tags?name=0.38.0

## Notes for reviewers

None.

## Effects on system behavior

Once this PR is merged, the `0.39.0` tag will be pushed.
