### PR TITLE
chore(tools.repos): use tag instead of `main` to `version`

### DIFF
--- a/tools.repos
+++ b/tools.repos
@@ -2,4 +2,4 @@ repositories:
   tools:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
-    version: main
+    version: 0.1.0


### PR DESCRIPTION
## Description

The `version control` for `autoware_tools` has begun, and monitoring by the release bot has also started.

- https://github.com/autowarefoundation/autoware/pull/5664
- https://github.com/autowarefoundation/autoware_tools/pull/209

Therefore, this PR changes the `version` specification for `autoware_tools` from the `main` branch to a tag.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
