### PR TITLE
ci(webauto-ci): install older xmlschema to fix scenario simulation error

### DIFF
--- a/.webauto-ci/main/autoware-build/run.sh
+++ b/.webauto-ci/main/autoware-build/run.sh
@@ -24,7 +24,7 @@ if [ -n "$CCACHE_DIR" ]; then
 fi
 
 # install xmlschema<4.0.0 before rosdep install as workaround for scenario_simulator_v2
-sudo pip3 install xmlschema==3.4.5
+pip3 install --user xmlschema==3.4.5
 
 sudo -E apt-get -y update
 

--- a/.webauto-ci/main/autoware-build/run.sh
+++ b/.webauto-ci/main/autoware-build/run.sh
@@ -23,6 +23,9 @@ if [ -n "$CCACHE_DIR" ]; then
     ccache -M "$CCACHE_SIZE"
 fi
 
+# install xmlschema<4.0.0 before rosdep install as workaround for scenario_simulator_v2
+sudo pip3 install xmlschema==3.4.5
+
 sudo -E apt-get -y update
 
 # shellcheck disable=SC2012


### PR DESCRIPTION
## Description
This PR fixes issues with running Autoware on TIER IV's evaluator tool that we are using in ODD WG.
There was an incompatible update in the xmlschema library that is used by the scenario_simulator_v2. This fix will install older version of xmlschema as a workaround.

## How was this PR tested?
I'm now running test with TIER IV evaluator tool: https://evaluation.ci.tier4.jp/evaluation/reports/ad6db378-0067-542a-8045-1dbf1263b700?project_id=awf

## Notes for reviewers

None.

## Effects on system behavior

None.
