### PR TITLE
ci(clang-tidy): enable bugprone checkings

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -1,17 +1,10 @@
 Checks: "
   -*,
   bugprone-*,
-  -bugprone-branch-clone,
   -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-infinite-loop,
-  -bugprone-integer-division,
-  -bugprone-macro-parentheses,
-  -bugprone-narrowing-conversions,
-  -bugprone-parent-virtual-call,
-  -bugprone-reserved-identifier,
-  -bugprone-signed-char-misuse"
+  -bugprone-narrowing-conversions"
 
 WarningsAsErrors: "*"
 


### PR DESCRIPTION
## Description

This is a subsequent PR of https://github.com/autowarefoundation/autoware/pull/5543.

Here, the following checks are newly enabled:

- bugprone-branch-clone
- bugprone-exception-escape
- bugprone-integer-division
- bugprone-macro-parentheses
- bugprone-parent-virtual-call
- bugprone-reserved-identifier
- bugprone-signed-char-misuse

The warnings of these checks have been removed by the following PRs:

https://github.com/autowarefoundation/autoware.universe/pull/9627 
https://github.com/autowarefoundation/autoware.universe/pull/9628 
https://github.com/autowarefoundation/autoware.universe/pull/9629 
https://github.com/autowarefoundation/autoware.universe/pull/9630 
https://github.com/autowarefoundation/autoware.universe/pull/9631 
https://github.com/autowarefoundation/autoware.universe/pull/9643 
https://github.com/autowarefoundation/autoware.universe/pull/9647 
https://github.com/autowarefoundation/autoware.universe/pull/9648 
https://github.com/autowarefoundation/autoware.universe/pull/9651 
https://github.com/autowarefoundation/autoware.universe/pull/9652 
https://github.com/autowarefoundation/autoware.universe/pull/9654 
https://github.com/autowarefoundation/autoware.universe/pull/9658 
https://github.com/autowarefoundation/autoware.universe/pull/9659 
https://github.com/autowarefoundation/autoware.universe/pull/9660 
https://github.com/autowarefoundation/autoware.universe/pull/9662 
https://github.com/autowarefoundation/autoware.universe/pull/9668 
https://github.com/autowarefoundation/autoware.universe/pull/9669 
https://github.com/autowarefoundation/autoware.universe/pull/9670 
https://github.com/autowarefoundation/autoware.universe/pull/9671 
https://github.com/autowarefoundation/autoware.universe/pull/9697 
https://github.com/autowarefoundation/autoware.universe/pull/9698 
https://github.com/autowarefoundation/autoware.universe/pull/9699 
https://github.com/autowarefoundation/autoware.universe/pull/9700 
https://github.com/autowarefoundation/autoware.universe/pull/9701 
https://github.com/autowarefoundation/autoware.universe/pull/9702 
https://github.com/autowarefoundation/autoware.universe/pull/9712 
https://github.com/autowarefoundation/autoware.universe/pull/9715 
https://github.com/autowarefoundation/autoware.universe/pull/9723 
https://github.com/autowarefoundation/autoware.universe/pull/9724 
https://github.com/autowarefoundation/autoware.universe/pull/9725 
https://github.com/autowarefoundation/autoware.universe/pull/9726 
https://github.com/autowarefoundation/autoware.universe/pull/9727 
https://github.com/autowarefoundation/autoware.universe/pull/9729 
https://github.com/autowarefoundation/autoware.universe/pull/9730 
https://github.com/autowarefoundation/autoware.universe/pull/9732 
https://github.com/autowarefoundation/autoware.universe/pull/9738 
https://github.com/autowarefoundation/autoware.universe/pull/9780 
https://github.com/autowarefoundation/autoware.universe/pull/9781 
https://github.com/autowarefoundation/autoware.universe/pull/9805 
https://github.com/autowarefoundation/autoware.universe/pull/9815 

## How was this PR tested?

## Notes for reviewers

You can verify it locally by the similar configurations with https://github.com/autowarefoundation/autoware/pull/5543#issuecomment-2533325979

## Effects on system behavior

None.
