### PR TITLE
fix(ansible): rename plotjuggler-ros to plotjuggler

### DIFF
--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -37,7 +37,7 @@
     state: latest
     update_cache: true
 
-- name: Hold check of ros-{{ rosdistro + '-plotjuggler-ros' }}
+- name: Hold check of ros-{{ rosdistro + '-plotjuggler' }}
   ansible.builtin.command: apt-mark showhold
   register: held_ros_packages
   changed_when: false
@@ -46,14 +46,14 @@
   become: true
   ansible.builtin.apt:
     name:
-      - ros-{{ rosdistro }}-plotjuggler-ros
+      - ros-{{ rosdistro }}-plotjuggler
     state: latest
     update_cache: true
-  when: "'ros-' + rosdistro + '-plotjuggler-ros' not in held_ros_packages.stdout"
+  when: "'ros-' + rosdistro + '-plotjuggler' not in held_ros_packages.stdout"
   register: install_result
   failed_when: false
 
-- name: Display warning if plotjuggler-ros package is held
+- name: Display warning if plotjuggler package is held
   ansible.builtin.debug:
-    msg: ROS package 'ros-{{ rosdistro }}-plotjuggler-ros' is apt-mark hold. Skipping installation.
+    msg: ROS package 'ros-{{ rosdistro }}-plotjuggler' is apt-mark hold. Skipping installation.
   when: not install_result.changed

--- a/tools-nightly.repos
+++ b/tools-nightly.repos
@@ -3,3 +3,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
     version: main
+  plotjuggler_ros:
+    type: git
+    url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+    version: main

--- a/tools-nightly.repos
+++ b/tools-nightly.repos
@@ -3,6 +3,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
     version: main
+  # This should be removed after merged PR (https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/94)
   plotjuggler_ros:
     type: git
     url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git

--- a/tools.repos
+++ b/tools.repos
@@ -3,6 +3,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
     version: 0.2.0
+  # This should be removed after merged PR (https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/94)
   plotjuggler_ros:
     type: git
     url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git

--- a/tools.repos
+++ b/tools.repos
@@ -3,3 +3,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
     version: 0.2.0
+  plotjuggler_ros:
+    type: git
+    url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+    version: 2.1.3


### PR DESCRIPTION
## Description

In [package release for Humble Hawksbill 2025-05-16](https://discourse.ros.org/t/new-packages-for-humble-hawksbill-2025-05-16/43801/1), `ros-humble-plotjuggler-ros` was removed.
In this PR, I changed the package name and add `plotjuggler-ros-plugins` to tools.repos.

## How was this PR tested?

- CI
- Check on my local environment

## Notes for reviewers

None.

## Effects on system behavior

None.
