### PR TITLE
fix(docker): replace `/etc/localtime` mount with `TZ` env to avoid apt tzdata upgrade failure

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -191,7 +191,7 @@ main() {
     # Launch the container
     set -x
     docker run -it --rm --net=host ${GPU_FLAG} ${USER_ID} ${MOUNT_X} \
-        -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -v /etc/localtime:/etc/localtime:ro \
+        -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -e TZ=$(cat /etc/timezone) \
         ${WORKSPACE} ${MAP} ${DATA} ${IMAGE} \
         ${LAUNCH_CMD}
 }

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -191,7 +191,7 @@ main() {
     # Launch the container
     set -x
     docker run -it --rm --net=host ${GPU_FLAG} ${USER_ID} ${MOUNT_X} \
-        -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -e TZ=$(cat /etc/timezone) \
+        -e XAUTHORITY=${XAUTHORITY} -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e NVIDIA_DRIVER_CAPABILITIES=all -e TZ="$(cat /etc/timezone)" \
         ${WORKSPACE} ${MAP} ${DATA} ${IMAGE} \
         ${LAUNCH_CMD}
 }


### PR DESCRIPTION
## Description

Replaced the volume mount of `/etc/localtime` with the `TZ` environment variable (`-e TZ=$(cat /etc/timezone)`).

This change resolves an issue where `sudo apt upgrade` inside the container fails with an error related to `tzdata`, specifically:
```
Errors were encountered while processing:
 /tmp/apt-dpkg-install-.../002-tzdata_2025b-0ubuntu0.22.04_all.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

The issue occurs when `/etc/localtime` is mounted as a read-only volume, which prevents `tzdata` from properly updating time zone data during package upgrades.
Switching to the `TZ` environment variable avoids this conflict and also improves portability.

## How was this PR tested?

Tested by running the container, verifying that the time zone is set correctly, and confirming that `sudo apt upgrade` completes without errors.

## Notes for reviewers

None.

## Effects on system behavior

- Time zone is now set using the `TZ` environment variable instead of mounting `/etc/localtime`  
