### PR TITLE
fix(docker-build-and-push): push `universe-visualization` images to ghcr.io

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -185,7 +185,7 @@ runs:
       id: meta-universe-visualization-devel
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.target-image }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
           type=raw,value=universe-visualization-devel-${{ inputs.platform }}
           type=raw,value=universe-visualization-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
@@ -198,7 +198,7 @@ runs:
       id: meta-universe-visualization
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.target-image }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
           type=raw,value=universe-visualization-${{ inputs.platform }}
           type=raw,value=universe-visualization-${{ steps.date.outputs.date }}-${{ inputs.platform }}


### PR DESCRIPTION
## Description

In https://github.com/autowarefoundation/autoware/pull/5679, the image push destination for `universe-visualization` was mistakenly set to docker.io because my forked repo uses docker.io. https://hub.docker.com/r/youtalk/autoware/tags

https://github.com/autowarefoundation/autoware/actions/runs/12920581839/job/36033142078#step:6:41068

This PR corrects it to ghcr.io.

## How was this PR tested?

https://github.com/autowarefoundation/autoware/actions/runs/12944782709

## Notes for reviewers

None.

## Effects on system behavior

None.
