### PR TITLE
feat: add autoware_utils main branch to autoware-nightly.repos

### DIFF
--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -11,6 +11,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
     version: main
+  core/autoware_utils: # TODO(mitsudome-r): Remove this repository entry when https://github.com/autowarefoundation/autoware/pull/5700 is merged.
+    type: git
+    url: https://github.com/autowarefoundation/autoware_utils.git
+    version: main
   universe/autoware.universe:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe.git


### PR DESCRIPTION
## Description
This add autoware_utils to autoware-nightly.repos until autoware_util is upgraded to 1.1.0 in autoware.repos with [this PR](https://github.com/autowarefoundation/autoware/pull/5700) is merged.

Otherwise, we can't work on porting Autoware Core packages that depends on the latest version of autoware_utils.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
