### PR TITLE
chore(autoware.repos): rename `autoware_core` and `autoware_universe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To learn more about using or developing Autoware, refer to the [Autoware documen
 - [autowarefoundation/autoware_common](https://github.com/autowarefoundation/autoware_common)
   - Library/utility type repository containing commonly referenced ROS packages.
   - These packages were moved to a separate repository in order to reduce CI execution time
-- [autowarefoundation/autoware.core](https://github.com/autowarefoundation/autoware.core)
+- [autowarefoundation/autoware_core](https://github.com/autowarefoundation/autoware_core)
   - Main repository for high-quality, stable ROS packages for Autonomous Driving.
   - Based on [Autoware.Auto](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto) and [Autoware.Universe](https://github.com/autowarefoundation/autoware_universe).
 - [autowarefoundation/autoware_universe](https://github.com/autowarefoundation/autoware_universe)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 <!--- Contributors -->
 <p align="center">
-    <a href="https://github.com/autowarefoundation/autoware.universe/graphs/contributors">
-        <img src="https://img.shields.io/github/contributors/autowarefoundation/autoware.universe?style=flat&label=Autoware%20Universe%20Contributors"
+    <a href="https://github.com/autowarefoundation/autoware_universe/graphs/contributors">
+        <img src="https://img.shields.io/github/contributors/autowarefoundation/autoware_universe?style=flat&label=Autoware%20Universe%20Contributors"
             alt="Autoware Universe Contributors" /></a>
     <a href="https://github.com/autowarefoundation/autoware/graphs/contributors">
         <img src="https://img.shields.io/github/contributors/autowarefoundation/autoware?style=flat&label=Autoware%20Contributors"
@@ -14,8 +14,8 @@
 
 <!--- Commit Activity -->
 <p align="center">
-    <a href="https://github.com/autowarefoundation/autoware.universe/pulse">
-        <img src="https://img.shields.io/github/commit-activity/m/autowarefoundation/autoware.universe?style=flat&label=Autoware%20Universe%20Commit%20Activity"
+    <a href="https://github.com/autowarefoundation/autoware_universe/pulse">
+        <img src="https://img.shields.io/github/commit-activity/m/autowarefoundation/autoware_universe?style=flat&label=Autoware%20Universe%20Commit%20Activity"
             alt="Autoware Universe Activity" /></a>
     <a href="https://github.com/autowarefoundation/autoware/pulse">
         <img src="https://img.shields.io/github/commit-activity/m/autowarefoundation/autoware?style=flat&label=Autoware%20Commit%20Activity"
@@ -34,8 +34,8 @@
     <a href="https://github.com/autowarefoundation/autoware/actions/workflows/health-check.yaml?query=branch%3Amain">
         <img src="https://img.shields.io/github/actions/workflow/status/autowarefoundation/autoware/health-check.yaml?style=flat&label=health-check"
             alt="health-check CI" /></a>
-    <a href="https://app.codecov.io/gh/autowarefoundation/autoware.universe">
-        <img src="https://img.shields.io/codecov/c/gh/autowarefoundation/autoware.universe?style=flat&label=Coverage&logo=codecov&logoColor=white"
+    <a href="https://app.codecov.io/gh/autowarefoundation/autoware_universe">
+        <img src="https://img.shields.io/codecov/c/gh/autowarefoundation/autoware_universe?style=flat&label=Coverage&logo=codecov&logoColor=white"
             alt="Code Coverage" /></a>
 </p>
 
@@ -70,8 +70,8 @@ To learn more about using or developing Autoware, refer to the [Autoware documen
   - These packages were moved to a separate repository in order to reduce CI execution time
 - [autowarefoundation/autoware.core](https://github.com/autowarefoundation/autoware.core)
   - Main repository for high-quality, stable ROS packages for Autonomous Driving.
-  - Based on [Autoware.Auto](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto) and [Autoware.Universe](https://github.com/autowarefoundation/autoware.universe).
-- [autowarefoundation/autoware.universe](https://github.com/autowarefoundation/autoware.universe)
+  - Based on [Autoware.Auto](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto) and [Autoware.Universe](https://github.com/autowarefoundation/autoware_universe).
+- [autowarefoundation/autoware_universe](https://github.com/autowarefoundation/autoware_universe)
   - Repository for experimental, cutting-edge ROS packages for Autonomous Driving.
   - Autoware Universe was created to make it easier for researchers and developers to extend the functionality of Autoware Core
 - [autowarefoundation/autoware_launch](https://github.com/autowarefoundation/autoware_launch)
@@ -89,7 +89,7 @@ If you wish to use Autoware.AI, the previous version of Autoware based on ROS 1,
 
 ## Contributing
 
-- [There is no formal process to become a contributor](https://github.com/autowarefoundation/autoware-projects/wiki#contributors) - you can comment on any [existing issues](https://github.com/autowarefoundation/autoware.universe/issues) or make a pull request on any Autoware repository!
+- [There is no formal process to become a contributor](https://github.com/autowarefoundation/autoware-projects/wiki#contributors) - you can comment on any [existing issues](https://github.com/autowarefoundation/autoware_universe/issues) or make a pull request on any Autoware repository!
   - Make sure to follow the [Contribution Guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
   - Take a look at Autoware's [various working groups](https://github.com/autowarefoundation/autoware-projects/wiki#working-group-list) to gain an understanding of any work in progress and to see how projects are managed.
 - If you have any technical questions, you can start a discussion in the [Q&A category](https://github.com/autowarefoundation/autoware/discussions/categories/q-a) to request help and confirm if a potential issue is a bug or not.

--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -7,9 +7,9 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
     version: main
-  core/autoware.core:
+  core/autoware_core:
     type: git
-    url: https://github.com/autowarefoundation/autoware.core.git
+    url: https://github.com/autowarefoundation/autoware_core.git
     version: main
   core/autoware_utils: # TODO(mitsudome-r): Remove this repository entry when https://github.com/autowarefoundation/autoware/pull/5700 is merged.
     type: git

--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -15,9 +15,9 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git
     version: main
-  universe/autoware.universe:
+  universe/autoware_universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
+    url: https://github.com/autowarefoundation/autoware_universe.git
     version: main
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -25,9 +25,9 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
     version: 0.6.3
-  core/autoware.core:
+  core/autoware_core:
     type: git
-    url: https://github.com/autowarefoundation/autoware.core.git
+    url: https://github.com/autowarefoundation/autoware_core.git
     version: 0.2.0
   # universe
   universe/autoware_universe:

--- a/autoware.repos
+++ b/autoware.repos
@@ -4,7 +4,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
     version: 1.4.0
-  # TODO (isamu-takagi): Use a released version when autoware.universe uses a released version.
+  # TODO (isamu-takagi): Use a released version when autoware_universe uses a released version.
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
@@ -30,9 +30,9 @@ repositories:
     url: https://github.com/autowarefoundation/autoware.core.git
     version: 0.2.0
   # universe
-  universe/autoware.universe:
+  universe/autoware_universe:
     type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
+    url: https://github.com/autowarefoundation/autoware_universe.git
     version: 0.41.2
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
     type: git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-ty
 COPY src/universe/external /autoware/src/universe/external
 # trt_batched_nms depends on autoware_tensorrt_common and autoware_cuda_utils, which are not available in universe-common-devel stage
 RUN rm -rf /autoware/src/universe/external/trt_batched_nms
-COPY src/universe/autoware.universe/common /autoware/src/universe/autoware.universe/common
+COPY src/universe/autoware_universe/common /autoware/src/universe/autoware_universe/common
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-common-depend-packages.txt \
   && cat /rosdep-universe-common-depend-packages.txt
@@ -57,7 +57,7 @@ FROM rosdep-depend AS rosdep-universe-visualization-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware.universe/visualization /autoware/src/universe/autoware.universe/visualization
+COPY src/universe/autoware_universe/visualization /autoware/src/universe/autoware_universe/visualization
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-visualization-depend-packages.txt \
   && cat /rosdep-universe-visualization-depend-packages.txt
@@ -69,8 +69,8 @@ FROM rosdep-depend AS rosdep-universe-sensing-perception-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware.universe/perception /autoware/src/universe/autoware.universe/perception
-COPY src/universe/autoware.universe/sensing /autoware/src/universe/autoware.universe/sensing
+COPY src/universe/autoware_universe/perception /autoware/src/universe/autoware_universe/perception
+COPY src/universe/autoware_universe/sensing /autoware/src/universe/autoware_universe/sensing
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-sensing-perception-depend-packages.txt \
   && cat /rosdep-universe-sensing-perception-depend-packages.txt
@@ -82,8 +82,8 @@ FROM rosdep-depend AS rosdep-universe-localization-mapping-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware.universe/localization /autoware/src/universe/autoware.universe/localization
-COPY src/universe/autoware.universe/map /autoware/src/universe/autoware.universe/map
+COPY src/universe/autoware_universe/localization /autoware/src/universe/autoware_universe/localization
+COPY src/universe/autoware_universe/map /autoware/src/universe/autoware_universe/map
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-localization-mapping-depend-packages.txt \
   && cat /rosdep-universe-localization-mapping-depend-packages.txt
@@ -95,17 +95,17 @@ FROM rosdep-depend AS rosdep-universe-planning-control-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware.universe/launch/tier4_control_launch /autoware/src/universe/autoware.universe/launch/tier4_control_launch
-COPY src/universe/autoware.universe/launch/tier4_planning_launch /autoware/src/universe/autoware.universe/launch/tier4_planning_launch
-COPY src/universe/autoware.universe/control /autoware/src/universe/autoware.universe/control
-COPY src/universe/autoware.universe/planning /autoware/src/universe/autoware.universe/planning
-# TODO(youtalk): Remove COPYs when https://github.com/autowarefoundation/autoware.universe/issues/8805 is resolved
-COPY src/universe/autoware.universe/evaluator/autoware_control_evaluator /autoware/src/universe/autoware.universe/evaluator/autoware_control_evaluator
-COPY src/universe/autoware.universe/evaluator/autoware_planning_evaluator /autoware/src/universe/autoware.universe/evaluator/autoware_planning_evaluator
-COPY src/universe/autoware.universe/sensing/autoware_pcl_extensions /autoware/src/universe/autoware.universe/sensing/autoware_pcl_extensions
-COPY src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor /autoware/src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor
-COPY src/universe/autoware.universe/vehicle/autoware_external_cmd_converter /autoware/src/universe/autoware.universe/vehicle/autoware_external_cmd_converter
-COPY src/universe/autoware.universe/vehicle/autoware_raw_vehicle_cmd_converter /autoware/src/universe/autoware.universe/vehicle/autoware_raw_vehicle_cmd_converter
+COPY src/universe/autoware_universe/launch/tier4_control_launch /autoware/src/universe/autoware_universe/launch/tier4_control_launch
+COPY src/universe/autoware_universe/launch/tier4_planning_launch /autoware/src/universe/autoware_universe/launch/tier4_planning_launch
+COPY src/universe/autoware_universe/control /autoware/src/universe/autoware_universe/control
+COPY src/universe/autoware_universe/planning /autoware/src/universe/autoware_universe/planning
+# TODO(youtalk): Remove COPYs when https://github.com/autowarefoundation/autoware_universe/issues/8805 is resolved
+COPY src/universe/autoware_universe/evaluator/autoware_control_evaluator /autoware/src/universe/autoware_universe/evaluator/autoware_control_evaluator
+COPY src/universe/autoware_universe/evaluator/autoware_planning_evaluator /autoware/src/universe/autoware_universe/evaluator/autoware_planning_evaluator
+COPY src/universe/autoware_universe/sensing/autoware_pcl_extensions /autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions
+COPY src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor /autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor
+COPY src/universe/autoware_universe/vehicle/autoware_external_cmd_converter /autoware/src/universe/autoware_universe/vehicle/autoware_external_cmd_converter
+COPY src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter /autoware/src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-planning-control-depend-packages.txt \
   && cat /rosdep-universe-planning-control-depend-packages.txt
@@ -117,12 +117,12 @@ FROM rosdep-depend AS rosdep-universe-vehicle-system-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware.universe/launch/tier4_vehicle_launch /autoware/src/universe/autoware.universe/launch/tier4_vehicle_launch
-COPY src/universe/autoware.universe/launch/tier4_system_launch /autoware/src/universe/autoware.universe/launch/tier4_system_launch
-COPY src/universe/autoware.universe/vehicle /autoware/src/universe/autoware.universe/vehicle
-COPY src/universe/autoware.universe/system /autoware/src/universe/autoware.universe/system
-COPY src/universe/autoware.universe/map/autoware_map_height_fitter /autoware/src/universe/autoware.universe/map/autoware_map_height_fitter
-COPY src/universe/autoware.universe/localization/autoware_pose2twist /autoware/src/universe/autoware.universe/localization/autoware_pose2twist
+COPY src/universe/autoware_universe/launch/tier4_vehicle_launch /autoware/src/universe/autoware_universe/launch/tier4_vehicle_launch
+COPY src/universe/autoware_universe/launch/tier4_system_launch /autoware/src/universe/autoware_universe/launch/tier4_system_launch
+COPY src/universe/autoware_universe/vehicle /autoware/src/universe/autoware_universe/vehicle
+COPY src/universe/autoware_universe/system /autoware/src/universe/autoware_universe/system
+COPY src/universe/autoware_universe/map/autoware_map_height_fitter /autoware/src/universe/autoware_universe/map/autoware_map_height_fitter
+COPY src/universe/autoware_universe/localization/autoware_pose2twist /autoware/src/universe/autoware_universe/localization/autoware_pose2twist
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-vehicle-system-depend-packages.txt \
   && cat /rosdep-universe-vehicle-system-depend-packages.txt
@@ -223,7 +223,7 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware.universe/common,target=/autoware/src/universe/autoware.universe/common \
+  --mount=type=bind,source=src/universe/autoware_universe/common,target=/autoware/src/universe/autoware_universe/common \
   --mount=type=bind,source=src/universe/external/eagleye,target=/autoware/src/universe/external/eagleye \
   --mount=type=bind,source=src/universe/external/glog,target=/autoware/src/universe/external/glog \
   --mount=type=bind,source=src/universe/external/llh_converter,target=/autoware/src/universe/external/llh_converter \
@@ -270,8 +270,8 @@ RUN --mount=type=ssh \
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/external/trt_batched_nms,target=/autoware/src/universe/external/trt_batched_nms \
-  --mount=type=bind,source=src/universe/autoware.universe/perception,target=/autoware/src/universe/autoware.universe/perception \
-  --mount=type=bind,source=src/universe/autoware.universe/sensing,target=/autoware/src/universe/autoware.universe/sensing \
+  --mount=type=bind,source=src/universe/autoware_universe/perception,target=/autoware/src/universe/autoware_universe/perception \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing,target=/autoware/src/universe/autoware_universe/sensing \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
@@ -297,8 +297,8 @@ COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware.universe/perception,target=/autoware/src/universe/autoware.universe/perception \
-  --mount=type=bind,source=src/universe/autoware.universe/sensing,target=/autoware/src/universe/autoware.universe/sensing \
+  --mount=type=bind,source=src/universe/autoware_universe/perception,target=/autoware/src/universe/autoware_universe/perception \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing,target=/autoware/src/universe/autoware_universe/sensing \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware "--packages-above-and-dependencies autoware_tensorrt_common"
@@ -322,8 +322,8 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware.universe/localization,target=/autoware/src/universe/autoware.universe/localization \
-  --mount=type=bind,source=src/universe/autoware.universe/map,target=/autoware/src/universe/autoware.universe/map \
+  --mount=type=bind,source=src/universe/autoware_universe/localization,target=/autoware/src/universe/autoware_universe/localization \
+  --mount=type=bind,source=src/universe/autoware_universe/map,target=/autoware/src/universe/autoware_universe/map \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
@@ -344,17 +344,17 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware.universe/launch/tier4_control_launch,target=/autoware/src/universe/autoware.universe/launch/tier4_control_launch \
-  --mount=type=bind,source=src/universe/autoware.universe/launch/tier4_planning_launch,target=/autoware/src/universe/autoware.universe/launch/tier4_planning_launch \
-  --mount=type=bind,source=src/universe/autoware.universe/control,target=/autoware/src/universe/autoware.universe/control \
-  --mount=type=bind,source=src/universe/autoware.universe/planning,target=/autoware/src/universe/autoware.universe/planning \
-  # TODO(youtalk): Remove --mount options when https://github.com/autowarefoundation/autoware.universe/issues/8805 is resolved
-  --mount=type=bind,source=src/universe/autoware.universe/evaluator/autoware_control_evaluator,target=/autoware/src/universe/autoware.universe/evaluator/autoware_control_evaluator \
-  --mount=type=bind,source=src/universe/autoware.universe/evaluator/autoware_planning_evaluator,target=/autoware/src/universe/autoware.universe/evaluator/autoware_planning_evaluator \
-  --mount=type=bind,source=src/universe/autoware.universe/sensing/autoware_pcl_extensions,target=/autoware/src/universe/autoware.universe/sensing/autoware_pcl_extensions \
-  --mount=type=bind,source=src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor,target=/autoware/src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor \
-  --mount=type=bind,source=src/universe/autoware.universe/vehicle/autoware_external_cmd_converter,target=/autoware/src/universe/autoware.universe/vehicle/autoware_external_cmd_converter \
-  --mount=type=bind,source=src/universe/autoware.universe/vehicle/autoware_raw_vehicle_cmd_converter,target=/autoware/src/universe/autoware.universe/vehicle/autoware_raw_vehicle_cmd_converter \
+  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_control_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_control_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_planning_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_planning_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/control,target=/autoware/src/universe/autoware_universe/control \
+  --mount=type=bind,source=src/universe/autoware_universe/planning,target=/autoware/src/universe/autoware_universe/planning \
+  # TODO(youtalk): Remove --mount options when https://github.com/autowarefoundation/autoware_universe/issues/8805 is resolved
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_control_evaluator,target=/autoware/src/universe/autoware_universe/evaluator/autoware_control_evaluator \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_planning_evaluator,target=/autoware/src/universe/autoware_universe/evaluator/autoware_planning_evaluator \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing/autoware_pcl_extensions,target=/autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor,target=/autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor \
+  --mount=type=bind,source=src/universe/autoware_universe/vehicle/autoware_external_cmd_converter,target=/autoware/src/universe/autoware_universe/vehicle/autoware_external_cmd_converter \
+  --mount=type=bind,source=src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter,target=/autoware/src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
@@ -378,12 +378,12 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware.universe/launch/tier4_vehicle_launch,target=/autoware/src/universe/autoware.universe/launch/tier4_vehicle_launch \
-  --mount=type=bind,source=src/universe/autoware.universe/launch/tier4_system_launch,target=/autoware/src/universe/autoware.universe/launch/tier4_system_launch \
-  --mount=type=bind,source=src/universe/autoware.universe/vehicle,target=/autoware/src/universe/autoware.universe/vehicle \
-  --mount=type=bind,source=src/universe/autoware.universe/system,target=/autoware/src/universe/autoware.universe/system \
-  --mount=type=bind,source=src/universe/autoware.universe/map/autoware_map_height_fitter,target=/autoware/src/universe/autoware.universe/map/autoware_map_height_fitter \
-  --mount=type=bind,source=src/universe/autoware.universe/localization/autoware_pose2twist,target=/autoware/src/universe/autoware.universe/localization/autoware_pose2twist \
+  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_vehicle_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_vehicle_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_system_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_system_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/vehicle,target=/autoware/src/universe/autoware_universe/vehicle \
+  --mount=type=bind,source=src/universe/autoware_universe/system,target=/autoware/src/universe/autoware_universe/system \
+  --mount=type=bind,source=src/universe/autoware_universe/map/autoware_map_height_fitter,target=/autoware/src/universe/autoware_universe/map/autoware_map_height_fitter \
+  --mount=type=bind,source=src/universe/autoware_universe/localization/autoware_pose2twist,target=/autoware/src/universe/autoware_universe/localization/autoware_pose2twist \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
@@ -407,7 +407,7 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware.universe/visualization,target=/autoware/src/universe/autoware.universe/visualization \
+  --mount=type=bind,source=src/universe/autoware_universe/visualization,target=/autoware/src/universe/autoware_universe/visualization \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
@@ -440,10 +440,10 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/param,target=/autoware/src/param \
   --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
   --mount=type=bind,source=src/sensor_kit,target=/autoware/src/sensor_kit \
-  --mount=type=bind,source=src/universe/autoware.universe/evaluator,target=/autoware/src/universe/autoware.universe/evaluator \
-  --mount=type=bind,source=src/universe/autoware.universe/launch,target=/autoware/src/universe/autoware.universe/launch \
-  --mount=type=bind,source=src/universe/autoware.universe/simulator,target=/autoware/src/universe/autoware.universe/simulator \
-  --mount=type=bind,source=src/universe/autoware.universe/tools,target=/autoware/src/universe/autoware.universe/tools \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
+  --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \
+  --mount=type=bind,source=src/universe/autoware_universe/simulator,target=/autoware/src/universe/autoware_universe/simulator \
+  --mount=type=bind,source=src/universe/autoware_universe/tools,target=/autoware/src/universe/autoware_universe/tools \
   --mount=type=bind,source=src/vehicle,target=/autoware/src/vehicle \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-ty
   > /rosdep-core-common-exec-depend-packages.txt \
   && cat /rosdep-core-common-exec-depend-packages.txt
 
-COPY src/core/autoware.core /autoware/src/core/autoware.core
+COPY src/core/autoware_core /autoware/src/core/autoware_core
 RUN rosdep update && /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-core-depend-packages.txt \
   && cat /rosdep-core-depend-packages.txt
@@ -200,7 +200,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && /autoware/cleanup_apt.sh
 
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/core/autoware.core,target=/autoware/src/core/autoware.core \
+  --mount=type=bind,source=src/core/autoware_core,target=/autoware/src/core/autoware_core \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -104,11 +104,11 @@ By generating only the package list files and copying them to the subsequent sta
 
 ### `core-common-devel`
 
-This stage installs the dependency packages based on `/rosdep-core-common-depend-packages.txt` and builds the packages under the `core` directory of `autoware.repos` except for `autoware.core`.
+This stage installs the dependency packages based on `/rosdep-core-common-depend-packages.txt` and builds the packages under the `core` directory of `autoware.repos` except for `autoware_core`.
 
 ### `core-devel`
 
-This stage installs the dependency packages based on `/rosdep-core-depend-packages.txt` and builds the `autoware.core` packages.
+This stage installs the dependency packages based on `/rosdep-core-depend-packages.txt` and builds the `autoware_core` packages.
 
 ### `core`
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,20 +14,20 @@ $ git clone git@github.com:autowarefoundation/autoware.git
 $ cd autoware
 $ vcs import src < autoware.repos
 $ docker run -it --rm \
-  –v $PWD/src/universe/autoware.universe/XXX/autoware_YYY:/autoware/src/autoware_YYY \
+  –v $PWD/src/universe/autoware_universe/XXX/autoware_YYY:/autoware/src/autoware_YYY \
   ghcr.io/autowarefoundation/autoware:universe-devel-cuda
 $ colcon build --mixin debug compile-commands
 $ source install/setup.bash
 $ ros2 run --prefix "gdb -ex run --args" autoware_YYY ZZZ
 ```
 
