### PR TITLE
feat(autoware.repos): remove autoware_individual_params

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -111,8 +111,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan
     version: e39a814180b03f00a5692b6951a5d4e9f0463486
-  # param
-  param/autoware_individual_params:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_individual_params.git
-    version: 70000825155182d9261ce0980076b0e2c6dc3f51

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -144,7 +144,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 COPY src/launcher /autoware/src/launcher
-COPY src/param /autoware/src/param
 COPY src/sensor_component /autoware/src/sensor_component
 COPY src/universe /autoware/src/universe
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
@@ -455,7 +454,6 @@ COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
-  --mount=type=bind,source=src/param,target=/autoware/src/param \
   --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
   --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \


### PR DESCRIPTION
## Description

**Parent Issue:**
- https://github.com/autowarefoundation/autoware/issues/5975

Should be merged after:
- https://github.com/autowarefoundation/autoware_launch/pull/1403 is merged.
- **A new autoware_launch version is released.**

## How was this PR tested?

- Tested with:
  - [AWSIM Labs Demo](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/digital-twin-simulation/awsim-tutorial/) (AWSIM should work the same way, changes are identical)
  - [Planning Simulator Demo](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
  - [Rosbag Replay Sim Demo](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)

## Notes for reviewers

Let's wait until a new autoware_launch version is released.

## Effects on system behavior

None.
