### PR TITLE
ci(docker): mount managed_transform_buffer in universe image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -234,13 +234,13 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/external/eagleye,target=/autoware/src/universe/external/eagleye \
   --mount=type=bind,source=src/universe/external/glog,target=/autoware/src/universe/external/glog \
   --mount=type=bind,source=src/universe/external/llh_converter,target=/autoware/src/universe/external/llh_converter \
+  --mount=type=bind,source=src/universe/external/managed_transform_buffer,target=/autoware/src/universe/external/managed_transform_buffer \
   --mount=type=bind,source=src/universe/external/morai_msgs,target=/autoware/src/universe/external/morai_msgs \
   --mount=type=bind,source=src/universe/external/muSSP,target=/autoware/src/universe/external/muSSP \
   --mount=type=bind,source=src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
   --mount=type=bind,source=src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
   --mount=type=bind,source=src/universe/external/tier4_ad_api_adaptor,target=/autoware/src/universe/external/tier4_ad_api_adaptor \
   --mount=type=bind,source=src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
-  --mount=type=bind,source=src/universe/external/managed_transform_buffer,target=/autoware/src/universe/external/managed_transform_buffer \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -240,6 +240,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
   --mount=type=bind,source=src/universe/external/tier4_ad_api_adaptor,target=/autoware/src/universe/external/tier4_ad_api_adaptor \
   --mount=type=bind,source=src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
+  --mount=type=bind,source=src/universe/external/managed_transform_buffer,target=/autoware/src/universe/external/managed_transform_buffer \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware


### PR DESCRIPTION
## Description

After recent `managed_transform_buffer` [PRs](https://github.com/autowarefoundation/autoware/issues/5385#issuecomment-2785853205), local docker build fails for me:

```
#106 655.1 Starting >>> autoware_pointcloud_preprocessor                                                                                                                                                                                                                           
#106 660.0 --- stderr: autoware_pointcloud_preprocessor                                                                                                                                                                                                                            
#106 660.0 CMake Error at /opt/ros/humble/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:77 (message):                                                                                                                                                
#106 660.0   ament_target_dependencies() the passed package name                                                                                                                                                                                                                   
#106 660.0   'managed_transform_buffer' was not found before                                                                                                                                                                                                                       
#106 660.0 Call Stack (most recent call first):                                                                                                                                                                                                                                    
#106 660.0   CMakeLists.txt:39 (ament_target_dependencies)                                                                                                                                                                                                                         
#106 660.0                                                                                                                                                                                                                                                                         
#106 660.0                                                                                                                                                                                                                                                                         
#106 660.0 ---                                                                                                                                                                                                                                                                     
#106 660.0 Failed   <<< autoware_pointcloud_preprocessor [4.92s, exited with code 1]                                                                                                                                                                                               
#106 ...                                                                                                                                                                                                                                                                           
```

Looks like I forgot to add external repository to multi-stage build process.

## How was this PR tested?

## Notes for reviewers

I'm not sure if actual layer is the most appropriate. Please feel free to move it to another layer if needed.

## Effects on system behavior

None.
