### PR TITLE
fix(ansible): dependencies for arm64

### DIFF
--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -11,8 +11,6 @@ This role installs TensorRT and cuDNN following [the official NVIDIA TensorRT In
 
 ## Manual Installation
 
-### AMD64
-
 ```bash
 # For the environment variables
 wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && source /tmp/amd64.env
@@ -35,37 +33,6 @@ libnvinfer10 \
 libnvinfer-plugin10 \
 libnvonnxparsers10 \
 libcudnn8-dev \
-libnvinfer-dev \
-libnvinfer-plugin-dev \
-libnvonnxparsers-dev \
-libnvinfer-headers-dev \
-libnvinfer-headers-plugin-dev
-```
-
-### ARM64
-
-```bash
-# For the environment variables
-wget -O /tmp/arm64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/arm64.env && source /tmp/arm64.env
-
-sudo apt-get install -y \
-libcudnn9-cuda-12=${cudnn_version} \
-libnvinfer10=${tensorrt_version} \
-libnvinfer-plugin10=${tensorrt_version} \
-libnvonnxparsers10=${tensorrt_version} \
-libcudnn9-dev-cuda-12=${cudnn_version} \
-libnvinfer-dev=${tensorrt_version} \
-libnvinfer-plugin-dev=${tensorrt_version} \
-libnvinfer-headers-dev=${tensorrt_version} \
-libnvinfer-headers-plugin-dev=${tensorrt_version} \
-libnvonnxparsers-dev=${tensorrt_version}
-
-sudo apt-mark hold \
-libcudnn9-cuda-12 \
-libnvinfer10 \
-libnvinfer-plugin10 \
-libnvonnxparsers10 \
-libcudnn9-dev-cuda-12 \
 libnvinfer-dev \
 libnvinfer-plugin-dev \
 libnvonnxparsers-dev \

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -2,7 +2,7 @@
   become: true
   ansible.builtin.apt:
     name:
-      - "{{ 'libcudnn9-cuda-12=' + cudnn_version if ansible_architecture == 'aarch64' else 'libcudnn8=' + cudnn_version }}"
+      - libcudnn8={{ cudnn_version }}
       - libnvinfer10={{ tensorrt_version }}
       - libnvinfer-plugin10={{ tensorrt_version }}
       - libnvonnxparsers10={{ tensorrt_version }}
@@ -14,7 +14,7 @@
   become: true
   ansible.builtin.apt:
     name:
-      - "{{ 'libcudnn9-dev-cuda-12=' + cudnn_version if ansible_architecture == 'aarch64' else 'libcudnn8-dev=' + cudnn_version }}"
+      - libcudnn8-dev={{ cudnn_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
       - libnvinfer-headers-dev={{ tensorrt_version }}
@@ -32,7 +32,6 @@
     name: "{{ item }}"
     selection: hold
   with_items:
-    - "{{ 'libcudnn9-cuda-12' if ansible_architecture == 'aarch64' else 'libcudnn8' }}"
     - libcudnn8
     - libnvinfer10
     - libnvinfer-plugin10
@@ -44,7 +43,7 @@
     name: "{{ item }}"
     selection: hold
   with_items:
-    - "{{ 'libcudnn9-dev-cuda-12' if ansible_architecture == 'aarch64' else 'libcudnn8-dev' }}"
+    - libcudnn8-dev
     - libnvinfer-dev
     - libnvinfer-plugin-dev
     - libnvinfer-headers-dev

--- a/arm64.env
+++ b/arm64.env
@@ -1,3 +1,2 @@
 # Override amd64's settings
-cudnn_version=9.3.0.75-1
-tensorrt_version=10.3.0.30-1+cuda12.5
+tensorrt_version=10.3.0.26-1+cuda12.5


### PR DESCRIPTION
## Description
Fixes `658.6 fatal: [localhost]: FAILED! => {"cache_update_time": 1738655505, "cache_updated": false, "changed": false, "msg": "no available installation candidate for libnvinfer10=10.3.0.30-1+cuda12.5"}` from failing [workflow](https://github.com/autowarefoundation/autoware/actions/runs/13129883903/job/36634272663).

For arm64, before dependencies were chosen based on Jetpack 6.1+ release. Now we follow [compatibility matrix](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-1030/support-matrix/index.html#platform-matrix) for latest Ubuntu 22.04 of Linux SBSA release.

## How was this PR tested?
Built locally with `--platform linux/arm64` flag and qemu support.

## Notes for reviewers

None.

## Effects on system behavior

None.
