### PR TITLE
fix(docker-build-and-push-arm64.yaml): change `runs-on` self-hosted only for `-cuda` job

### DIFF
--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -108,11 +108,6 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 16
-
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/docker-build-and-push-arm64.yaml
+++ b/.github/workflows/docker-build-and-push-arm64.yaml
@@ -79,7 +79,7 @@ jobs:
 
   docker-build-and-push-cuda:
     needs: [load-env, docker-build-and-push]
-    runs-on: ubuntu-22.04-arm
+    runs-on: [self-hosted, linux, ARM64]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware/pull/5688 introduced GitHub-hosted runners for ARM64 builds, but unfortunately, it was discovered that the `docker-build-and-push-cuda` job fails due to insufficient space.

https://github.com/autowarefoundation/autoware/actions/runs/13157760861/job/36726446105#step:7:26253
> OSError: [Errno 28] No space left on device

This PR temporarily reverts only that job back to our self-hosted runner. 

## How was this PR tested?

https://github.com/autowarefoundation/autoware/actions/runs/13173416516

## Notes for reviewers

None.

## Effects on system behavior

None.
