### PR TITLE
ci: enable bugprone-* warnings in clang-tidy

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -1,6 +1,16 @@
 Checks: "
   -*,
-  bugprone-dangling-handle"
+  bugprone-*,
+  -bugprone-branch-clone,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-exception-escape,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-integer-division,
+  -bugprone-macro-parentheses,
+  -bugprone-narrowing-conversions,
+  -bugprone-parent-virtual-call,
+  -bugprone-reserved-identifier,
+  -bugprone-signed-char-misuse"
 
 WarningsAsErrors: "*"
 

--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -5,6 +5,7 @@ Checks: "
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-infinite-loop,
   -bugprone-integer-division,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,


### PR DESCRIPTION
## Description

This PR enables `bugprone` prefix warnings in clang-tidy-ci.

By specifying `bugprone-*,` first, all the `bugprone` prefix warnings are enabled.
After that, the warnings which the current Autoware.universe has are disabled by using `-` prefix.

The enabled checks are the following.
The current Autoware.universe is free of these warnings.
```
    bugprone-argument-comment
    bugprone-assert-side-effect
    bugprone-bad-signal-to-kill-thread
    bugprone-bool-pointer-implicit-conversion
    bugprone-copy-constructor-init
    bugprone-dangling-handle
    bugprone-dynamic-static-initializers
    bugprone-fold-init-type
    bugprone-forward-declaration-namespace
    bugprone-forwarding-reference-overload
    bugprone-inaccurate-erase
    bugprone-incorrect-roundings
    bugprone-lambda-function-name
    bugprone-macro-repeated-side-effects
    bugprone-misplaced-operator-in-strlen-in-alloc
    bugprone-misplaced-pointer-arithmetic-in-alloc
    bugprone-misplaced-widening-cast
    bugprone-move-forwarding-reference
    bugprone-multiple-statement-macro
    bugprone-no-escape
    bugprone-not-null-terminated-result
    bugprone-posix-return
    bugprone-redundant-branch-condition
    bugprone-signal-handler
    bugprone-sizeof-container
    bugprone-sizeof-expression
    bugprone-spuriously-wake-up-functions
    bugprone-string-constructor
    bugprone-string-integer-assignment
    bugprone-string-literal-with-embedded-nul
    bugprone-stringview-nullptr
    bugprone-suspicious-enum-usage
    bugprone-suspicious-include
    bugprone-suspicious-memory-comparison
    bugprone-suspicious-memset-usage
    bugprone-suspicious-missing-comma
    bugprone-suspicious-semicolon
    bugprone-suspicious-string-compare
    bugprone-swapped-arguments
    bugprone-terminating-continue
    bugprone-throw-keyword-missing
    bugprone-too-small-loop-variable
    bugprone-undefined-memory-manipulation
    bugprone-undelegated-constructor
    bugprone-unhandled-exception-at-new
    bugprone-unhandled-self-assignment
    bugprone-unused-raii
    bugprone-unused-return-value
    bugprone-use-after-move
    bugprone-virtual-near-miss
```

## How was this PR tested?

I locally tested that this configuration works fine and the current Autoware.universe has no errors/warnings with it.

## Notes for reviewers

The number of warnings for each check are:

  -bugprone-branch-clone, 31
  -bugprone-easily-swappable-parameters, too many
  -bugprone-exception-escape, 13
  -bugprone-implicit-widening-of-multiplication-result, too many
  -bugprone-integer-division, 16
  -bugprone-macro-parentheses, 1
  -bugprone-narrowing-conversions, too many
  -bugprone-parent-virtual-call, 1
  -bugprone-reserved-identifier, 10
  -bugprone-signed-char-misuse" 2

And `bugprone-infinite-loop` is suppressed because it takes too long time to run checkings.

## Effects on system behavior