### PR TITLE
feat(pre-commit): add `--profile=black` argument to isort hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+        args: [--profile=black]
 
   - repo: https://github.com/psf/black
     rev: 24.8.0


### PR DESCRIPTION
## Description
This PR adds the --profile=black argument to the isort hook in the .pre-commit-config.yaml file. This ensures alignment between isort and black, reducing potential formatting conflicts and improving consistency in code formatting across the project.

## How was this PR tested?
The change was validated by:
Running pre-commit run --all-files to confirm the isort and black hooks work without conflicts.
Ensuring no unintended modifications or errors occurred in existing files.

## Notes for reviewers
None.

## Effects on system behavior
None.
