### PR TITLE
chore(docker): autoware_data directory as an option

### DIFF
--- a/docker/etc/ros_entrypoint.sh
+++ b/docker/etc/ros_entrypoint.sh
@@ -27,6 +27,12 @@ else
     source "/opt/ros/$ROS_DISTRO/setup.bash"
     source /opt/autoware/setup.bash
 
+    # Add symlink for autoware_data if directory exists
+    if [ -d /autoware_data ]; then
+        ln -s /autoware_data /home/"$USER_NAME"/autoware_data
+        echo "Linked /autoware_data to /home/$USER_NAME/autoware_data"
+    fi
+
     # Execute the command as the user
     exec /usr/sbin/gosu "$USER_NAME" "$@"
 fi

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -37,9 +37,9 @@ print_help() {
     echo -e "Options:"
     echo -e "  ${GREEN}--help/-h${NC}       Display this help message"
     echo -e "  ${GREEN}--map-path${NC}      Specify to mount map files into /autoware_map (mandatory for runtime)"
-    echo -e "  ${GREEN}--data-path${NC}     Specify to mount data files into /root/autoware_data (mandatory for runtime)"
     echo -e "  ${GREEN}--devel${NC}         Launch the latest Autoware development environment with shell access"
     echo -e "  ${GREEN}--workspace${NC}     (--devel only)Specify the directory to mount into /workspace, by default it uses current directory (pwd)"
+    echo -e "  ${GREEN}--data${NC}          (--devel only)Specify the directory to mount into /autoware_data"
     echo -e "  ${GREEN}--no-nvidia${NC}     Disable NVIDIA GPU support"
     echo -e "  ${GREEN}--headless${NC}      Run Autoware in headless mode (default: false)"
     echo ""
@@ -70,7 +70,7 @@ parse_arguments() {
             MAP_PATH="$2"
             shift
             ;;
-        --data-path)
+        --data)
             DATA_PATH="$2"
             shift
             ;;
@@ -115,7 +115,7 @@ set_variables() {
 
         # Set data path
         if [ "$DATA_PATH" != "" ]; then
-            DATA="-v ${DATA_PATH}:/root/autoware_data:rw"
+            DATA="-v ${DATA_PATH}:/autoware_data:rw"
         fi
 
         # Set launch command
@@ -127,14 +127,13 @@ set_variables() {
         IMAGE="ghcr.io/autowarefoundation/autoware:universe"
 
         # Set map path
-        if [ "$MAP_PATH" = "" ] || [ "$DATA_PATH" = "" ]; then
+        if [ "$MAP_PATH" = "" ]; then
             echo -e "\n------------------------------------------------------------"
-            echo -e "${RED}Note:${NC} The --map-path and --data-path option is mandatory for the universe(runtime image). For development environment with shell access, use --devel option."
+            echo -e "${RED}Note:${NC} The --map-path option is mandatory for the universe(runtime image). For development environment with shell access, use --devel option."
             echo -e "------------------------------------------------------------"
             exit 1
         else
             MAP="-v ${MAP_PATH}:/autoware_map:ro"
-            DATA="-v ${DATA_PATH}:/root/autoware_data:rw"
         fi
 
         # Set default launch command if not provided
@@ -184,6 +183,9 @@ main() {
     fi
     if [ "$MAP_PATH" != "" ]; then
         echo -e "${GREEN}MAP PATH(mounted):${NC} ${MAP_PATH}:/autoware_map"
+    fi
+    if [ "$DATA_PATH" != "" ]; then
+        echo -e "${GREEN}DATA PATH(mounted):${NC} ${DATA_PATH}:/autoware_data"
     fi
     echo -e "${GREEN}LAUNCH CMD:${NC} ${LAUNCH_CMD}"
     echo -e "${GREEN}-----------------------------------------------------------------${NC}"


### PR DESCRIPTION
## Description

After revert addressed in https://github.com/autowarefoundation/autoware/pull/5876, data directory mount is unnecessary. However, since development image has no artifacts, we can add an option for specifying data directory to mount.
Please note that an entrypoint update is required (launch files uses `$HOME` for artifacts). We can't mount autoware data directory into `$HOME/autoware_data` directly, because user creation fails.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
