### PR TITLE
fix: linux kernel parameters for scenario evaluation

### DIFF
--- a/.webauto-ci.yaml
+++ b/.webauto-ci.yaml
@@ -21,6 +21,8 @@ artifacts:
         AUTOWARE_PATH: /opt/autoware
         DEBIAN_FRONTEND: noninteractive
         LANG: C.UTF-8
+      linux_parameters:
+        kernel_version: 5.19.0-50-generic
       phases:
         - name: environment-setup
           user: root


### PR DESCRIPTION
## Description
This fixes the setting to run TIER IV's evaluator with AWF projects: https://evaluation.ci.tier4.jp/evaluation/reports?project_id=awf
Currently, the [build is failing](https://evaluation.ci.tier4.jp/evaluation/reports/1ae27a66-dc23-58f8-baf1-e7a566165a47/builds/ef75a1a2-f043-5a14-8054-0a32bc50e284?project_id=awf) since we don't provide agnocast for amzn2.x86_64. This PR fixes the issue.


## How was this PR tested?

https://evaluation.ci.tier4.jp/evaluation/reports/aa380956-a374-5c12-b7e1-c5e6d98305ac?project_id=awf

## Notes for reviewers

None.

## Effects on system behavior

None.
