### PR TITLE
fix(docker): add `set -e` to return shell script's error

### DIFF
--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
 function build_and_clean() {
     local ccache_dir=$1

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 function build_and_clean() {
     local ccache_dir=$1

--- a/docker/scripts/cleanup_apt.sh
+++ b/docker/scripts/cleanup_apt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
 function cleanup_apt() {
     local apt_clean=$1

--- a/docker/scripts/cleanup_apt.sh
+++ b/docker/scripts/cleanup_apt.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 function cleanup_apt() {
     local apt_clean=$1

--- a/docker/scripts/cleanup_system.sh
+++ b/docker/scripts/cleanup_system.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
 function cleanup_system() {
     local lib_dir=$1

--- a/docker/scripts/cleanup_system.sh
+++ b/docker/scripts/cleanup_system.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 function cleanup_system() {
     local lib_dir=$1

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 function resolve_rosdep_keys() {
     local src_path=$1

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
 function resolve_rosdep_keys() {
     local src_path=$1


### PR DESCRIPTION
## Description

This PR fixes the issue where the shell scripts invoked during `docker build` returns an error, but the `docker build` process continues.
For example, there was the following issue where the execution continued even if dependency packages were not found with `rosdep keys`.

https://github.com/autowarefoundation/autoware/pull/5586#discussion_r1893609888

> ERROR: no rosdep rule for 'automatic_pose_initializer'
> ERROR: no rosdep rule for 'autoware_pointcloud_preprocessor'

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
