### PR TITLE
feat(docker-build-and-push): push `autoware:universe-common-devel` image

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -104,6 +104,19 @@ runs:
         flavor: |
           latest=false
 
+    - name: Docker meta for autoware:universe-common-devel
+      id: meta-universe-common-devel
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=universe-common-devel-${{ inputs.platform }}
+          type=raw,value=universe-common-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-common-devel-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-universe-common-devel
+        flavor: |
+          latest=false
+
     - name: Docker meta for autoware:universe-sensing-perception-devel
       id: meta-universe-sensing-perception-devel
       uses: docker/metadata-action@v5
@@ -276,6 +289,7 @@ runs:
           ${{ steps.meta-core-common-devel.outputs.bake-file }}
           ${{ steps.meta-core.outputs.bake-file }}
           ${{ steps.meta-core-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-common-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception-devel.outputs.bake-file }}
           ${{ steps.meta-universe-sensing-perception.outputs.bake-file }}
           ${{ steps.meta-universe-localization-mapping-devel.outputs.bake-file }}

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -3,6 +3,7 @@ group "default" {
     "core-common-devel",
     "core",
     "core-devel",
+    "universe-common-devel",
     "universe-sensing-perception-devel",
     "universe-sensing-perception",
     "universe-localization-mapping-devel",
@@ -22,6 +23,7 @@ group "default" {
 target "docker-metadata-action-core-common-devel" {}
 target "docker-metadata-action-core" {}
 target "docker-metadata-action-core-devel" {}
+target "docker-metadata-action-universe-common-devel" {}
 target "docker-metadata-action-universe-sensing-perception-devel" {}
 target "docker-metadata-action-universe-sensing-perception" {}
 target "docker-metadata-action-universe-localization-mapping-devel" {}
@@ -51,6 +53,12 @@ target "core-devel" {
   inherits = ["docker-metadata-action-core-devel"]
   dockerfile = "docker/Dockerfile"
   target = "core-devel"
+}
+
+target "universe-common-devel" {
+  inherits = ["docker-metadata-action-universe-common-devel"]
+  dockerfile = "docker/Dockerfile"
+  target = "universe-common-devel"
 }
 
 target "universe-sensing-perception-devel" {


### PR DESCRIPTION
## Description

As with https://github.com/autowarefoundation/autoware/pull/5849, We want to reduce the dependency on `build_depends.repos` not only in `autoware_core` but also in `autoware_universe`. Therefore, this PR pushes the `autoware:universe-common-devel` image to the registry. 

I’ll modify `autoware_universe`’s CIs to use it next.

## How was this PR tested?

https://github.com/autowarefoundation/autoware/actions/runs/14076100054

## Notes for reviewers

None.

## Effects on system behavior

None.
