### PR TITLE
ci(docker-build-and-push.yaml): add `max-parallelism` option to restrict `docker build make` parallelism

### DIFF
--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -21,7 +21,7 @@ runs:
         with:
           buildkitd-config-inline: |
             [worker.oci]
-            max-parallelism = ${{ inputs.max-parallelism }}
+            max-parallelism = 2
         install: true
 
     - name: Get current date

--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -18,11 +18,11 @@ runs:
   steps:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-config-inline: |
-            [worker.oci]
-            max-parallelism = 2
-        install: true
+      with:
+        buildkitd-config-inline: |
+          [worker.oci]
+          max-parallelism = 2
+      install: true
 
     - name: Get current date
       id: date

--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -8,12 +8,21 @@ inputs:
   build-args:
     description: Additional build args.
     required: false
+  max-parallelism:
+    default: 2
+    description: Maximum parallelism for buildkitd.
+    required: false
 
 runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+            max-parallelism = ${{ inputs.max-parallelism }}
+        install: true
 
     - name: Get current date
       id: date

--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -21,7 +21,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = ${{ inputs.max-parallelism }}
+            max-parallelism = ${{ inputs.max-parallelism }}
       install: true
 
     - name: Get current date

--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -21,7 +21,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = 2
+          max-parallelism = ${{ inputs.max-parallelism }}
       install: true
 
     - name: Get current date

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -53,6 +53,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -11,6 +11,10 @@ inputs:
   build-args:
     description: Additional build args.
     required: false
+  max-parallelism:
+    default: 2
+    description: Maximum parallelism for buildkitd.
+    required: false
 
 runs:
   using: composite
@@ -31,6 +35,11 @@ runs:
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        buildkitd-config-inline: |
+          [worker.oci]
+          max-parallelism = ${{ inputs.max-parallelism }}
+        install: true
 
     - name: Restore ccache
       uses: actions/cache/restore@v4

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -51,7 +51,8 @@ runs:
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -38,7 +38,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = 2
+          max-parallelism = ${{ inputs.max-parallelism }}
         install: true
 
     - name: Restore ccache

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -38,7 +38,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = ${{ inputs.max-parallelism }}
+          max-parallelism = 2
         install: true
 
     - name: Restore ccache

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -38,7 +38,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = ${{ inputs.max-parallelism }}
+            max-parallelism = ${{ inputs.max-parallelism }}
         install: true
 
     - name: Restore ccache

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -37,7 +37,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = ${{ inputs.max-parallelism }}
+            max-parallelism = ${{ inputs.max-parallelism }}
         install: true
 
     - name: Cache ccache

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -37,7 +37,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = ${{ inputs.max-parallelism }}
+          max-parallelism = 2
         install: true
 
     - name: Cache ccache

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -11,6 +11,10 @@ inputs:
   build-args:
     description: Additional build args.
     required: false
+  max-parallelism:
+    default: 2
+    description: Maximum parallelism for buildkitd.
+    required: false
 
 runs:
   using: composite
@@ -30,6 +34,11 @@ runs:
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        buildkitd-config-inline: |
+          [worker.oci]
+          max-parallelism = ${{ inputs.max-parallelism }}
+        install: true
 
     - name: Cache ccache
       uses: actions/cache@v4

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -37,7 +37,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = 2
+          max-parallelism = ${{ inputs.max-parallelism }}
         install: true
 
     - name: Cache ccache

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -50,7 +50,8 @@ runs:
           apt-get-tools-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -52,6 +52,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -38,7 +38,7 @@ runs:
         with:
           buildkitd-config-inline: |
             [worker.oci]
-            max-parallelism = ${{ inputs.max-parallelism }}
+            max-parallelism = 2
         install: true
 
     - name: Restore ccache

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -53,6 +53,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -51,7 +51,8 @@ runs:
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -35,10 +35,10 @@ runs:
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-config-inline: |
-            [worker.oci]
-            max-parallelism = 2
+      with:
+        buildkitd-config-inline: |
+          [worker.oci]
+          max-parallelism = 2
         install: true
 
     - name: Restore ccache

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -38,7 +38,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = 2
+          max-parallelism = ${{ inputs.max-parallelism }}
         install: true
 
     - name: Restore ccache

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -11,6 +11,10 @@ inputs:
   build-args:
     description: Additional build args.
     required: false
+  max-parallelism:
+    default: 2
+    description: Maximum parallelism for buildkitd.
+    required: false
 
 runs:
   using: composite
@@ -31,6 +35,11 @@ runs:
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+            max-parallelism = ${{ inputs.max-parallelism }}
+        install: true
 
     - name: Restore ccache
       uses: actions/cache/restore@v4

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -38,7 +38,7 @@ runs:
       with:
         buildkitd-config-inline: |
           [worker.oci]
-          max-parallelism = ${{ inputs.max-parallelism }}
+            max-parallelism = ${{ inputs.max-parallelism }}
         install: true
 
     - name: Restore ccache

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -91,6 +91,7 @@ runs:
     - name: Inject cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
+        utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |
           {
             "root-ccache": "/root/.ccache",

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -89,7 +89,8 @@ runs:
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      # TODO(youtalk): Use the release version again
+      uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
       with:
         utility-image: ghcr.io/containerd/busybox:latest
         cache-map: |

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -61,6 +61,15 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
+      - name: Set Swap Space
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag')) &&
+          matrix.platform == 'arm64' }}
+        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
+        with:
+          swap-size-gb: 8
+
       - name: Build 'Autoware' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
