### PR TITLE
fix(ansible): remove agnocast-kmod installation when no exists

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -33,10 +33,3 @@
     state: absent
   become: true
   when: dkms_status.rc != 0
-
-- name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
-  ansible.builtin.apt:
-    name: agnocast-kmod={{ agnocast_version }}*
-    state: present
-  become: true
-  when: dkms_status.rc != 0

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -33,9 +33,3 @@
     state: absent
   become: true
   when: dkms_status.rc != 0
-#- name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
-#  ansible.builtin.apt:
-#    name: agnocast-kmod={{ agnocast_version }}*
-#    state: present
-#  become: true
-#  when: dkms_status.rc != 0

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -33,7 +33,6 @@
     state: absent
   become: true
   when: dkms_status.rc != 0
-
 #- name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
 #  ansible.builtin.apt:
 #    name: agnocast-kmod={{ agnocast_version }}*

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -33,3 +33,10 @@
     state: absent
   become: true
   when: dkms_status.rc != 0
+
+#- name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
+#  ansible.builtin.apt:
+#    name: agnocast-kmod={{ agnocast_version }}*
+#    state: present
+#  become: true
+#  when: dkms_status.rc != 0


### PR DESCRIPTION
## Description
Currently, agnocast-kmod uses functions only available in Linux kernel v6.3 and above, causing build failures. We will temporarily remove it from Ansible until we implement compatibility fixes.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
