### PR TITLE
feat(autoware.repos): bumped the cuda_blackboard's version to 0.2.0

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -78,7 +78,7 @@ repositories:
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git
-    version: v0.1.1
+    version: v0.2.0
   universe/external/negotiated:
     type: git
     url: https://github.com/osrf/negotiated.git


### PR DESCRIPTION
## Description

In the `cuda_blackboard` subscribers needed to configure whether they need or not a compatible subscriber (a default ROS message), causing confusion as to when that was necessary. In the `v0.2.0` release, the compatible subscriber is added by default and disconnected automatically once a negotiated (a cuda blackboard) publisher is detected.


## How was this PR tested?

Tested locally using the logging simulator with the PRs from https://github.com/autowarefoundation/autoware_universe/issues/9722

## Notes for reviewers

This PR does not make an impact in the current autoware.
However, it is required to address the feedback received in https://github.com/autowarefoundation/autoware_universe/pull/9453

## Effects on system behavior
Nodes using the `cuda_blackboard` will be able to automatically disconnect to the compatible subscriber once a negotiated subscriber message is received.
