### PR TITLE
chore(create-prs-to-update-vcs-repositories.yaml): target only major and minor version updates for `simulator.repos`

### DIFF
--- a/.github/workflows/create-prs-to-update-vcs-repositories.yaml
+++ b/.github/workflows/create-prs-to-update-vcs-repositories.yaml
@@ -36,7 +36,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           repo_name: autowarefoundation/autoware
           parent_dir: .
-          targets: major minor patch
+          targets: major minor
           base_branch: main
           new_branch_prefix: feat/update-
           autoware_repos_file_name: simulator.repos


### PR DESCRIPTION
## Description

The version updates for `scenario_simulator_v2` are significantly faster compared to other repositories, which often leads to an accumulation of PRs created by the release bot. 

https://github.com/autowarefoundation/autoware/pulls?q=is%3Apr+update+tier4%2Fscenario_simulator_v2

To address this, the version updates in `simulator.repos` will be limited to major and minor updates only.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