@@ -128,6 +137,15 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
+      - name: Set Swap Space
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag')) &&
+          matrix.platform == 'arm64' }}
+        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
+        with:
+          swap-size-gb: 8
+
       - name: Build 'autoware-tools'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
@@ -192,6 +210,15 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
+
+      - name: Set Swap Space
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag')) &&
+          matrix.platform == 'arm64' }}
+        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
+        with:
+          swap-size-gb: 8
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -212,10 +212,9 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
           swap-size-gb: 16

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -61,15 +61,6 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 8
-
       - name: Build 'Autoware' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
@@ -137,15 +128,6 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 8
-
       - name: Build 'autoware-tools'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
@@ -210,15 +192,6 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
-
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 16
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -212,6 +212,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
+        # docker-build-and-push-cuda consumes a lot of memory
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -62,12 +62,13 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag') }}
+          (github.event_name == 'push' && github.ref_type == 'tag')) &&
+          matrix.platform == 'arm64' }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
-          swap-size-gb: 8
+          swap-size-gb: 16
 
       - name: Build 'Autoware' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
@@ -137,12 +138,13 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag') }}
+          (github.event_name == 'push' && github.ref_type == 'tag')) &&
+          matrix.platform == 'arm64' }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
-          swap-size-gb: 8
+          swap-size-gb: 16
 
       - name: Build 'autoware-tools'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
@@ -210,12 +212,13 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
+        # docker-build-and-push-cuda consumes a lot of memory
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
-          swap-size-gb: 8
+          swap-size-gb: 16
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -61,15 +61,6 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 16
-
       - name: Build 'Autoware' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
@@ -137,15 +128,6 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 16
-
       - name: Build 'autoware-tools'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
@@ -210,15 +192,6 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
-
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 16
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -62,13 +62,12 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
-          swap-size-gb: 16
+          swap-size-gb: 8
 
       - name: Build 'Autoware' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
@@ -138,13 +137,12 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag')) &&
-          matrix.platform == 'arm64' }}
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
-          swap-size-gb: 16
+          swap-size-gb: 8
 
       - name: Build 'autoware-tools'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
@@ -212,13 +210,12 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
-        # docker-build-and-push-cuda consumes a lot of memory
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
-          swap-size-gb: 16
+          swap-size-gb: 8
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -156,7 +156,7 @@ jobs:
         platform: [amd64, arm64]
         include:
           - platform: amd64
-            runner: ubuntu-22.04
+            runner: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
             arch-platform: linux/amd64
             lib-dir: x86_64
           - platform: arm64

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -174,11 +174,11 @@ jobs:
         platform: [amd64, arm64]
         include:
           - platform: amd64
-            runner: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
+            runner: ubuntu-22.04
             arch-platform: linux/amd64
             lib-dir: x86_64
           - platform: arm64
-            runner: [self-hosted, linux, ARM64]
+            runner: ubuntu-22.04-arm
             arch-platform: linux/arm64
             lib-dir: aarch64
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -245,13 +245,25 @@ jobs:
           df -h
 
   update-docker-manifest:
-    needs: [docker-build-and-push, docker-build-and-push-cuda]
+    needs: docker-build-and-push
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Combine multi arch images for 'autoware'
+      - name: Combine multi arch images for 'autoware' without CUDA
+        uses: ./.github/actions/combine-multi-arch-images
+        with:
+          package-name: autoware
+
+  update-docker-manifest-cuda:
+    needs: docker-build-and-push-cuda
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Combine multi arch images for 'autoware' with CUDA
         uses: ./.github/actions/combine-multi-arch-images
         with:
           package-name: autoware

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -218,7 +218,7 @@ jobs:
           matrix.platform == 'arm64' }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
-          swap-size-gb: 8
+          swap-size-gb: 16
 
       - name: Build 'Autoware' with CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -212,10 +212,10 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Set Swap Space
-        # docker-build-and-push-cuda consumes a lot of memory
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag') }}
+          (github.event_name == 'push' && github.ref_type == 'tag')) &&
+          matrix.platform == 'arm64' }}
         uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
         with:
           swap-size-gb: 16

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -76,15 +76,6 @@ jobs:
           github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch') &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 16
-
       - name: Build 'Autoware'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'schedule' ||

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -76,6 +76,15 @@ jobs:
           github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/free-disk-space
 
+      - name: Set Swap Space
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch') &&
+          matrix.platform == 'arm64' }}
+        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
+        with:
+          swap-size-gb: 8
+
       - name: Build 'Autoware'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'schedule' ||

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -76,15 +76,6 @@ jobs:
           github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Set Swap Space
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch') &&
-          matrix.platform == 'arm64' }}
-        uses: pierotofy/set-swap-space@0404882bc4666c0ff2f6fd8b3d32af69a730183c
-        with:
-          swap-size-gb: 8
-
       - name: Build 'Autoware'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'schedule' ||


### PR DESCRIPTION
## Description

- [x] #6079 
- [x] #6072

Communication disruptions like the following with GitHub runners frequently occur.
```
docker-build-and-push-cuda (amd64)
The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```
So this PR limits the maximum number of parallel executions for `docker build bake` to 2, which is half the number of CPU cores. This will slightly increase execution time, but is expected to alleviate CPU and memory exhaustion.
https://docs.docker.com/build/ci/github-actions/configure-builder/#max-parallelism

## How was this PR tested?

https://github.com/autowarefoundation/autoware/actions/runs/14768570284

## Notes for reviewers

None.

## Effects on system behavior

None.
