### PR TITLE
chore(.github): skip `free-disk-space` action if there are no changed files

### DIFF
--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -29,9 +29,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
@@ -44,6 +41,12 @@ jobs:
             ansible-galaxy-requirements.yaml
             ansible/**
             docker/**
+
+      - name: Free disk space
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
+        uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
@@ -81,9 +84,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
@@ -96,6 +96,12 @@ jobs:
             ansible-galaxy-requirements.yaml
             ansible/**
             docker/**
+
+      - name: Free disk space
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
+        uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -24,9 +24,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
@@ -39,6 +36,12 @@ jobs:
             ansible-galaxy-requirements.yaml
             ansible/**
             docker/**
+
+      - name: Free disk space
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
+        uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
@@ -76,9 +79,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
@@ -91,6 +91,12 @@ jobs:
             ansible-galaxy-requirements.yaml
             ansible/**
             docker/**
+
+      - name: Free disk space
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
+        uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||


### PR DESCRIPTION
## Description

Even when there were no differences by the `changed-files` action, the `free-disk-space` action, which takes several minutes, was still executed. 
<img width="742" alt="Screenshot 2024-12-05 at 21 09 46" src="https://github.com/user-attachments/assets/e7c799e1-e5f1-4b1d-b74b-cef30886c20e">

To reduce costs for the self-hosted runner, the `free-disk-space` action will also be skipped as the same as the `docker-build-and-push` action when there are no differences.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
