### PR TITLE
feat(autoware*.repos): remove *_launch refs and bump autoware_launch to 0.43.1

### DIFF
--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -31,27 +31,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
     version: main
-  sensor_kit/sample_sensor_kit_launch:
-    type: git
-    url: https://github.com/autowarefoundation/sample_sensor_kit_launch.git
-    version: main
-  sensor_kit/external/awsim_sensor_kit_launch: # TODO: Integrate into sample_sensor_kit_launch
-    type: git
-    url: https://github.com/tier4/awsim_sensor_kit_launch.git
-    version: main
-  sensor_kit/awsim_labs_sensor_kit_launch:
-    type: git
-    url: https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch.git
-    version: main
-  sensor_kit/single_lidar_sensor_kit_launch:
-    type: git
-    url: https://github.com/autowarefoundation/single_lidar_sensor_kit_launch.git
-    version: main
-  vehicle/sample_vehicle_launch:
-    type: git
-    url: https://github.com/autowarefoundation/sample_vehicle_launch.git
-    version: main
-  vehicle/awsim_labs_vehicle_launch:
-    type: git
-    url: https://github.com/autowarefoundation/awsim_labs_vehicle_launch.git
-    version: main

--- a/autoware.repos
+++ b/autoware.repos
@@ -87,7 +87,7 @@ repositories:
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
-    version: 0.43.0
+    version: 0.43.1
   # sensor_component
   sensor_component/external/sensor_component_description:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -107,32 +107,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan
     version: e39a814180b03f00a5692b6951a5d4e9f0463486
-  # sensor_kit
-  sensor_kit/sample_sensor_kit_launch:
-    type: git
-    url: https://github.com/autowarefoundation/sample_sensor_kit_launch.git
-    version: 0.42.0
-  sensor_kit/external/awsim_sensor_kit_launch: # TODO: Integrate into sample_sensor_kit_launch
-    type: git
-    url: https://github.com/tier4/awsim_sensor_kit_launch.git
-    version: 0.42.0
-  sensor_kit/awsim_labs_sensor_kit_launch:
-    type: git
-    url: https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch.git
-    version: 0.42.0
-  sensor_kit/single_lidar_sensor_kit_launch:
-    type: git
-    url: https://github.com/autowarefoundation/single_lidar_sensor_kit_launch.git
-    version: 0.42.0
-  # vehicle
-  vehicle/sample_vehicle_launch:
-    type: git
-    url: https://github.com/autowarefoundation/sample_vehicle_launch.git
-    version: cd852aed85aaf033a0747050cf4300967e89c1ae
-  vehicle/awsim_labs_vehicle_launch:
-    type: git
-    url: https://github.com/autowarefoundation/awsim_labs_vehicle_launch.git
-    version: be791b9b257ef6a440c635f95438310abf876d95
   # param
   param/autoware_individual_params:
     type: git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -147,9 +147,7 @@ ARG ROS_DISTRO
 COPY src/launcher /autoware/src/launcher
 COPY src/param /autoware/src/param
 COPY src/sensor_component /autoware/src/sensor_component
-COPY src/sensor_kit /autoware/src/sensor_kit
 COPY src/universe /autoware/src/universe
-COPY src/vehicle /autoware/src/vehicle
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-depend-packages.txt \
   && cat /rosdep-universe-depend-packages.txt
@@ -459,12 +457,10 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
   --mount=type=bind,source=src/param,target=/autoware/src/param \
   --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
-  --mount=type=bind,source=src/sensor_kit,target=/autoware/src/sensor_kit \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
   --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \
   --mount=type=bind,source=src/universe/autoware_universe/simulator,target=/autoware/src/universe/autoware_universe/simulator \
   --mount=type=bind,source=src/universe/autoware_universe/tools,target=/autoware/src/universe/autoware_universe/tools \
-  --mount=type=bind,source=src/vehicle,target=/autoware/src/vehicle \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware


### PR DESCRIPTION
## Description

Related:
- https://github.com/autowarefoundation/autoware/issues/5912#issuecomment-2743482983

Merge with:
- https://github.com/autowarefoundation/autoware_launch/pull/1369

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
