### PR TITLE
ci(action.yaml): add `--shallow` option to `vcs import`

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -29,7 +29,7 @@ runs:
     - name: Run vcs import
       run: |
         mkdir src
-        vcs import src < autoware.repos
+        vcs import --shallow src < autoware.repos
         vcs import src < extra-packages.repos
       shell: bash
 

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -29,7 +29,7 @@ runs:
     - name: Run vcs import
       run: |
         mkdir src
-        vcs import src < simulator.repos
+        vcs import --shallow src < simulator.repos
       shell: bash
 
     - name: Setup Docker Buildx

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -29,7 +29,7 @@ runs:
     - name: Run vcs import
       run: |
         mkdir src
-        vcs import src < autoware.repos
+        vcs import --shallow src < autoware.repos
         vcs import src < extra-packages.repos
       shell: bash
 

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -32,14 +32,14 @@ runs:
     - name: Run vcs import
       run: |
         mkdir src
-        vcs import src < autoware.repos
-        vcs import src < extra-packages.repos
+        vcs import --shallow src < autoware.repos
+        vcs import --shallow src < extra-packages.repos
       shell: bash
 
     - name: Import additional repositories
       if: ${{ inputs.additional-repos != '' }}
       run: |
-        vcs import --force src < ${{ inputs.additional-repos }}
+        vcs import --shallow --force src < ${{ inputs.additional-repos }}
       shell: bash
 
     - name: Cache ccache


### PR DESCRIPTION
## Description

This PR adds the `-–shallow` option to the `vcs import` command to speed up the `git clone` process.

```
$ vcs import --help
usage: vcs import [-h] [--input FILE_OR_URL] [--force] [--shallow] [--recursive] [--retry N] [--skip-existing] [--debug] [-w N] [--repos] [path]
...
  --shallow            Create a shallow clone without a history (default: False)
...
```

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
