### PR TITLE
feat(.git): delete `-amd64` and  `-arm64` image tags after pushing manifest

### DIFF
--- a/.github/actions/combine-multi-arch-images/action.yaml
+++ b/.github/actions/combine-multi-arch-images/action.yaml
@@ -82,14 +82,14 @@ runs:
             amd64_image="${{ steps.set-image-name.outputs.image-name }}:$amd64_tag"
           else
             echo "No amd64 tag found for '$base_tag'."
-            amd64_image=""
+            continue
           fi
 
           if [ "$arm64_tag" != "" ]; then
             arm64_image="${{ steps.set-image-name.outputs.image-name }}:$arm64_tag"
           else
             echo "No arm64 tag found for '$base_tag'."
-            arm64_image=""
+            continue
           fi
 
           echo "amd64_image: $amd64_image"

--- a/.github/actions/combine-multi-arch-images/action.yaml
+++ b/.github/actions/combine-multi-arch-images/action.yaml
@@ -67,7 +67,7 @@ runs:
         ALL_TAGS: ${{ steps.get-all-tags.outputs.tags }}
       shell: bash
 
-    - name: Create Docker manifest
+    - name: Create Docker manifest and delete -amd64 and -arm64 tags
       run: |
         for base_tag in $BASE_TAGS; do
           echo -e "\nbase_tag: $base_tag"
@@ -100,6 +100,16 @@ runs:
             $arm64_image; then
 
             docker manifest push ${{ steps.set-image-name.outputs.image-name }}:$base_tag
+
+            # Delete amd64_image and arm64_image
+            curl -X DELETE \
+              -H "Authorization: Bearer ${{ github.token }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ inputs.package-name }}/versions/$amd64_tag
+            curl -X DELETE \
+              -H "Authorization: Bearer ${{ github.token }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ inputs.package-name }}/versions/$arm64_tag
           fi
         done
       env:


### PR DESCRIPTION
## Description

- [x] #5525 

This PR deletes the `-amd64` and `-arm64` image tags after the manifest for the multi-architecture image has been pushed.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
