### PR TITLE
feat: add autoware_rviz_plugins to autoware-nightly.repos

### DIFF
--- a/autoware-nightly.repos
+++ b/autoware-nightly.repos
@@ -15,6 +15,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git
     version: main
+  core/autoware_rviz_plugins:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
+    version: main
   universe/autoware_universe:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git


### PR DESCRIPTION
## Description
This adds autoware_rviz_plugins repository to autoware-nightly.repos.
Currently, it is empty, but we are porting packages from Autoware Universe, and this needs to be added in order to port packages one by one. 

We can release a version once initial set of packages are ported and add to autoware.repos file in another PR. 

## How was this PR tested?

Build pass in CI. 

## Notes for reviewers

None.

## Effects on system behavior

None.
