### PR TITLE
feat(.github): monitor version update for `tools.repos` too

### DIFF
--- a/.github/workflows/create-prs-to-update-vcs-repositories.yaml
+++ b/.github/workflows/create-prs-to-update-vcs-repositories.yaml
@@ -41,3 +41,15 @@ jobs:
           new_branch_prefix: feat/update-
           autoware_repos_file_name: simulator.repos
           verbosity: 0
+
+      - name: Create PRs to update VCS repositories for tools.repos
+        uses: autowarefoundation/autoware-github-actions/create-prs-to-update-vcs-repositories@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repo_name: autowarefoundation/autoware
+          parent_dir: .
+          targets: major minor patch
+          base_branch: main
+          new_branch_prefix: feat/update-
+          autoware_repos_file_name: tools.repos
+          verbosity: 0


### PR DESCRIPTION
## Description

Monitor version update for vcs-imported repositories in the `tools.repos`.

## How was this PR tested?

The performed test is described in [this PR's description](https://github.com/autowarefoundation/autoware-github-actions/pull/330).

## Notes for reviewers

Though the test is performed as above, there are perhaps some missing checks and so on. Please feel free to share any your ideas and questions. I'm welcome to do the proposed actions and answer questions. Thanks!

## Effects on system behavior

As the repositories in the `tools.repos` are updated, the version update PR will be created for each repository, respectively.