### PR TITLE
feat(autoware.repos): added ros2_spconv

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -76,6 +76,10 @@ repositories:
     type: git
     url: https://github.com/tier4/glog.git
     version: v0.6.0_t4-ros
+  universe/external/ros2_spconv:
+    type: git
+    url: https://github.com/knzo25/ros2_spconv.git
+    version: main
   # launcher
   launcher/autoware_launch:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -74,7 +74,7 @@ repositories:
   universe/external/ros2_spconv:
     type: git
     url: https://github.com/knzo25/ros2_spconv.git
-    version: main
+    version: feat/autoware_compile_test
   # launcher
   launcher/autoware_launch:
     type: git


### PR DESCRIPTION
## Description

Temporarily adds https://github.com/knzo25/ros2_spconv
to the autoware.repos file to test compilation times 

**This PR is required by:**
- https://github.com/autowarefoundation/autoware.universe/pull/10024

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
