### PR TITLE
feat: monitor version update in `simulator.repos` too

### DIFF
--- a/.github/workflows/create-prs-to-update-vcs-repositories.yaml
+++ b/.github/workflows/create-prs-to-update-vcs-repositories.yaml
@@ -18,7 +18,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Create PRs to update VCS repositories
+      - name: Create PRs to update VCS repositories for autoware.repos
         uses: autowarefoundation/autoware-github-actions/create-prs-to-update-vcs-repositories@v1
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -28,4 +28,16 @@ jobs:
           base_branch: main
           new_branch_prefix: feat/update-
           autoware_repos_file_name: autoware.repos
+          verbosity: 0
+
+      - name: Create PRs to update VCS repositories for simulator.repos
+        uses: autowarefoundation/autoware-github-actions/create-prs-to-update-vcs-repositories@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repo_name: autowarefoundation/autoware
+          parent_dir: .
+          targets: major minor patch
+          base_branch: main
+          new_branch_prefix: feat/update-
+          autoware_repos_file_name: simulator.repos
           verbosity: 0


### PR DESCRIPTION
## Description

Monitor version update for vcs-imported repositories in the `simulator.repos`.

## How was this PR tested?

The performed test is described in [this PR's description](https://github.com/autowarefoundation/autoware-github-actions/pull/330).

## Notes for reviewers

Though the test is performed as above, there are perhaps some missing checks and so on. Please feel free to share any your ideas and questions. I'm welcome to do the proposed actions and answer questions. Thanks!

## Effects on system behavior

As the repositories in the `simulator.repos` are updated, the version update PR will be created for each repository, respectively.
