### PR TITLE
fix(.github): not push manifest if eithor `amd64` or `arm64` image is missing

### DIFF
--- a/.github/actions/combine-multi-arch-images/action.yaml
+++ b/.github/actions/combine-multi-arch-images/action.yaml
@@ -82,14 +82,14 @@ runs:
             amd64_image="${{ steps.set-image-name.outputs.image-name }}:$amd64_tag"
           else
             echo "No amd64 tag found for '$base_tag'."
-            amd64_image=""
+            continue
           fi
 
           if [ "$arm64_tag" != "" ]; then
             arm64_image="${{ steps.set-image-name.outputs.image-name }}:$arm64_tag"
           else
             echo "No arm64 tag found for '$base_tag'."
-            arm64_image=""
+            continue
           fi
 
           echo "amd64_image: $amd64_image"


### PR DESCRIPTION
## Description

When pushing the `docker manifest` for multi-architecture images, this PR does not push if either the `amd64` image or the `arm64` image is missing as following.

https://github.com/autowarefoundation/autoware/actions/runs/12130229119/job/33820159404#step:3:566
```
base_tag: universe-cuda
amd64_tag: 
arm64_tag: universe-cuda-arm64
No amd64 tag found for 'universe-cuda'.
amd64_image: 
arm64_image: ghcr.io/autowarefoundation/autoware:universe-cuda-arm64
Created manifest list ghcr.io/autowarefoundation/autoware:universe-cuda
sha256:eb74c92f9dc29ed2887924117bb97cfbd52653da50be6ccc003c7b85849f6aee
```

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
