### PR TITLE
feat(autoware.repos): remove `autoware_common` from `autoware.repos`

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -13,11 +13,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
     version: 1.1.0
-  # TODO(youtalk): Remove autoware_common when https://github.com/autowarefoundation/autoware/issues/4911 is closed
-  core/autoware_common:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
-    version: remove-autoware-cmake-utils
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
## Description

Resolved https://github.com/autowarefoundation/autoware/issues/4911

`autoware_common` is finally no longer needed, this PR removes it from `autoware.repos`.
Ref. https://github.com/autowarefoundation/autoware/issues/4911#issuecomment-2550441066

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
