### PR TITLE
fix(docker): append `set -o pipefail` to return shell script's pipe error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,8 @@ RUN rosdep update && /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO
 
 COPY src/universe/external /autoware/src/universe/external
 COPY src/universe/autoware.universe/common /autoware/src/universe/autoware.universe/common
+COPY src/universe/autoware.universe/perception/autoware_tensorrt_common /autoware/src/universe/autoware.universe/perception/autoware_tensorrt_common
+COPY src/universe/autoware.universe/sensing/autoware_cuda_utils /autoware/src/universe/autoware.universe/sensing/autoware_cuda_utils
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-common-depend-packages.txt \
   && cat /rosdep-universe-common-depend-packages.txt

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 function build_and_clean() {
     local ccache_dir=$1

--- a/docker/scripts/cleanup_apt.sh
+++ b/docker/scripts/cleanup_apt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 function cleanup_apt() {
     local apt_clean=$1

--- a/docker/scripts/cleanup_system.sh
+++ b/docker/scripts/cleanup_system.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 function cleanup_system() {
     local lib_dir=$1

--- a/docker/scripts/resolve_rosdep_keys.sh
+++ b/docker/scripts/resolve_rosdep_keys.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 function resolve_rosdep_keys() {
     local src_path=$1


### PR DESCRIPTION
## Description

- [ ] https://github.com/autowarefoundation/autoware/pull/5702

In https://github.com/autowarefoundation/autoware/pull/5661, the shell scripts ware modified to return an error if any command within the script returned an error. In this PR, it was further enhanced to return an error even when commands are connected with pipes.

As a result, for example, if `rosdep` fails to resolve dependencies, the CI will correctly fail with an error.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
