### PR TITLE
ci(action.yaml): add `utility-image` to `buildkit-cache-dance` action to resolve docker.io rate limit

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -53,6 +53,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -51,7 +51,8 @@ runs:
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -50,7 +50,8 @@ runs:
           apt-get-tools-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -52,6 +52,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -53,6 +53,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -51,7 +51,8 @@ runs:
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -91,6 +91,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -89,7 +89,8 @@ runs:
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |


### PR DESCRIPTION
## Description

The currently released `buildkit-cache-dance` action runs by default using `busybox:1`, but this can cause CI execution to fail due to Docker Hub’s rate limit.

https://github.com/autowarefoundation/autoware/actions/runs/14587953654/job/40924568898#step:7:990
```
Run reproducible-containers/buildkit-cache-dance@v3.1.2

FROM busybox:1
COPY buildstamp buildstamp
RUN --mount=type=cache,target=/root/.ccache     --mount=type=bind,source=.,target=/var/dance-cache     cp -p -R /var/dance-cache/. /root/.ccache  || true

Error running command: docker buildx build -f scratch/Dancefile.inject --tag dance:inject root-ccache
#0 building with "builder-ac31bade-da26-4d2d-bd6b-b0d6d17f48c1" instance using docker-container driver

#1 [internal] load build definition from Dancefile.inject
#1 transferring dockerfile: 242B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/busybox:1
#2 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/busybox/manifests/sha256:ad9fa4d07136a83e69a54ef00102f579d04eba431932de3b0f098cc5d5948f9f: 429 Too Many Requests - Server message: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```

This PR uses the newly introduced `utility-image` argument allows us to use an image from `ghcr.io` to address this issue.
https://github.com/reproducible-containers/buildkit-cache-dance/commit/7c892679bab8ff382a8c88ab7f973d5e30a8f239

## How was this PR tested?

https://github.com/autowarefoundation/autoware/actions/runs/14607852622/job/40980290439#step:8:933
```
Run reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239

FROM ghcr.io/containerd/busybox:latest
COPY buildstamp buildstamp
RUN --mount=type=cache,target=/root/.ccache     --mount=type=bind,source=.,target=/var/dance-cache     cp -p -R /var/dance-cache/. /root/.ccache  || true


FROM ghcr.io/containerd/busybox:latest
COPY buildstamp buildstamp
RUN --mount=type=cache,target=/var/cache/apt     --mount=type=bind,source=.,target=/var/dance-cache     cp -p -R /var/dance-cache/. /var/cache/apt  || true
```

## Notes for reviewers

None.

## Effects on system behavior

None.
