### PR TITLE
revert: revert "feat(autoware.repos): fix tier4_autoware_msgs version"

### DIFF
--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -23,10 +23,6 @@ repositories:
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
     version: tier4/universe
-  universe/external/tier4_autoware_msgs:
-    type: git
-    url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: tier4/universe
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -41,7 +41,7 @@ repositories:
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: v0.40.0
+    version: tier4/universe
   # Fix the version not to merge https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9
   universe/external/morai_msgs:
     type: git


### PR DESCRIPTION
Reverts autowarefoundation/autoware#5749

I have merged the above PR since the CI was passing. However, the build check was actually skipped, and the build is failing.
It seems like we have to release 0.41.0 with the latest tier4/universe branch. 