### PR TITLE
fix(Dockerfile): move `sensor_component_description` to `universe-vehicle-system` stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,6 +132,7 @@ COPY src/universe/autoware_universe/vehicle /autoware/src/universe/autoware_univ
 COPY src/universe/autoware_universe/system /autoware/src/universe/autoware_universe/system
 COPY src/universe/autoware_universe/map/autoware_map_height_fitter /autoware/src/universe/autoware_universe/map/autoware_map_height_fitter
 COPY src/universe/autoware_universe/localization/autoware_pose2twist /autoware/src/universe/autoware_universe/localization/autoware_pose2twist
+COPY src/sensor_component/external/sensor_component_description /autoware/src/sensor_component/external/sensor_component_description
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-vehicle-system-depend-packages.txt \
   && cat /rosdep-universe-vehicle-system-depend-packages.txt
@@ -404,6 +405,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/autoware_universe/system,target=/autoware/src/universe/autoware_universe/system \
   --mount=type=bind,source=src/universe/autoware_universe/map/autoware_map_height_fitter,target=/autoware/src/universe/autoware_universe/map/autoware_map_height_fitter \
   --mount=type=bind,source=src/universe/autoware_universe/localization/autoware_pose2twist,target=/autoware/src/universe/autoware_universe/localization/autoware_pose2twist \
+  --mount=type=bind,source=src/sensor_component/external/sensor_component_description,target=/autoware/src/sensor_component/external/sensor_component_description \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware


### PR DESCRIPTION
## Description

I am conducting experiments to launch the `autoware` multi-container setup. When launching the `autoware:universe-vehicle-system` container, the following error occurred. 

```
autoware-vehicle  | [ERROR] [launch]: Caught exception in launch (see debug for traceback): executed command failed. Command: xacro /opt/autoware/share/tier4_vehicle_launch/urdf/vehicle.xacro vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit config_dir:=/opt/autoware/share/sample_sensor_kit_description/config
autoware-vehicle  | Captured stderr output: error: <class 'ament_index_python.packages.PackageNotFoundError'>: "package 'velodyne_description' not found, searching: ['/opt/autoware', '/opt/ros/humble']" "package 'velodyne_description' not found, searching: ['/opt/autoware', '/opt/ros/humble']"
autoware-vehicle  | when instantiating macro: sensor_kit_macro (/opt/autoware/share/sample_sensor_kit_description/urdf/sensor_kit.xacro)
autoware-vehicle  | in file: /opt/autoware/share/sample_sensor_kit_description/urdf/sensors.xacro
autoware-vehicle  | included from: /opt/autoware/share/tier4_vehicle_launch/urdf/vehicle.xacro
```

Therefore, this PR modified the `Dockerfile` to build the `sensing_component_description` during the `universe-vehicle-system-devel` stage.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
