### PR TITLE
chore(autoware.repos): fix autoware.core commit hash

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -33,7 +33,7 @@ repositories:
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
-    version: df9cd361d74f61de5aa7b800e5fba576755ac3eb
+    version: 0.0.0
   # universe
   universe/autoware.universe:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -33,7 +33,7 @@ repositories:
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
-    version: main
+    version: df9cd361d74f61de5aa7b800e5fba576755ac3eb
   # universe
   universe/autoware.universe:
     type: git


### PR DESCRIPTION
## Description
This fixes commit hash for autoware.core in autoware.repos file.
We will be starting porting of packages from Autoware Universe to Autoware Core, and we need to have version fix in autoware.repos file to provide stable build for the user during the process.

Related Links:
* [Discussion Thread](https://github.com/orgs/autowarefoundation/discussions/5365)
* [Issue for porting the first package](https://github.com/autowarefoundation/autoware.core/issues/99)

## How was this PR tested?
Tested in the health-check CI.

## Notes for reviewers

None.

## Effects on system behavior

None.
