### PR TITLE
fix(autoware.repos): fix url for nightly vcs import

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -85,7 +85,7 @@ repositories:
     version: eac198b55dcd052af5988f0f174902913c5f20e7
   universe/external/managed_transform_buffer:
     type: git
-    url: https://github.com/autowarefoundation/ManagedTransformBuffer.git
+    url: https://github.com/autowarefoundation/managed_transform_buffer.git
     version: 0.1.0
   # launcher
   launcher/autoware_launch:


### PR DESCRIPTION
## Description

Fix this error. Related to https://github.com/autowarefoundation/autoware/pull/5611.
```
=== src/universe/external/managed_transform_buffer (git) ===
Path already exists and contains a different repository
```

## How was this PR tested?

```
vcs import src --input autoware.repos
vcs import src --input autoware-nightly.repos
```

## Notes for reviewers

None.

## Effects on system behavior

None.
