### PR TITLE
revert: "feat(autoware.repos): minor update autowarefoundation/autoware_lanelet2_extension to 0.7.0"

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -24,7 +24,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.7.0
+    version: 0.6.4
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git


### PR DESCRIPTION
Reverts autowarefoundation/autoware#5995

There is an issue with `tinyxml2` during the CI build, and we need to revert it.