### PR TITLE
fix(docker-build*/action.yaml): fix `ccache`, `apt-get` and container registry cache keys

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -37,8 +37,9 @@ runs:
       with:
         path: |
           root-ccache
-        key: ccache-${{ inputs.platform }}-${{ hashFiles('src/**/*.cpp') }}
+        key: ccache-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}${{ hashFiles('src/**/*.cpp') }}
         restore-keys: |
+          ccache-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}
           ccache-${{ inputs.platform }}-
 
     - name: Restore apt-get
@@ -46,8 +47,9 @@ runs:
       with:
         path: |
           var-cache-apt
-        key: apt-get-${{ inputs.platform }}-${{ hashFiles('src/**/package.xml') }}
+        key: apt-get-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}${{ hashFiles('src/**/package.xml') }}
         restore-keys: |
+          apt-get-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -37,17 +37,18 @@ runs:
       with:
         path: |
           root-ccache
-        key: ccache-${{ inputs.platform }}-${{ hashFiles('src/**/*.cpp') }}
+        key: ccache-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}${{ hashFiles('src/**/*.cpp') }}
         restore-keys: |
+          ccache-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}
           ccache-${{ inputs.platform }}-
-
     - name: Restore apt-get
       uses: actions/cache/restore@v4
       with:
         path: |
           var-cache-apt
-        key: apt-get-${{ inputs.platform }}-${{ hashFiles('src/**/package.xml') }}
+        key: apt-get-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}${{ hashFiles('src/**/package.xml') }}
         restore-keys: |
+          apt-get-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}
           apt-get-${{ inputs.platform }}-
 
     - name: Inject cache into docker

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -114,4 +114,4 @@ runs:
         context: .
         push: false
         build-args: ${{ inputs.build-args }}
-        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.platform }}-${{ inputs.cache-tag-suffix }}
+        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ inputs.platform }}-main

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -34,17 +34,14 @@ jobs:
           - build-type: main
             platform: amd64
             runner: ubuntu-22.04
-            arch-platform: linux/amd64
             lib-dir: x86_64
           - build-type: nightly
             platform: amd64
             runner: ubuntu-22.04
-            arch-platform: linux/amd64
             lib-dir: x86_64
           - build-type: main-arm64
             platform: arm64
             runner: ubuntu-22.04-arm
-            arch-platform: linux/arm64
             lib-dir: aarch64
     runs-on: ${{ matrix.runner }}
     steps:
@@ -91,7 +88,7 @@ jobs:
           github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/docker-build
         with:
-          platform: ${{ matrix.arch-platform }}
+          platform: ${{ matrix.platform }}
           cache-tag-suffix: ${{ matrix.build-type }}
           additional-repos: ${{ matrix.build-type == 'nightly' && 'autoware-nightly.repos' || '' }}
           build-args: |


### PR DESCRIPTION
## Description

The container build for `arm64` has been very slow recently.
https://github.com/autowarefoundation/autoware/actions/runs/14699199364

So I investigated the caching and found that the keys for `ccache`, `apt-get`, and the container registry were incorrect. This PR fixes them.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
