### PR TITLE
ci: run free disk space for setup-universe workflow

### DIFF
--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -10,6 +10,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:


### PR DESCRIPTION
## Description
This PR adds free disk space action in setup-universe workflow.
We have another PR that tries to upgrade NVIDIA libraries https://github.com/autowarefoundation/autoware/pull/5608, and setup-universe failed with not enough disk space. This PR will fix that issue.

## How was this PR tested?

It was tested here: https://github.com/mitsudome-r/autoware/actions/runs/13012692216/job/36294019399?pr=17 

## Notes for reviewers

None.

## Effects on system behavior

None.
