### PR TITLE
chore(.devcontainer): add `core-devel` development container

### DIFF
--- a/.devcontainer/core-devel/devcontainer.json
+++ b/.devcontainer/core-devel/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "autoware:core-devel",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": { "BASE_IMAGE": "ghcr.io/autowarefoundation/autoware:core-devel" }
+  },
+  "remoteUser": "autoware",
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--net=host",
+    "--volume=/etc/localtime:/etc/localtime:ro"
+  ],
+  "customizations": {
+    "vscode": {
+      "settings.json": {
+        "terminal.integrated.profiles.linux": { "bash": { "path": "/bin/bash" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a development container configuration that uses the `autoware:core-devel` image. This makes it easier to develop the `autoware.core`.

## How was this PR tested?

```
docker run -it --rm -v $PWD/src/core/autoware.core:/autoware/src/autoware.core ghcr.io/autowarefoundation/autoware:core-devel
```

and attach the container on an IDE.

## Notes for reviewers

None.

## Effects on system behavior

None.
