### PR TITLE
ci: revert "use require-label action for health-check"

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -12,14 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  require-label:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
+  label-check:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
     with:
       label: tag:run-health-check
 
   load-env:
-    needs: require-label
-    if: ${{ needs.require-label.outputs.result == 'true' ||
+    needs: label-check
+    if: ${{ needs.label-check.outputs.result == 'true' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/load-env.yaml


### PR DESCRIPTION
Reverts autowarefoundation/autoware#5771

The `health-check` workflow triggered by the `schedule` and `workflow_dispatch` events is now always failing. 
https://github.com/autowarefoundation/autoware/actions/runs/13675622013

I tried some correction methods, but it still isn’t working well. So I revert it for now and submit a fix PR later.