### PR TITLE
ci(docker): remove artifacts from base CUDA image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -41,9 +41,9 @@ CMD ["/bin/bash"]
 FROM base AS base-cuda
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Set up CUDA runtime environment and artifacts
+# Set up CUDA runtime environment
 # hadolint ignore=SC2002
 RUN --mount=type=ssh \
-  ./setup-dev-env.sh -y --module base --download-artifacts --no-cuda-drivers --runtime openadkit \
+  ./setup-dev-env.sh -y --module base --no-cuda-drivers --runtime openadkit \
   && pip uninstall -y ansible ansible-core \
   && /autoware/cleanup_apt.sh true


### PR DESCRIPTION
## Description

Relax about 1.7 GB space.

## How was this PR tested?

## Notes for reviewers

Due to type of CI runner, there is no unit tests which can use ML artifacts.

## Effects on system behavior

None.
