### PR TITLE
ci(docker): inherite `$AUTOWARE_BASE_IMAGE` instead of `$BASE_IMAGE`

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -81,7 +81,6 @@ jobs:
           build-args: |
             *.platform=${{ matrix.arch-platform }}
             *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
             *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
             *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -73,7 +73,6 @@ jobs:
           additional-repos: ${{ matrix.build-type == 'nightly' && 'autoware-nightly.repos' || '' }}
           build-args: |
             ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
             AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
             AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
             LIB_DIR=${{ matrix.lib-dir }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,8 @@
-ARG BASE_IMAGE
 ARG AUTOWARE_BASE_IMAGE
 ARG AUTOWARE_BASE_CUDA_IMAGE
 
 # hadolint ignore=DL3006
-FROM $BASE_IMAGE AS rosdep-depend
+FROM $AUTOWARE_BASE_IMAGE AS rosdep-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -151,7 +151,6 @@ build_images() {
         --set "*.ssh=default" \
         --set "*.platform=$platform" \
         --set "*.args.ROS_DISTRO=$rosdistro" \
-        --set "*.args.BASE_IMAGE=$base_image" \
         --set "*.args.AUTOWARE_BASE_IMAGE=$autoware_base_image" \
         --set "*.args.AUTOWARE_BASE_CUDA_IMAGE=$autoware_base_cuda_image" \
         --set "*.args.SETUP_ARGS=$setup_args" \


### PR DESCRIPTION
## Description

- [x] #6055 

The `$BASE_IMAGE` image from Docker Hub has a rate limit, and when development accelerates, CI executions may fail. 
https://docs.docker.com/docker-hub/usage/

I couldn’t find the error log right away, but I’ve seen it several times before. Therefore, this PRuses the `autoware-base` image from GHCR instead to reduce the impact of Docker Hub’s rate limit.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
