### PR TITLE
ci(docker-build-and-push): switch to self-hosted runners

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -156,7 +156,7 @@ jobs:
         platform: [amd64, arm64]
         include:
           - platform: amd64
-            runner: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
+            runner: [self-hosted, Linux, X64]
             arch-platform: linux/amd64
             lib-dir: x86_64
           - platform: arm64

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -188,9 +188,10 @@ jobs:
             docker/**
 
       - name: Free disk space
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+        if: ${{ runner.environment == 'github-hosted' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' && github.ref_type == 'tag') }}
+          (github.event_name == 'push' && github.ref_type == 'tag')) }}
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware' with CUDA


### PR DESCRIPTION
## Description

More details here:

- https://github.com/autowarefoundation/autoware_universe/pull/10677

## How was this PR tested?

Testing the workflow:
- https://github.com/autowarefoundation/autoware/actions/runs/15260291185 ❌

https://github.com/autowarefoundation/autoware/actions/runs/15260291185/job/42916734580#step:7:6295

> ```
> ERROR: target universe-devel: failed to solve: failed to configure registry cache exporter: invalid reference format
> Build references
> Check build summary support
> Error: buildx bake failed with: ERROR: target universe-devel: failed to solve: failed to configure registry cache exporter: invalid reference format
> ```

@youtalk -san is this expected to fail here with workflow dispatch?

My modification shouldn't affect this early stage, this failing part is about ARM64 Autoware build stage. (`docker-build-and-push`)
This PR modifies (`docker-build-and-push-cuda`).

## Notes for reviewers

None.

## Effects on system behavior

None.