-For example, if you want to make modifications to [`autoware.universe/perception/autoware_bytetrack`](https://github.com/autowarefoundation/autoware.universe/tree/main/perception/autoware_bytetrack), you can execute the following commands to perform the volume mount and debug build and execution of only the `autoware_bytetrack`.
+For example, if you want to make modifications to [`autoware_universe/perception/autoware_bytetrack`](https://github.com/autowarefoundation/autoware_universe/tree/main/perception/autoware_bytetrack), you can execute the following commands to perform the volume mount and debug build and execution of only the `autoware_bytetrack`.
 
 Note that `gdb` is not currently installed in the development containers, but it would be installed in the near future.
 
 ```shell
 $ docker run -it --rm \
-  -v $PWD/src/universe/autoware.universe/perception/autoware_bytetrack:/autoware/src/autoware_bytetrack \
+  -v $PWD/src/universe/autoware_universe/perception/autoware_bytetrack:/autoware/src/autoware_bytetrack \
   ghcr.io/autowarefoundation/autoware:universe-devel-cuda
 $ root@a566e785c4d2:/autoware# colcon build --mixin debug compile-commands
 Starting >>> autoware_bytetrack
@@ -119,7 +119,7 @@ This stage is an Autoware Core runtime container. It only includes the dependenc
 This stage installs the dependency packages based on `/rosdep-universe-common-depend-packages.txt` and builds the packages under the following directories of `autoware.repos`:
 
 - `universe/external`
-- `universe/autoware.universe/common`
+- `universe/autoware_universe/common`
 
 ### `universe-common-devel-cuda`
 
@@ -129,15 +129,15 @@ This stage is built on top of `universe-common-devel` and installs the CUDA deve
 
 This stage installs the dependency packages based on `/rosdep-universe-sensing-perception-depend-packages.txt` and builds the non-CUDA related packages under the following directories of `autoware.repos`:
 
-- `universe/autoware.universe/perception`
-- `universe/autoware.universe/sensing`
+- `universe/autoware_universe/perception`
+- `universe/autoware_universe/sensing`
 
 ### `universe-sensing-perception-devel-cuda`
 
 This stage copies the non-CUDA related binaries built in the `universe-sensing-perception-devel` stage and builds the CUDA related packages under the following directories of `autoware.repos`:
 
-- `universe/autoware.universe/perception`
-- `universe/autoware.universe/sensing`
+- `universe/autoware_universe/perception`
+- `universe/autoware_universe/sensing`
 
 ### `universe-sensing-perception`
 
@@ -159,8 +159,8 @@ This stage is a Autoware Universe Visualization runtime container. It only inclu
 
 This stage installs the dependency packages based on `/rosdep-universe-localization-mapping-depend-packages.txt` and builds the packages under the following directories of `autoware.repos`:
 
-- `universe/autoware.universe/localization`
-- `universe/autoware.universe/map`
+- `universe/autoware_universe/localization`
+- `universe/autoware_universe/map`
 
 ### `universe-localization-mapping`
 
@@ -170,8 +170,8 @@ This stage is an Autoware Universe Localization/Mapping runtime container. It on
 
 This stage installs the dependency packages based on `/rosdep-universe-planning-control-depend-packages.txt` and builds the packages under the following directories of `autoware.repos`:
 
-- `universe/autoware.universe/control`
-- `universe/autoware.universe/planning`
+- `universe/autoware_universe/control`
+- `universe/autoware_universe/planning`
 
 ### `universe-planning-control`
 
@@ -181,8 +181,8 @@ This stage is an Autoware Universe Planning/Control runtime container. It only i
 
 This stage installs the dependency packages based on `/rosdep-universe-vehicle-system-depend-packages.txt` and builds the packages under the following directories of `autoware.repos`:
 
-- `universe/autoware.universe/vehicle`
-- `universe/autoware.universe/system`
+- `universe/autoware_universe/vehicle`
+- `universe/autoware_universe/system`
 
 ### `universe-vehicle-system`
 
@@ -204,10 +204,10 @@ Then it builds the remaining packages of `autoware.repos`:
 - `param`
 - `sensor_component`
 - `sensor_kit`
-- `universe/autoware.universe/evaluator`
-- `universe/autoware.universe/launch`
-- `universe/autoware.universe/simulator`
-- `universe/autoware.universe/tools`
+- `universe/autoware_universe/evaluator`
+- `universe/autoware_universe/launch`
+- `universe/autoware_universe/simulator`
+- `universe/autoware_universe/tools`
 - `vehicle`
 
 This stage provides an all-in-one development container to Autoware developers. By running the host's source code with volume mounting, it allows for easy building and debugging of Autoware.

--- a/docker/README.md
+++ b/docker/README.md
@@ -68,6 +68,7 @@ ros2 launch autoware_pointcloud_preprocessor preprocessor.launch.xml
 
 ## Multi-stage Dockerfile structure
 
+<!-- cspell:disable-next-line -->
 <!-- dockerfilegraph -f docker/Dockerfile -o svg --legend --concentrate --nodesep 0.3 --unflatten 4 -m 50 -e solid -->
 
 ![](./Dockerfile.svg)


### PR DESCRIPTION
## Description

Since https://github.com/orgs/autowarefoundation/discussions/5684 is closed, this PR renames `autoware_core` and `autoware_universe`.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
