### PR TITLE
fix: add params to update cache in agnocast ansible role

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -4,10 +4,13 @@
     state: present
   become: true
 
-- name: Add agnocast PPA repository
+- name: Add agnocast PPA repository with extended retries
   ansible.builtin.apt_repository:
     repo: ppa:t4-system-software/agnocast
     state: present
+    update_cache: true
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 30
   become: true
 
 - name: Update apt cache

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -4,6 +4,7 @@
     state: present
   become: true
 
+# TODO(rej55, sykwer): IPv6 support
 - name: Save current IPv6 settings
   ansible.builtin.shell: |
     sysctl net.ipv6.conf.all.disable_ipv6

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -8,7 +8,7 @@
   ansible.builtin.apt_repository:
     repo: ppa:t4-system-software/agnocast
     state: present
-    update_cache: true
+    update_cache: false
     update_cache_retries: 10
     update_cache_retry_max_delay: 60
   become: true

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -13,7 +13,7 @@
   become: true
 
 - name: Temporarily disable IPv6
-  ansible.builtin.sysctl:
+  ansible.posix.sysctl:
     name: "{{ item.name }}"
     value: 1
     sysctl_set: true
@@ -30,7 +30,7 @@
     update_cache: false
   become: true
 
-- name: Restore original IPv6 settings
+- name: Restore original IPv6 settings # noqa
   ansible.builtin.command: >
     sysctl -w {{ item }}
   loop: "{{ ipv6_settings.stdout_lines }}"

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -19,8 +19,8 @@
     sysctl_set: yes
     state: present
   loop:
-    - { name: 'net.ipv6.conf.all.disable_ipv6' }
-    - { name: 'net.ipv6.conf.default.disable_ipv6' }
+    - { name: "net.ipv6.conf.all.disable_ipv6" }
+    - { name: "net.ipv6.conf.default.disable_ipv6" }
   become: true
 
 - name: Add agnocast PPA repository while IPv6 is disabled

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -16,7 +16,7 @@
   ansible.builtin.sysctl:
     name: "{{ item.name }}"
     value: 1
-    sysctl_set: yes
+    sysctl_set: true
     state: present
   loop:
     - { name: "net.ipv6.conf.all.disable_ipv6" }

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -30,7 +30,7 @@
     update_cache: false
   become: true
 
-- name: Restore original IPv6 settings # noqa
+- name: Restore original IPv6 settings # noqa: command-shell
   ansible.builtin.command: >
     sysctl -w {{ item }}
   loop: "{{ ipv6_settings.stdout_lines }}"

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -4,13 +4,37 @@
     state: present
   become: true
 
-- name: Add agnocast PPA repository with extended retries
+- name: Save current IPv6 settings
+  ansible.builtin.shell: |
+    sysctl net.ipv6.conf.all.disable_ipv6
+    sysctl net.ipv6.conf.default.disable_ipv6
+  register: ipv6_settings
+  changed_when: false
+  become: true
+
+- name: Temporarily disable IPv6
+  ansible.builtin.sysctl:
+    name: "{{ item.name }}"
+    value: 1
+    sysctl_set: yes
+    state: present
+  loop:
+    - { name: 'net.ipv6.conf.all.disable_ipv6' }
+    - { name: 'net.ipv6.conf.default.disable_ipv6' }
+  become: true
+
+- name: Add agnocast PPA repository while IPv6 is disabled
   ansible.builtin.apt_repository:
     repo: ppa:t4-system-software/agnocast
     state: present
     update_cache: false
-    update_cache_retries: 10
-    update_cache_retry_max_delay: 60
+  become: true
+
+- name: Restore original IPv6 settings
+  ansible.builtin.command: >
+    sysctl -w {{ item }}
+  loop: "{{ ipv6_settings.stdout_lines }}"
+  when: item is search('=0')
   become: true
 
 - name: Update apt cache

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -10,7 +10,7 @@
     state: present
     update_cache: true
     update_cache_retries: 10
-    update_cache_retry_max_delay: 30
+    update_cache_retry_max_delay: 60
   become: true
 
 - name: Update apt cache

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -19,8 +19,8 @@
     sysctl_set: true
     state: present
   loop:
-    - { name: "net.ipv6.conf.all.disable_ipv6" }
-    - { name: "net.ipv6.conf.default.disable_ipv6" }
+    - { name: net.ipv6.conf.all.disable_ipv6 }
+    - { name: net.ipv6.conf.default.disable_ipv6 }
   become: true
 
 - name: Add agnocast PPA repository while IPv6 is disabled

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -30,7 +30,7 @@
     update_cache: false
   become: true
 
-- name: Restore original IPv6 settings # noqa: command-shell
+- name: Restore original IPv6 settings # noqa: no-changed-when
   ansible.builtin.command: >
     sysctl -w {{ item }}
   loop: "{{ ipv6_settings.stdout_lines }}"


### PR DESCRIPTION
## Description

We have a problem that we failed to fetch Agnocast's PPA information due to timed out.
This PR add some parameters to avoid time out.

## How was this PR tested?

We tried this ansible role on TIER IV's environment.

## Notes for reviewers

None.

## Effects on system behavior

None.
