### PR TITLE
ci(docker-build-and-push.yaml): run `update-docker-manifest` job after `docker-build-and-push` job

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -245,13 +245,25 @@ jobs:
           df -h
 
   update-docker-manifest:
-    needs: [docker-build-and-push, docker-build-and-push-cuda]
+    needs: docker-build-and-push
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Combine multi arch images for 'autoware'
+      - name: Combine multi arch images for 'autoware' without CUDA
+        uses: ./.github/actions/combine-multi-arch-images
+        with:
+          package-name: autoware
+
+  update-docker-manifest-cuda:
+    needs: docker-build-and-push-cuda
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Combine multi arch images for 'autoware' with CUDA
         uses: ./.github/actions/combine-multi-arch-images
         with:
           package-name: autoware


### PR DESCRIPTION
## Description

There are still cases where the `docker-build-and-push-cuda` job fails due to resource exhaustion. 
https://github.com/autowarefoundation/autoware/actions/runs/14613041309/job/41003518568

The fix for that will be handled separately, but this PR changes the process so that if the `docker-build-and-push` job succeeds, the CUDA-independent image tags will be integrated into multi-arch format first.

## How was this PR tested?

https://github.com/autowarefoundation/autoware/actions/runs/14632030289
<img width="1047" alt="Screenshot 2025-04-24 at 11 22 49" src="https://github.com/user-attachments/assets/d9f193bc-3e02-4118-9bfe-59f04b40324c" />

## Notes for reviewers

None.

## Effects on system behavior

None.
