### PR TITLE
revert: "feat(simulator.repos): major update tier4/scenario_simulator_v2 to 16.3.2"

### DIFF
--- a/simulator.repos
+++ b/simulator.repos
@@ -2,4 +2,4 @@ repositories:
   simulator/scenario_simulator:
     type: git
     url: https://github.com/tier4/scenario_simulator_v2.git
-    version: 16.3.2
+    version: 15.1.1


### PR DESCRIPTION
## Description
Reverts autowarefoundation/autoware#6092.
It seems like 16.3.2 produces error with agnocast turned off (which is the default setting in Autoware).

Therefore, I'm reverting the version until we have working version of scenario simulator.

## How was this PR tested?
I have built locally and ran scenario simulator tutorial. With version 16.3.2, I got
![image](https://github.com/user-attachments/assets/e5b1528e-63ad-4efd-8c1c-f5887909e5a4). 

With version 15.1.1, it ran successfully. 