### PR TITLE
feat(docker): support `--pull-latest-image` option for pulling latest image on demand

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -190,6 +190,7 @@ main() {
 
     # Launch the container
     set -x
+    docker pull ${IMAGE}
     docker run -it --rm --net=host ${GPU_FLAG} ${USER_ID} ${MOUNT_X} \
         -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -v /etc/localtime:/etc/localtime:ro \
         ${WORKSPACE} ${MAP} ${DATA} ${IMAGE} \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,6 +20,7 @@ fi
 option_no_nvidia=false
 option_devel=false
 option_headless=false
+option_pull_latest_image=false
 MAP_PATH=""
 DATA_PATH=""
 WORKSPACE_PATH=""
@@ -35,13 +36,14 @@ print_help() {
     echo -e "------------------------------------------------------------"
     echo -e "${RED}Usage:${NC} run.sh [OPTIONS] [LAUNCH_CMD](optional)"
     echo -e "Options:"
-    echo -e "  ${GREEN}--help/-h${NC}       Display this help message"
-    echo -e "  ${GREEN}--map-path${NC}      Specify to mount map files into /autoware_map (mandatory for runtime)"
-    echo -e "  ${GREEN}--data-path${NC}     Specify to mount data files into /root/autoware_data (mandatory for runtime)"
-    echo -e "  ${GREEN}--devel${NC}         Launch the latest Autoware development environment with shell access"
-    echo -e "  ${GREEN}--workspace${NC}     (--devel only)Specify the directory to mount into /workspace, by default it uses current directory (pwd)"
-    echo -e "  ${GREEN}--no-nvidia${NC}     Disable NVIDIA GPU support"
-    echo -e "  ${GREEN}--headless${NC}      Run Autoware in headless mode (default: false)"
+    echo -e "  ${GREEN}--help/-h${NC}            Display this help message"
+    echo -e "  ${GREEN}--map-path${NC}           Specify to mount map files into /autoware_map (mandatory for runtime)"
+    echo -e "  ${GREEN}--data-path${NC}          Specify to mount data files into /root/autoware_data (mandatory for runtime)"
+    echo -e "  ${GREEN}--devel${NC}              Launch the latest Autoware development environment with shell access"
+    echo -e "  ${GREEN}--workspace${NC}          (--devel only)Specify the directory to mount into /workspace, by default it uses current directory (pwd)"
+    echo -e "  ${GREEN}--no-nvidia${NC}          Disable NVIDIA GPU support"
+    echo -e "  ${GREEN}--headless${NC}           Run Autoware in headless mode (default: false)"
+    echo -e "  ${GREEN}--pull-latest-image${NC}  Pull the latest image before starting the container"
     echo ""
 }
 
@@ -61,6 +63,9 @@ parse_arguments() {
             ;;
         --headless)
             option_headless=true
+            ;;
+        --pull-latest-image)
+            option_pull_latest_image=true
             ;;
         --workspace)
             WORKSPACE_PATH="$2"
@@ -188,9 +193,12 @@ main() {
     echo -e "${GREEN}LAUNCH CMD:${NC} ${LAUNCH_CMD}"
     echo -e "${GREEN}-----------------------------------------------------------------${NC}"
 
+    if [ "$option_pull_latest_image" = "true" ]; then
+        docker pull ${IMAGE}
+    fi
+
     # Launch the container
     set -x
-    docker pull ${IMAGE}
     docker run -it --rm --net=host ${GPU_FLAG} ${USER_ID} ${MOUNT_X} \
         -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -v /etc/localtime:/etc/localtime:ro \
         ${WORKSPACE} ${MAP} ${DATA} ${IMAGE} \


### PR DESCRIPTION
## Description

Added a new `--pull-latest-image` option to allow users to explicitly pull the latest version of the Docker image before launching the container.  
Developers who need the latest image can now opt in using this flag.

## How was this PR tested?

Tested locally by running the script with and without the `--pull-latest-image` flag and verifying that the image is only pulled if the flag is specified.

## Notes for reviewers

None.

## Effects on system behavior

- When `--pull-latest-image` is specified, the latest version of the image will be pulled