### PR TITLE
chore: release 0.44.1

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -8,7 +8,7 @@ repositories:
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: e62ea6fdb9ee50e49c7642c77e85250cb15b8e80
+    version: 12287684e096a02d279299a7e6cb44740fc34467
   core/autoware_internal_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
@@ -28,12 +28,12 @@ repositories:
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
-    version: 0.3.0
+    version: 1.1.0
   # universe
   universe/autoware_universe:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git
-    version: 0.43.0
+    version: 0.44.1
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
@@ -91,7 +91,7 @@ repositories:
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
-    version: 0.43.1
+    version: 0.44.0
   # sensor_component
   sensor_component/external/sensor_component_description:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -111,11 +111,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan
     version: e39a814180b03f00a5692b6951a5d4e9f0463486
-  # param
-  param/autoware_individual_params:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_individual_params.git
-    version: 70000825155182d9261ce0980076b0e2c6dc3f51
   # middleware
   # TODO(TIER IV): During the transition period of Agnocast introduction,
   # the Agnocast ROS packages are provided as a source build.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -144,7 +144,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 COPY src/launcher /autoware/src/launcher
-COPY src/param /autoware/src/param
 COPY src/sensor_component /autoware/src/sensor_component
 COPY src/universe /autoware/src/universe
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
@@ -457,7 +456,6 @@ COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
-  --mount=type=bind,source=src/param,target=/autoware/src/param \
   --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
   --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \


### PR DESCRIPTION
## Description

**Merge after:**
1. https://github.com/autowarefoundation/autoware_universe/pull/10576 is merged.
2. `0.44.1` tag is created in autoware_universe repo.
3. `run:health-check` tag is added to this PR and does pass

This PR also incorporates:
- https://github.com/autowarefoundation/autoware/pull/6029

## How was this PR tested?

You can see the updates and tests done in:
- https://github.com/autowarefoundation/autoware_universe/pull/10576#issuecomment-2856393057

## Notes for reviewers

None.

## Effects on system behavior

None.
