### PR TITLE
feat: add simulator and tools nightly repos

### DIFF
--- a/simulator-nightly.repos
+++ b/simulator-nightly.repos
@@ -1,0 +1,1 @@
+repositories:

--- a/tools-nightly.repos
+++ b/tools-nightly.repos
@@ -1,0 +1,5 @@
+repositories:
+  tools:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_tools.git
+    version: main


### PR DESCRIPTION
## Description

When building with combination autoware-nightly.repos and tools.repos, the following error occurs. So add tools-nightly.repos to use the corresponding tools version when using autoware-nightly. Same for simulator.repos so I add an empty file.

```
/home/isamutakagi/workspace/awf/autoware/repo/src/tools/planning/autoware_static_centerline_generator/src/type_alias.hpp:42:7: error: ‘tier4_planning_msgs’ has not been declared
   42 | using tier4_planning_msgs::msg::PathWithLaneId;
```

## How was this PR tested?

Check if the build passes when using *-nightly.repos files.

## Notes for reviewers

None.

## Effects on system behavior

None.
