### PR TITLE
chore(autoware.repos): fix branch refs to commit hashes

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -8,7 +8,7 @@ repositories:
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: beta/1.7.0
+    version: e62ea6fdb9ee50e49c7642c77e85250cb15b8e80
   core/autoware_internal_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
@@ -50,31 +50,31 @@ repositories:
   universe/external/muSSP:
     type: git
     url: https://github.com/tier4/muSSP.git
-    version: tier4/main
+    version: c79e98fd5e658f4f90c06d93472faa977bc873b9
   universe/external/pointcloud_to_laserscan:
     type: git
     url: https://github.com/tier4/pointcloud_to_laserscan.git
-    version: tier4/main
+    version: d969ec699f84fad827fbadfa3001c9c657482fbe
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git
-    version: autoware-main
+    version: c1919448336e86a8dd9c94a337032c05fcf6c381
   universe/external/rtklib_ros_bridge:
     type: git
     url: https://github.com/MapIV/rtklib_ros_bridge.git
-    version: ros2-v0.1.0
+    version: ef094407bba4f475a8032972e0c60cbb939b51b8
   universe/external/llh_converter:
     type: git
     url: https://github.com/MapIV/llh_converter.git
-    version: ros2
+    version: 07ad112b4f6b83eccd3a5f777bbe40ff01c67382
   universe/external/glog:  # TODO(Horibe): to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git
-    version: v0.6.0_t4-ros
+    version: ea36766fdc2ac8e8c8e3ac988ae69acd6d09bb30
   universe/external/trt_batched_nms:
     type: git
     url: https://github.com/autowarefoundation/trt_batched_nms.git
-    version: main
+    version: 1a9df130b4a5d96c25019b5793abbfde42d237ac
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git
@@ -92,7 +92,7 @@ repositories:
   sensor_component/external/sensor_component_description:
     type: git
     url: https://github.com/tier4/sensor_component_description.git
-    version: main
+    version: 03ba094851ec90febfcfc0adb20b64b0e19df7a8
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
@@ -101,12 +101,12 @@ repositories:
   sensor_component/transport_drivers:
     type: git
     url: https://github.com/autowarefoundation/transport_drivers
-    version: main
+    version: 39ebd8afe1bb9760a6cd6272e428468480f6de90
   # Continental compatible version of ROS 2 socket CAN
   sensor_component/ros2_socketcan:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan
-    version: main
+    version: e39a814180b03f00a5692b6951a5d4e9f0463486
   # sensor_kit
   sensor_kit/sample_sensor_kit_launch:
     type: git
@@ -128,16 +128,16 @@ repositories:
   vehicle/sample_vehicle_launch:
     type: git
     url: https://github.com/autowarefoundation/sample_vehicle_launch.git
-    version: main
+    version: cd852aed85aaf033a0747050cf4300967e89c1ae
   vehicle/awsim_labs_vehicle_launch:
     type: git
     url: https://github.com/autowarefoundation/awsim_labs_vehicle_launch.git
-    version: main
+    version: be791b9b257ef6a440c635f95438310abf876d95
   # param
   param/autoware_individual_params:
     type: git
     url: https://github.com/autowarefoundation/autoware_individual_params.git
-    version: main
+    version: 70000825155182d9261ce0980076b0e2c6dc3f51
   # middleware
   # TODO(TIER IV): During the transition period of Agnocast introduction,
   # the Agnocast ROS packages are provided as a source build.


### PR DESCRIPTION
## Description

If you run:
```bash
vcs import src < autoware.repos
vcs export src --exact-with-tags
```

You'll get:

<details>
  <summary>🖱️Click here to expand🔛</summary>

