### PR TITLE
chore(docker): make artifacts available for non-root user

### DIFF
--- a/docker/etc/ros_entrypoint.sh
+++ b/docker/etc/ros_entrypoint.sh
@@ -27,6 +27,12 @@ else
     source "/opt/ros/$ROS_DISTRO/setup.bash"
     source /opt/autoware/setup.bash
 
+    # Add symlink for autoware_data if directory exists
+    if [ -d /autoware_data ]; then
+        ln -s /autoware_data /home/"$USER_NAME"/autoware_data
+        echo "Linked /autoware_data to /home/$USER_NAME/autoware_data"
+    fi
+
     # Execute the command as the user
     exec /usr/sbin/gosu "$USER_NAME" "$@"
 fi

--- a/docker/etc/ros_entrypoint.sh
+++ b/docker/etc/ros_entrypoint.sh
@@ -22,7 +22,7 @@ else
     # Add sudo privileges to the user
     echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
-    # Source ROS2
+    # Source ROS 2
     # hadolint ignore=SC1090
     source "/opt/ros/$ROS_DISTRO/setup.bash"
     source /opt/autoware/setup.bash


### PR DESCRIPTION
## Description

Solves issue with unavailable artifacts for devel container. 
Docs update addressed in https://github.com/autowarefoundation/autoware-documentation/pull/659.

## How was this PR tested?

```bash
./docker/run.sh --map-path ~/autoware_map/sample-map-planning --data-path ~/autoware_data ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```

and

```bash
./docker/run.sh --devel --map-path ~/autoware_map/sample-map-planning --data-path ~/autoware_data ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```

## Notes for reviewers

None.

## Effects on system behavior

None.
