### PR TITLE
fix(docker-build-and-push): set docker meta data to `universe-visualization` images

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -181,6 +181,32 @@ runs:
         flavor: |
           latest=false
 
+    - name: Docker meta for autoware:universe-visualization-devel
+      id: meta-universe-visualization-devel
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=universe-visualization-devel-${{ inputs.platform }}
+          type=raw,value=universe-visualization-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-visualization-devel-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-universe-visualization-devel
+        flavor: |
+          latest=false
+
+    - name: Docker meta for autoware:universe-visualization
+      id: meta-universe-visualization
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=universe-visualization-${{ inputs.platform }}
+          type=raw,value=universe-visualization-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-visualization-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-universe-visualization
+        flavor: |
+          latest=false
+
     - name: Docker meta for autoware:universe-devel
       id: meta-universe-devel
       uses: docker/metadata-action@v5
@@ -229,6 +255,8 @@ runs:
           ${{ steps.meta-universe-planning-control.outputs.bake-file }}
           ${{ steps.meta-universe-vehicle-system-devel.outputs.bake-file }}
           ${{ steps.meta-universe-vehicle-system.outputs.bake-file }}
+          ${{ steps.meta-universe-visualization-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-visualization.outputs.bake-file }}
           ${{ steps.meta-universe-devel.outputs.bake-file }}
           ${{ steps.meta-universe.outputs.bake-file }}
         provenance: false


### PR DESCRIPTION
## Description

After https://github.com/autowarefoundation/autoware/pull/5460 was merged, I discovered that the `docker-build-and-push` workflow was failing. This PR sets the Docker metadata to fix the problem.

## How was this PR tested?

- https://github.com/youtalk/autoware/pull/162
- https://github.com/youtalk/autoware/actions/runs/12902024333

## Notes for reviewers

None.

## Effects on system behavior

None.
