### PR TITLE
build: move tamagawa_imu_driver and pacmod_interface repositories to extra-packages.repos

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -26,6 +26,7 @@ runs:
       run: |
         mkdir src
         vcs import src < autoware.repos
+        vcs import src < extra-packages.repos
       shell: bash
 
     - name: Setup Docker Buildx

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -33,6 +33,7 @@ runs:
       run: |
         mkdir src
         vcs import src < autoware.repos
+        vcs import src < extra-packages.repos
       shell: bash
 
     - name: Import additional repositories

--- a/autoware.repos
+++ b/autoware.repos
@@ -85,10 +85,6 @@ repositories:
     type: git
     url: https://github.com/tier4/sensor_component_description.git
     version: main
-  sensor_component/external/tamagawa_imu_driver:
-    type: git
-    url: https://github.com/tier4/tamagawa_imu_driver.git
-    version: ros2
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
@@ -128,10 +124,6 @@ repositories:
   vehicle/awsim_labs_vehicle_launch:
     type: git
     url: https://github.com/autowarefoundation/awsim_labs_vehicle_launch.git
-    version: main
-  vehicle/external/pacmod_interface:
-    type: git
-    url: https://github.com/tier4/pacmod_interface.git
     version: main
   # param
   param/autoware_individual_params:

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -113,9 +113,11 @@ clone_repositories() {
     if [ ! -d "src" ]; then
         mkdir -p src
         vcs import src <autoware.repos
+        vcs import src <extra-packages.repos
     else
         echo "Source directory already exists. Updating repositories..."
         vcs import src <autoware.repos
+        vcs import src <extra-packages.repos
         vcs pull src
     fi
 }

--- a/extra-packages.repos
+++ b/extra-packages.repos
@@ -1,0 +1,9 @@
+repositories:
+  sensor_component/external/tamagawa_imu_driver:
+    type: git
+    url: https://github.com/tier4/tamagawa_imu_driver.git
+    version: ros2
+  vehicle/external/pacmod_interface:
+    type: git
+    url: https://github.com/tier4/pacmod_interface.git
+    version: main


### PR DESCRIPTION
## Description

As part of https://github.com/autowarefoundation/autoware/issues/3366 we've agreed to move these two drivers to a separate repos file.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