```console
mfc@whale:~/projects/autoware$ vcs export src --exact-with-tags
repositories:
  core/autoware_adapi_msgs:
    type: git
    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
    version: e62ea6fdb9ee50e49c7642c77e85250cb15b8e80
  core/autoware_cmake:
    type: git
    url: https://github.com/autowarefoundation/autoware_cmake.git
    version: 1.0.1
  core/autoware_core:
    type: git
    url: https://github.com/autowarefoundation/autoware_core.git
    version: 0.3.0
  core/autoware_internal_msgs:
    type: git
    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
    version: 1.8.0
  core/autoware_lanelet2_extension:
    type: git
    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
    version: 0.6.3
  core/autoware_msgs:
    type: git
    url: https://github.com/autowarefoundation/autoware_msgs.git
    version: 1.4.0
  core/autoware_utils:
    type: git
    url: https://github.com/autowarefoundation/autoware_utils.git
    version: 1.3.0
  launcher/autoware_launch:
    type: git
    url: https://github.com/autowarefoundation/autoware_launch.git
    version: 0.43.0
  middleware/external/agnocast:
    type: git
    url: https://github.com/tier4/agnocast.git
    version: 1.0.2
  param/autoware_individual_params:
    type: git
    url: https://github.com/autowarefoundation/autoware_individual_params.git
    version: 70000825155182d9261ce0980076b0e2c6dc3f51
  sensor_component/external/nebula:
    type: git
    url: https://github.com/tier4/nebula.git
    version: v0.2.4
  sensor_component/external/sensor_component_description:
    type: git
    url: https://github.com/tier4/sensor_component_description.git
    version: 03ba094851ec90febfcfc0adb20b64b0e19df7a8
  sensor_component/ros2_socketcan:
    type: git
    url: https://github.com/autowarefoundation/ros2_socketcan
    version: e39a814180b03f00a5692b6951a5d4e9f0463486
  sensor_component/transport_drivers:
    type: git
    url: https://github.com/autowarefoundation/transport_drivers
    version: 39ebd8afe1bb9760a6cd6272e428468480f6de90
  sensor_kit/awsim_labs_sensor_kit_launch:
    type: git
    url: https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch.git
    version: 0.42.0
  sensor_kit/external/awsim_sensor_kit_launch:
    type: git
    url: https://github.com/tier4/awsim_sensor_kit_launch.git
    version: 0.42.0
  sensor_kit/sample_sensor_kit_launch:
    type: git
    url: https://github.com/autowarefoundation/sample_sensor_kit_launch.git
    version: 0.42.0
  sensor_kit/single_lidar_sensor_kit_launch:
    type: git
    url: https://github.com/autowarefoundation/single_lidar_sensor_kit_launch.git
    version: 0.42.0
  tools:
    type: git
    url: https://github.com/autowarefoundation/autoware_tools.git
    version: 0.2.0
  universe/autoware_universe:
    type: git
    url: https://github.com/autowarefoundation/autoware_universe.git
    version: 0.43.0
  universe/external/cuda_blackboard:
    type: git
    url: https://github.com/autowarefoundation/cuda_blackboard.git
    version: v0.2.0
  universe/external/eagleye:
    type: git
    url: https://github.com/MapIV/eagleye.git
    version: c1919448336e86a8dd9c94a337032c05fcf6c381
  universe/external/glog:
    type: git
    url: https://github.com/tier4/glog.git
    version: ea36766fdc2ac8e8c8e3ac988ae69acd6d09bb30
  universe/external/llh_converter:
    type: git
    url: https://github.com/MapIV/llh_converter.git
    version: 07ad112b4f6b83eccd3a5f777bbe40ff01c67382
  universe/external/morai_msgs:
    type: git
    url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
    version: e2e75fc1603a9798773e467a679edf68b448e705
  universe/external/muSSP:
    type: git
    url: https://github.com/tier4/muSSP.git
    version: c79e98fd5e658f4f90c06d93472faa977bc873b9
  universe/external/negotiated:
    type: git
    url: https://github.com/osrf/negotiated.git
    version: eac198b55dcd052af5988f0f174902913c5f20e7
  universe/external/pointcloud_to_laserscan:
    type: git
    url: https://github.com/tier4/pointcloud_to_laserscan.git
    version: d969ec699f84fad827fbadfa3001c9c657482fbe
  universe/external/rtklib_ros_bridge:
    type: git
    url: https://github.com/MapIV/rtklib_ros_bridge.git
    version: ef094407bba4f475a8032972e0c60cbb939b51b8
  universe/external/tier4_ad_api_adaptor:
    type: git
    url: https://github.com/tier4/tier4_ad_api_adaptor.git
    version: 0.41.0
  universe/external/tier4_autoware_msgs:
    type: git
    url: https://github.com/tier4/tier4_autoware_msgs.git
    version: v0.41.0
  universe/external/trt_batched_nms:
    type: git
    url: https://github.com/autowarefoundation/trt_batched_nms.git
    version: 1a9df130b4a5d96c25019b5793abbfde42d237ac
  vehicle/awsim_labs_vehicle_launch:
    type: git
    url: https://github.com/autowarefoundation/awsim_labs_vehicle_launch.git
    version: be791b9b257ef6a440c635f95438310abf876d95
  vehicle/sample_vehicle_launch:
    type: git
    url: https://github.com/autowarefoundation/sample_vehicle_launch.git
    version: cd852aed85aaf033a0747050cf4300967e89c1ae
```
</details>

I've updated all the branch refs in the `autoware.repos` to the the commit from here.

## How was this PR tested?

https://colab.research.google.com/drive/1KxHh_0Q7DHsebhoWlSxib0IJK8y-8l29?usp=sharing

Here I've compared the `vcs export src --exact-with-tags` to the updated `autoware.repos` file here. And only diff is with `autoware-tools`, which is outside and it's already versioned.

## Notes for reviewers

None.

## Effects on system behavior

None.
