### PR TITLE
fix(docker): fix `autoware_tensorrt_common` and `autoware_cuda_utils` dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,8 @@ RUN rosdep update && /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO
 
 COPY src/universe/external /autoware/src/universe/external
 COPY src/universe/autoware.universe/common /autoware/src/universe/autoware.universe/common
+COPY src/universe/autoware.universe/perception/autoware_tensorrt_common /autoware/src/universe/autoware.universe/perception/autoware_tensorrt_common
+COPY src/universe/autoware.universe/sensing/autoware_cuda_utils /autoware/src/universe/autoware.universe/sensing/autoware_cuda_utils
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-common-depend-packages.txt \
   && cat /rosdep-universe-common-depend-packages.txt


### PR DESCRIPTION
## Description

This PR adds copies of the packages `autoware_cuda_utils` and `autoware_tensorrt_common` because I found that the `autoware:universe-common` image depends on them.

https://github.com/autowarefoundation/autoware/actions/runs/12981132448/job/36199122604?pr=5697#step:5:1459

>  [rosdep-depend 15/15] RUN /autoware/resolve_rosdep_keys.sh /autoware/src humble   > /rosdep-universe-common-depend-packages.txt   && cat /rosdep-universe-common-depend-packages.txt:
> 0.910 ERROR: no rosdep rule for 'autoware_cuda_utils'
> 0.910 ERROR: no rosdep rule for 'autoware_tensorrt_common'

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
