### PR TITLE
feat(autoware.repos): use version tag for sensor_kits

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -108,11 +108,11 @@ repositories:
   sensor_kit/sample_sensor_kit_launch:
     type: git
     url: https://github.com/autowarefoundation/sample_sensor_kit_launch.git
-    version: main
+    version: 0.39.0
   sensor_kit/external/awsim_sensor_kit_launch: # TODO: Integrate into sample_sensor_kit_launch
     type: git
     url: https://github.com/tier4/awsim_sensor_kit_launch.git
-    version: main
+    version: 0.39.0
   sensor_kit/awsim_labs_sensor_kit_launch:
     type: git
     url: https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch.git


### PR DESCRIPTION
## Description
This updates the version for sample_sensor_kit_launch and awsim_sensor_kit_launch to make sure that we are using a compatible version with autoware.universe 0.39.0

https://github.com/autowarefoundation/autoware/issues/5544

## How was this PR tested?

I have tested locally with AWSIM.

## Notes for reviewers

None.

## Effects on system behavior

None.
