### PR TITLE
ci: use require-label action for health-check

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -12,14 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  label-check:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: tag:run-health-check
 
   load-env:
-    needs: label-check
-    if: ${{ needs.label-check.outputs.result == 'true' ||
+    needs: require-label
+    if: ${{ needs.require-label.outputs.result == 'true' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/load-env.yaml


### PR DESCRIPTION
## Description
This replaces make-sure-label-is-present action with require-label action in order to enforce build check for all PRs.
Currently, if a PR does not have `tag:run-health-check` label added, it will skip the build check. Skipped CI will be treated as passing check in GitHub so there is risk that a PR can be merged without build check.

Using require-label action will report failure when the label is not present, which enables us to detect that CI is not running.

Relevant PR: https://github.com/autowarefoundation/autoware.universe/pull/9709

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
