### PR TITLE
feat(autoware.repos): fix tier4_autoware_msgs version

### DIFF
--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -23,6 +23,10 @@ repositories:
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
     version: tier4/universe
+  universe/external/tier4_autoware_msgs:
+    type: git
+    url: https://github.com/tier4/tier4_autoware_msgs.git
+    version: tier4/universe
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -41,7 +41,7 @@ repositories:
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: v0.40.0
+    version: v0.41.0
   # Fix the version not to merge https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9
   universe/external/morai_msgs:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -41,7 +41,7 @@ repositories:
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: tier4/universe
+    version: v0.40.0
   # Fix the version not to merge https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9
   universe/external/morai_msgs:
     type: git


### PR DESCRIPTION
## Description
This is a recreation of https://github.com/autowarefoundation/autoware/pull/5749 since it was reverted due to build failure.

The old PR specified v0.40.0 which is no longer compatible with version 0.41.0 of autoware.universe. This PR instead specifies v0.41.0 for tier4_autoware_msgs which includes new messages used by the latest autoware.universe.

## How was this PR tested?
The build will be tested through CI.

## Notes for reviewers

None.

## Effects on system behavior

None.
