### PR TITLE
fix(docker-build-and-push-cuda): add `vcs import src < extra-packages.repos`

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -26,6 +26,7 @@ runs:
       run: |
         mkdir src
         vcs import src < autoware.repos
+        vcs import src < extra-packages.repos
       shell: bash
 
     - name: Setup Docker Buildx


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware/pull/5801 introduces `extra-packages.repos` to install drivers but the `docker-build-and-push-cuda` action couldn't be accidentally applied. This PR fixes the problem.

Ref. https://github.com/youtalk/autoware/actions/runs/13986694925/job/39163904844#step:6:2841

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
