### PR TITLE
fix(docker): enable `--dependency-types` again

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ COPY src/universe/autoware.universe/sensing /autoware/src/universe/autoware.univ
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-sensing-perception-depend-packages.txt \
   && cat /rosdep-universe-sensing-perception-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-types=exec \
   > /rosdep-universe-sensing-perception-exec-depend-packages.txt \
   && cat /rosdep-universe-sensing-perception-exec-depend-packages.txt
 
@@ -57,7 +57,7 @@ COPY src/universe/autoware.universe/map /autoware/src/universe/autoware.universe
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-localization-mapping-depend-packages.txt \
   && cat /rosdep-universe-localization-mapping-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-types=exec \
   > /rosdep-universe-localization-mapping-exec-depend-packages.txt \
   && cat /rosdep-universe-localization-mapping-exec-depend-packages.txt
 
@@ -75,7 +75,7 @@ COPY src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor /au
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-planning-control-depend-packages.txt \
   && cat /rosdep-universe-planning-control-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-types=exec \
   > /rosdep-universe-planning-control-exec-depend-packages.txt \
   && cat /rosdep-universe-planning-control-exec-depend-packages.txt
 
@@ -90,7 +90,7 @@ COPY src/universe/autoware.universe/localization/autoware_pose2twist /autoware/s
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-vehicle-system-depend-packages.txt \
   && cat /rosdep-universe-vehicle-system-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-types=exec \
   > /rosdep-universe-vehicle-system-exec-depend-packages.txt \
   && cat /rosdep-universe-vehicle-system-exec-depend-packages.txt
 
@@ -108,7 +108,7 @@ RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-depend-packages.txt \
   && cat /rosdep-universe-depend-packages.txt
 
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-types=exec \
   > /rosdep-exec-depend-packages.txt \
   && cat /rosdep-exec-depend-packages.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ COPY src/universe/autoware.universe/sensing /autoware/src/universe/autoware.univ
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-sensing-perception-depend-packages.txt \
   && cat /rosdep-universe-sensing-perception-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
   > /rosdep-universe-sensing-perception-exec-depend-packages.txt \
   && cat /rosdep-universe-sensing-perception-exec-depend-packages.txt
 
@@ -57,7 +57,7 @@ COPY src/universe/autoware.universe/map /autoware/src/universe/autoware.universe
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-localization-mapping-depend-packages.txt \
   && cat /rosdep-universe-localization-mapping-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
   > /rosdep-universe-localization-mapping-exec-depend-packages.txt \
   && cat /rosdep-universe-localization-mapping-exec-depend-packages.txt
 
@@ -75,7 +75,7 @@ COPY src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor /au
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-planning-control-depend-packages.txt \
   && cat /rosdep-universe-planning-control-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
   > /rosdep-universe-planning-control-exec-depend-packages.txt \
   && cat /rosdep-universe-planning-control-exec-depend-packages.txt
 
@@ -90,7 +90,7 @@ COPY src/universe/autoware.universe/localization/autoware_pose2twist /autoware/s
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-vehicle-system-depend-packages.txt \
   && cat /rosdep-universe-vehicle-system-depend-packages.txt
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
   > /rosdep-universe-vehicle-system-exec-depend-packages.txt \
   && cat /rosdep-universe-vehicle-system-exec-depend-packages.txt
 
@@ -108,7 +108,7 @@ RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-depend-packages.txt \
   && cat /rosdep-universe-depend-packages.txt
 
-RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} exec \
   > /rosdep-exec-depend-packages.txt \
   && cat /rosdep-exec-depend-packages.txt
 

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -5,7 +5,7 @@ function resolve_rosdep_keys() {
     local ros_distro=$2
     local rosdep_keys_args=$3
 
-    rosdep keys "$rosdep_keys_args" --ignore-src --from-paths "$src_path" |
+    rosdep keys $rosdep_keys_args --ignore-src --from-paths "$src_path" |
         xargs rosdep resolve --rosdistro "$ros_distro" |
         grep -v '^#' |
         sed 's/ \+/\n/g' |

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -3,8 +3,9 @@
 function resolve_rosdep_keys() {
     local src_path=$1
     local ros_distro=$2
+    local dependency_types=$3
 
-    rosdep keys --ignore-src --from-paths "$src_path" |
+    rosdep keys --dependency-types="$dependency_types" --ignore-src --from-paths "$src_path" |
         xargs rosdep resolve --rosdistro "$ros_distro" |
         grep -v '^#' |
         sed 's/ \+/\n/g' |

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -5,6 +5,7 @@ function resolve_rosdep_keys() {
     local ros_distro=$2
     local rosdep_keys_args=$3
 
+    # shellcheck disable=SC2086
     rosdep keys $rosdep_keys_args --ignore-src --from-paths "$src_path" |
         xargs rosdep resolve --rosdistro "$ros_distro" |
         grep -v '^#' |

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -4,6 +4,9 @@ function resolve_rosdep_keys() {
     local src_path=$1
     local ros_distro=$2
     local dependency_types=$3
+    if [ -z "$dependency_types" ]; then
+        dependency_types="build build_export buildtool buildtool_export exec test"
+    fi
 
     rosdep keys --dependency-types="$dependency_types" --ignore-src --from-paths "$src_path" |
         xargs rosdep resolve --rosdistro "$ros_distro" |

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -3,12 +3,9 @@
 function resolve_rosdep_keys() {
     local src_path=$1
     local ros_distro=$2
-    local dependency_types=$3
-    if [ -z "$dependency_types" ]; then
-        dependency_types="build build_export buildtool buildtool_export exec test"
-    fi
+    local rosdep_keys_args=$3
 
-    rosdep keys --dependency-types="$dependency_types" --ignore-src --from-paths "$src_path" |
+    rosdep keys "$rosdep_keys_args" --ignore-src --from-paths "$src_path" |
         xargs rosdep resolve --rosdistro "$ros_distro" |
         grep -v '^#' |
         sed 's/ \+/\n/g' |


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware/pull/5424 introduced the `rosdep` script and refactored the `Dockerfile`, but it accidentally removed the `--dependency-types` setting at that time.
This PR fixes that issue.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
