### PR TITLE
fix(.github): update `github-release` workflow

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -9,7 +9,6 @@
     - source: .github/stale.yml
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/comment-on-pr.yaml
-    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/pre-commit-optional-autoupdate.yaml
     - source: .github/workflows/pre-commit-autoupdate.yaml

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -7,7 +7,7 @@ name: github-release
 on:
   push:
     tags:
-      - "*.*.*"
+      - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       tag-name:
@@ -60,6 +60,7 @@ jobs:
         run: |
           gh release ${{ steps.select-verb.outputs.verb }} "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
+            --target "main"
             --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Run generate-changelog
         id: generate-changelog
         uses: autowarefoundation/autoware-github-actions/generate-changelog@v1
+        with:
+          git-cliff-args: |
+            --tag-pattern "^(\d+)\.(\d+)\.(\d+)$"
 
       - name: Select verb
         id: select-verb

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -40,9 +40,7 @@ jobs:
         id: generate-changelog
         uses: autowarefoundation/autoware-github-actions/generate-changelog@v1
         with:
-          git-cliff-args: |
-            --tag-pattern "^(\d+)\.(\d+)\.(\d+)$"
-            --latest
+          git-cliff-args: --tag-pattern "^(\d+)\.(\d+)\.(\d+)$" --latest
 
       - name: Select verb
         id: select-verb

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -42,6 +42,7 @@ jobs:
         with:
           git-cliff-args: |
             --tag-pattern "^(\d+)\.(\d+)\.(\d+)$"
+            --latest
 
       - name: Select verb
         id: select-verb

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -6,14 +6,12 @@ name: github-release
 
 on:
   push:
-    branches:
-      - beta/v*
     tags:
-      - v*
+      - "*.*.*"
   workflow_dispatch:
     inputs:
-      beta-branch-or-tag-name:
-        description: The name of the beta branch or tag to release
+      tag-name:
+        description: The name of the tag to release
         type: string
         required: true
 
@@ -25,32 +23,18 @@ jobs:
         id: set-tag-name
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            REF_NAME="${{ github.event.inputs.beta-branch-or-tag-name }}"
+            REF_NAME="${{ github.event.inputs.tag-name }}"
           else
             REF_NAME="${{ github.ref_name }}"
           fi
 
           echo "ref-name=$REF_NAME" >> $GITHUB_OUTPUT
-          echo "tag-name=${REF_NAME#beta/}" >> $GITHUB_OUTPUT
 
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ steps.set-tag-name.outputs.ref-name }}
-
-      - name: Set target name for beta branches
-        id: set-target-name
-        run: |
-          if [[ "${{ steps.set-tag-name.outputs.ref-name }}" =~ "beta/" ]]; then
-            echo "target-name=${{ steps.set-tag-name.outputs.ref-name }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create a local tag for beta branches
-        run: |
-          if [ "${{ steps.set-target-name.outputs.target-name }}" != "" ]; then
-            git tag "${{ steps.set-tag-name.outputs.tag-name }}"
-          fi
 
       - name: Run generate-changelog
         id: generate-changelog
@@ -74,7 +58,6 @@ jobs:
         run: |
           gh release ${{ steps.select-verb.outputs.verb }} "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
-            --target "${{ steps.set-target-name.outputs.target-name }}" \
             --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -28,13 +28,13 @@ jobs:
             REF_NAME="${{ github.ref_name }}"
           fi
 
-          echo "ref-name=$REF_NAME" >> $GITHUB_OUTPUT
+          echo "tag-name=$REF_NAME" >> $GITHUB_OUTPUT
 
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ steps.set-tag-name.outputs.ref-name }}
+          ref: ${{ steps.set-tag-name.outputs.tag-name }}
 
       - name: Run generate-changelog
         id: generate-changelog

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           gh release ${{ steps.select-verb.outputs.verb }} "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
-            --target "main"
+            --target "main" \
             --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:


### PR DESCRIPTION
## Description

This PR fixes the `github-release` workflow so that the GitHub release page is correctly generated when a version tag is pushed.

## How was this PR tested?

The result of executing a `workflow_dispatch` trigger with `tag-name` set to `0.40.0` in my forked repository:

https://github.com/youtalk/autoware/releases/tag/untagged-abca71c3a111e29fae42

## Notes for reviewers

None.

## Effects on system behavior

None.
