### PR TITLE
feat(Dockerfile): introduce `universe-external-devel` stage

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -103,6 +103,19 @@ runs:
         flavor: |
           latest=false
 
+    - name: Docker meta for autoware:universe-common-devel
+      id: meta-universe-common-devel
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=universe-common-devel-${{ inputs.platform }}
+          type=raw,value=universe-common-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-common-devel-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-universe-common-devel
+        flavor: |
+          latest=false
+
     - name: Docker meta for autoware:universe-sensing-perception-devel
       id: meta-universe-sensing-perception-devel
       uses: docker/metadata-action@v5
@@ -275,6 +288,7 @@ runs:
           ${{ steps.meta-core-external-devel.outputs.bake-file }}
           ${{ steps.meta-core.outputs.bake-file }}
           ${{ steps.meta-core-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-common-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception.outputs.bake-file }}
           ${{ steps.meta-universe-localization-mapping-devel.outputs.bake-file }}

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -103,16 +103,16 @@ runs:
         flavor: |
           latest=false
 
-    - name: Docker meta for autoware:universe-common-devel
-      id: meta-universe-common-devel
+    - name: Docker meta for autoware:universe-external-devel
+      id: meta-universe-external-devel
       uses: docker/metadata-action@v5
       with:
         images: ${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-common-devel-${{ inputs.platform }}
-          type=raw,value=universe-common-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-common-devel-,suffix=-${{ inputs.platform }}
-        bake-target: docker-metadata-action-universe-common-devel
+          type=raw,value=universe-external-devel-${{ inputs.platform }}
+          type=raw,value=universe-external-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-external-devel-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-universe-external-devel
         flavor: |
           latest=false
 
@@ -288,7 +288,7 @@ runs:
           ${{ steps.meta-core-external-devel.outputs.bake-file }}
           ${{ steps.meta-core.outputs.bake-file }}
           ${{ steps.meta-core-devel.outputs.bake-file }}
-          ${{ steps.meta-universe-common-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-external-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception.outputs.bake-file }}
           ${{ steps.meta-universe-localization-mapping-devel.outputs.bake-file }}

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -107,7 +107,7 @@ runs:
       id: meta-universe-external-devel
       uses: docker/metadata-action@v5
       with:
-        images: ${{ github.repository_owner }}/${{ inputs.target-image }}
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
           type=raw,value=universe-external-devel-${{ inputs.platform }}
           type=raw,value=universe-external-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,6 +46,10 @@ RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-ty
   && cat /rosdep-core-exec-depend-packages.txt
 
 COPY src/universe/external /autoware/src/universe/external
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
+  > /rosdep-universe-external-depend-packages.txt \
+  && cat /rosdep-universe-external-depend-packages.txt
+
 COPY src/universe/autoware.universe/common /autoware/src/universe/autoware.universe/common
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-common-depend-packages.txt \
@@ -199,7 +203,31 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
-FROM core-devel AS universe-common-devel
+FROM core-devel AS universe-external-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+# Install rosdep dependencies
+COPY --from=rosdep-depend /rosdep-universe-external-depend-packages.txt /tmp/rosdep-universe-external-depend-packages.txt
+# hadolint ignore=SC2002
+RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update \
+  && cat /tmp/rosdep-universe-external-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
+  && /autoware/cleanup_apt.sh
+
+# hadolint ignore=SC1091
+RUN --mount=type=cache,target=${CCACHE_DIR} \
+  --mount=type=bind,from=rosdep-depend,source=/autoware/src/universe/external,target=/autoware/src/universe/external \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
+FROM universe-external-devel AS universe-common-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
@@ -216,7 +244,6 @@ RUN --mount=type=ssh \
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,from=rosdep-depend,source=/autoware/src/universe/autoware.universe/common,target=/autoware/src/universe/autoware.universe/common \
-  --mount=type=bind,from=rosdep-depend,source=/autoware/src/universe/external,target=/autoware/src/universe/external \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -3,6 +3,7 @@ group "default" {
     "core-external-devel",
     "core",
     "core-devel",
+    "universe-common-devel",
     "universe-sensing-perception-devel",
     "universe-sensing-perception",
     "universe-localization-mapping-devel",
@@ -22,6 +23,7 @@ group "default" {
 target "docker-metadata-action-core-external-devel" {}
 target "docker-metadata-action-core" {}
 target "docker-metadata-action-core-devel" {}
+target "docker-metadata-action-universe-common-devel" {}
 target "docker-metadata-action-universe-sensing-perception-devel" {}
 target "docker-metadata-action-universe-sensing-perception" {}
 target "docker-metadata-action-universe-localization-mapping-devel" {}
@@ -51,6 +53,12 @@ target "core-devel" {
   inherits = ["docker-metadata-action-core-devel"]
   dockerfile = "docker/Dockerfile"
   target = "core-devel"
+}
+
+target "universe-common-devel" {
+  inherits = ["docker-metadata-action-universe-common-devel"]
+  dockerfile = "docker/Dockerfile"
+  target = "universe-common-devel"
 }
 
 target "universe-sensing-perception-devel" {

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -3,7 +3,7 @@ group "default" {
     "core-external-devel",
     "core",
     "core-devel",
-    "universe-common-devel",
+    "universe-external-devel",
     "universe-sensing-perception-devel",
     "universe-sensing-perception",
     "universe-localization-mapping-devel",
@@ -23,7 +23,7 @@ group "default" {
 target "docker-metadata-action-core-external-devel" {}
 target "docker-metadata-action-core" {}
 target "docker-metadata-action-core-devel" {}
-target "docker-metadata-action-universe-common-devel" {}
+target "docker-metadata-action-universe-external-devel" {}
 target "docker-metadata-action-universe-sensing-perception-devel" {}
 target "docker-metadata-action-universe-sensing-perception" {}
 target "docker-metadata-action-universe-localization-mapping-devel" {}
@@ -55,10 +55,10 @@ target "core-devel" {
   target = "core-devel"
 }
 
-target "universe-common-devel" {
-  inherits = ["docker-metadata-action-universe-common-devel"]
+target "universe-external-devel" {
+  inherits = ["docker-metadata-action-universe-external-devel"]
   dockerfile = "docker/Dockerfile"
-  target = "universe-common-devel"
+  target = "universe-external-devel"
 }
 
 target "universe-sensing-perception-devel" {


### PR DESCRIPTION
## Description

- [ ] #5852 

This PR adds the `autoware:universe-external-devel` stage, which excludes the `autoware.universe/common` directory from the `autoware:universe-common-devel` stage.

This stage is intended to be used in the CI of `autoware.universe`.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
