### PR TITLE
fix: add `tier4_ad_api_adaptor` to autoware-nightly.repos

### DIFF
--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -15,6 +15,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe.git
     version: main
+  universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
+    type: git
+    url: https://github.com/tier4/tier4_ad_api_adaptor.git
+    version: tier4/universe
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git


### PR DESCRIPTION
## Description

`tier4_ad_api_adaptor` has been pinned to the v0.40.0 tag by the following pull request.

https://github.com/autowarefoundation/autoware/pull/5675

However, to use it with the latest version of autoware.universe, we need to use the latest version of the branch.

This pull request will add `tier4_ad_api_adaptor` to autoware-nightly.repos.

## How was this PR tested?

TODO

## Notes for reviewers

None.

## Effects on system behavior

None.
