### PR TITLE
fix(ansible): correctly restore IPv6 disablement

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -32,8 +32,11 @@
   become: true
 
 - name: Restore original IPv6 settings # noqa: no-changed-when
-  ansible.builtin.command: >
-    sysctl -w {{ item }}
+  ansible.posix.sysctl:
+    name: "{{ item.split('=')[0] | trim }}"
+    value: 0
+    sysctl_set: true
+    state: present
   loop: "{{ ipv6_settings.stdout_lines }}"
   when: item is search('=\\s*0')
   become: true

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -35,7 +35,7 @@
   ansible.builtin.command: >
     sysctl -w {{ item }}
   loop: "{{ ipv6_settings.stdout_lines }}"
-  when: item is search('=0')
+  when: item is search('=\\s*0')
   become: true
 
 - name: Update apt cache


### PR DESCRIPTION
## Description

In the agnocast ansible role, there is a process that temporarily disables IPv6.
However, the command used to restore it has an issue, and **the recovery does not complete properly.**
This PR fixes that.

### Details

The setting restore tries to match the pattern `=0`, but the actual line looks like `net.ipv6.conf.all.disable_ipv6 = 0` , with a space between = and 0.
Because of this mismatch, the condition isn’t met, and **the revert command does not run.**

## How was this PR tested?

Here is a comparison of agnocast ansible log.

| before | after|
| -- | --|
| restoring is skipped | restored successfully | 
|![2025-05-13_09-58](https://github.com/user-attachments/assets/f3d59700-e36f-474a-a83c-addecec03512) |![2025-05-13_09-57](https://github.com/user-attachments/assets/628525e0-b882-4908-91a5-df979cf45653)|

### How to see the current settings

```
sysctl net.ipv6.conf.all.disable_ipv6
sysctl net.ipv6.conf.default.disable_ipv6
```

## Notes for reviewers

### How to recover when ipv6 settings are already disabled
> [!NOTE]
> ```
> sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
> sudo sysctl -w net.ipv6.conf.default.disable_ipv6=0
> ```

## Effects on system behavior

None.
