### PR TITLE
chore(Dockerfile): rename from `autoware:core-common-devel` to `autoware:core-external-devel`

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -64,16 +64,16 @@ runs:
       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Docker meta for autoware:core-common-devel
-      id: meta-core-common-devel
+    - name: Docker meta for autoware:core-external-devel
+      id: meta-core-external-devel
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=core-common-devel-${{ inputs.platform }}
-          type=raw,value=core-common-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=core-common-devel-,suffix=-${{ inputs.platform }}
-        bake-target: docker-metadata-action-core-common-devel
+          type=raw,value=core-external-devel-${{ inputs.platform }}
+          type=raw,value=core-external-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=core-external-devel-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-core-external-devel
         flavor: |
           latest=false
 
@@ -272,7 +272,7 @@ runs:
         push: true
         files: |
           docker/docker-bake.hcl
-          ${{ steps.meta-core-common-devel.outputs.bake-file }}
+          ${{ steps.meta-core-external-devel.outputs.bake-file }}
           ${{ steps.meta-core.outputs.bake-file }}
           ${{ steps.meta-core-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception-devel.outputs.bake-file }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,11 +31,11 @@ COPY src/core/autoware_lanelet2_extension /autoware/src/core/autoware_lanelet2_e
 COPY src/core/autoware_msgs /autoware/src/core/autoware_msgs
 COPY src/core/autoware_utils /autoware/src/core/autoware_utils
 RUN rosdep update && /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
-  > /rosdep-core-common-depend-packages.txt \
-  && cat /rosdep-core-common-depend-packages.txt
+  > /rosdep-core-external-depend-packages.txt \
+  && cat /rosdep-core-external-depend-packages.txt
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-types=exec \
-  > /rosdep-core-common-exec-depend-packages.txt \
-  && cat /rosdep-core-common-exec-depend-packages.txt
+  > /rosdep-core-external-exec-depend-packages.txt \
+  && cat /rosdep-core-external-exec-depend-packages.txt
 
 COPY src/core/autoware.core /autoware/src/core/autoware.core
 RUN rosdep update && /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
@@ -141,7 +141,7 @@ RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-ty
   && cat /rosdep-exec-depend-packages.txt
 
 # hadolint ignore=DL3006
-FROM $AUTOWARE_BASE_IMAGE AS core-common-devel
+FROM $AUTOWARE_BASE_IMAGE AS core-external-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -158,11 +158,11 @@ RUN --mount=type=ssh \
   && /autoware/cleanup_apt.sh
 
 # Install rosdep dependencies
-COPY --from=rosdep-depend /rosdep-core-common-depend-packages.txt /tmp/rosdep-core-common-depend-packages.txt
+COPY --from=rosdep-depend /rosdep-core-external-depend-packages.txt /tmp/rosdep-core-external-depend-packages.txt
 # hadolint ignore=SC2002
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get update \
-  && cat /tmp/rosdep-core-common-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
+  && cat /tmp/rosdep-core-external-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && /autoware/cleanup_apt.sh
 
 RUN --mount=type=cache,target=${CCACHE_DIR} \
@@ -178,7 +178,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
-FROM core-common-devel AS core-devel
+FROM core-external-devel AS core-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"

--- a/docker/Dockerfile.svg
+++ b/docker/Dockerfile.svg
@@ -21,9 +21,9 @@
     <!-- key2 -->
     <g id="node2" class="node">
       <title>key2</title>
-      <text text-anchor="start" x="315.12" y="-353.8" font-family="monospace" font-size="10.00"/>
-      <text text-anchor="start" x="315.12" y="-337.05" font-family="monospace" font-size="10.00"/>
-      <text text-anchor="start" x="315.12" y="-320.3" font-family="monospace" font-size="10.00"/>
+      <text text-anchor="start" x="315.12" y="-353.8" font-family="monospace" font-size="10.00"></text>
+      <text text-anchor="start" x="315.12" y="-337.05" font-family="monospace" font-size="10.00"></text>
+      <text text-anchor="start" x="315.12" y="-320.3" font-family="monospace" font-size="10.00"></text>
     </g>
     <!-- key&#45;&gt;key2 -->
     <g id="edge1" class="edge">
@@ -180,7 +180,7 @@
         stroke="black"
         d="M582.25,-467.18C582.25,-467.18 462.25,-467.18 462.25,-467.18 456.25,-467.18 450.25,-461.18 450.25,-455.18 450.25,-455.18 450.25,-443.18 450.25,-443.18 450.25,-437.18 456.25,-431.18 462.25,-431.18 462.25,-431.18 582.25,-431.18 582.25,-431.18 588.25,-431.18 594.25,-437.18 594.25,-443.18 594.25,-443.18 594.25,-455.18 594.25,-455.18 594.25,-461.18 588.25,-467.18 582.25,-467.18"
       />
-      <text text-anchor="middle" x="522.25" y="-444.13" font-family="Times,serif" font-size="14.00">core&#45;common&#45;devel</text>
+      <text text-anchor="middle" x="522.25" y="-444.13" font-family="Times,serif" font-size="14.00">core&#45;external&#45;devel</text>
     </g>
     <!-- stage_0&#45;&gt;stage_7 -->
     <g id="edge11" class="edge">

--- a/docker/Dockerfile.svg
+++ b/docker/Dockerfile.svg
@@ -21,9 +21,9 @@
     <!-- key2 -->
     <g id="node2" class="node">
       <title>key2</title>
-      <text text-anchor="start" x="315.12" y="-353.8" font-family="monospace" font-size="10.00"></text>
-      <text text-anchor="start" x="315.12" y="-337.05" font-family="monospace" font-size="10.00"></text>
-      <text text-anchor="start" x="315.12" y="-320.3" font-family="monospace" font-size="10.00"></text>
+      <text text-anchor="start" x="315.12" y="-353.8" font-family="monospace" font-size="10.00"/>
+      <text text-anchor="start" x="315.12" y="-337.05" font-family="monospace" font-size="10.00"/>
+      <text text-anchor="start" x="315.12" y="-320.3" font-family="monospace" font-size="10.00"/>
     </g>
     <!-- key&#45;&gt;key2 -->
     <g id="edge1" class="edge">

--- a/docker/README.md
+++ b/docker/README.md
@@ -91,7 +91,7 @@ This stage is built on top of `$AUTOWARE_BASE_IMAGE` and adds the CUDA runtime e
 The ROS dependency package list files will be generated.
 These files will be used in the subsequent stages:
 
-- `core-common-devel`
+- `core-external-devel`
 - `core-devel`
 - `core`
 - `universe-common`
@@ -102,9 +102,9 @@ These files will be used in the subsequent stages:
 
 By generating only the package list files and copying them to the subsequent stages, the dependency packages will not be reinstalled during the container build process unless the dependency packages change.
 
-### `core-common-devel`
+### `core-external-devel`
 
-This stage installs the dependency packages based on `/rosdep-core-common-depend-packages.txt` and builds the packages under the `core` directory of `autoware.repos` except for `autoware.core`.
+This stage installs the dependency packages based on `/rosdep-core-external-depend-packages.txt` and builds the packages under the `core` directory of `autoware.repos` except for `autoware.core`.
 
 ### `core-devel`
 

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,6 +1,6 @@
 group "default" {
   targets = [
-    "core-common-devel",
+    "core-external-devel",
     "core",
     "core-devel",
     "universe-sensing-perception-devel",
@@ -19,7 +19,7 @@ group "default" {
 }
 
 // For docker/metadata-action
-target "docker-metadata-action-core-common-devel" {}
+target "docker-metadata-action-core-external-devel" {}
 target "docker-metadata-action-core" {}
 target "docker-metadata-action-core-devel" {}
 target "docker-metadata-action-universe-sensing-perception-devel" {}
@@ -35,10 +35,10 @@ target "docker-metadata-action-universe-visualization" {}
 target "docker-metadata-action-universe-devel" {}
 target "docker-metadata-action-universe" {}
 
-target "core-common-devel" {
-  inherits = ["docker-metadata-action-core-common-devel"]
+target "core-external-devel" {
+  inherits = ["docker-metadata-action-core-external-devel"]
   dockerfile = "docker/Dockerfile"
-  target = "core-common-devel"
+  target = "core-external-devel"
 }
 
 target "core" {


### PR DESCRIPTION
## Description

Since `autoware:core-common-devel` stage, which https://github.com/autowarefoundation/autoware/pull/5849 introduced, could be interpreted as including the `autoware.core/common` directory, this PR renames the stage to `autoware:core-external-devel`.

This stage is intended to be used in the CI of `autoware.core`.

The subsequent PR https://github.com/autowarefoundation/autoware/pull/5853 will introduce the `autoware:universe-external-devel` stage, which includes only the external dependency repositories of `autoware.universe`, ensuring consistency.

## How was this PR tested?

- https://github.com/youtalk/autoware/actions/runs/13719057191
- https://hub.docker.com/layers/youtalk/autoware/core-external-devel-20250307-amd64/images/sha256-50ac008d1265476c0f6d32a2e4636a00bc53040ae977b113a3d37062b84d1921

## Notes for reviewers

None.

## Effects on system behavior

None.
