### PR TITLE
feat: add new traffic light detector artifacts download

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -291,6 +291,31 @@
     extra_opts:
       - --strip-components=1 # Removes the top-level folder during extraction
 
+# traffic_light_detector model which referenced by tensorrt_yolox package
+- name: Download tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/tl_detector_yolox_s/v1/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx"
+    mode: "644"
+    checksum: sha256:0b8478553f2f0374a1236e65f669f11335b1fea7756ca7bcdfcf9646657ed594
+
+- name: Download tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/tl_detector_yolox_s/v1/yolox_s_car_ped_tl_detector_960_960_batch_1.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: sha256:690cff409519aca26f4ec0fc56ed35d9aa23ee1c18d6205c43469ae06e2f4e02
+
+- name: Download tensorrt/car_ped_tl_detector_labels.txt
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/tl_detector_yolox_s/v1/car_ped_tl_detector_labels.txt
+    dest: "{{ data_dir }}/tensorrt_yolox/car_ped_tl_detector_labels.txt"
+    mode: "644"
+    checksum: sha256:a2a91f5fe9c2e68e3e3647a272bb9bb25cd07631a1990a3fb15efddce7691131
+
 # traffic_light_classifier
 - name: Create traffic_light_classifier directory inside {{ data_dir }}
   ansible.builtin.file:

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -292,7 +292,7 @@
     extra_opts:
       - --strip-components=1 # Removes the top-level folder during extraction
 
-# traffic_light_detector model which referenced by tensorrt_yolox package
+# tensorrt_yolox for whole_image_traffic_light_detector
 - name: Download tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx
   become: true
   ansible.builtin.get_url:

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -245,6 +245,7 @@
     mode: "644"
     checksum: sha256:3540a365bfd6d8afb1b5d8df4ec47f82cb984760d3270c9b41dbbb3422d09a0c
 
+# cspell: ignore semseg
 - name: Download tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx
   become: true
   ansible.builtin.get_url:


### PR DESCRIPTION
## Description
This PR add new artifact, which is whole image traffic light detection model working on YOLOX.
Related issue is below.
- https://github.com/autowarefoundation/autoware.universe/issues/9719

## How was this PR tested?
I have checked this PR like below.
- Run `./setup-dev-env.sh`
- Run like https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts
- Run `ros2 launch autoware_tensorrt_yolox yolox_traffic_light_detector.launch.xml`

## Notes for reviewers

None.

## Effects on system behavior

None.
