### PR TITLE
ci(health-check): use ubuntu-24.04 for runner

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -41,7 +41,7 @@ jobs:
             lib-dir: x86_64
           - build-type: main-arm64
             platform: arm64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
             lib-dir: aarch64
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -33,11 +33,11 @@ jobs:
         include:
           - build-type: main
             platform: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
             lib-dir: x86_64
           - build-type: nightly
             platform: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
             lib-dir: x86_64
           - build-type: main-arm64
             platform: arm64


### PR DESCRIPTION
## Description
Sometimes health-check CI fails due to lack of disk space. (example: https://github.com/autowarefoundation/autoware/actions/runs/15107217677?pr=6153) 

In order to resolve the issue, this PR replaces the runner used for healt-check workflow with ubuntu-24.04. The runner has larger disk space compared to ubuntu-22.04 runner and has lower risk of having the disk space error. 

The CI is meant to build autoware through docker build process, which should have no dependency on host's OS. 

## How was this PR tested?

I have tested in this workflow: https://github.com/autowarefoundation/autoware/actions/runs/15110345942

## Notes for reviewers

None.

## Effects on system behavior

None.
