### PR TITLE
feat(autoware.repos): use version tag for awsim_labs_sensor_kit_launch

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -111,7 +111,7 @@ repositories:
   sensor_kit/awsim_labs_sensor_kit_launch:
     type: git
     url: https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch.git
-    version: main
+    version: 0.39.0
   sensor_kit/single_lidar_sensor_kit_launch:
     type: git
     url: https://github.com/autowarefoundation/single_lidar_sensor_kit_launch.git


### PR DESCRIPTION
## Description
This updates the version for awsim_labs_sensor_kit_launch to make sure that we are using a compatible version with autoware.universe 0.39.0

https://github.com/autowarefoundation/autoware/issues/5544
## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
