### PR TITLE
fix(docker-build-and-push-cuda): install apt version of vcstool

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -22,7 +22,15 @@ runs:
     - name: Install jq and vcstool
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install jq python3-pip python3-vcstool
+        sudo apt-get -y install curl gnupg lsb-release
+
+        # Add the ROS 2 GPG key and repository
+        sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | \
+          sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+        sudo apt-get update
+        sudo apt-get install -y jq python3-pip python3-vcstool
       shell: bash
 
     - name: Run vcs import

--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -22,8 +22,7 @@ runs:
     - name: Install jq and vcstool
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install jq python3-pip
-        pip install --no-cache-dir vcstool
+        sudo apt-get -y install jq python3-pip python3-vcstool
       shell: bash
 
     - name: Run vcs import


### PR DESCRIPTION
## Description

- Follow up from https://github.com/autowarefoundation/autoware/pull/6176

**Error:** https://github.com/autowarefoundation/autoware/actions/runs/15271148991/job/43038988408#step:7:428

<details>
  <summary>🖱️Click here to expand🔛</summary>

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
</details>

Since the self hosted machines are Ubuntu 24.04, I think **they are more cautious about mixing pip packages with the python apt packages**.

**More info can be found here:** https://askubuntu.com/questions/1465218/pip-error-on-ubuntu-externally-managed-environment-%C3%97-this-environment-is-extern

We already have `python3-vcstool` available in both Ubuntu 22.04 and 24.04 so this PR modifies this step to **install the apt version as recommended**.

## How was this PR tested?

Being tested here: https://github.com/autowarefoundation/autoware/actions/runs/15300562020 ❌

It gave out `E: Unable to locate package python3-vcstool`

Checking on my machine:
```console
mfc@whale:~$ apt-cache policy python3-vcstool
python3-vcstool:
  Installed: 0.3.0-1
  Candidate: 0.3.0-1
  Version table:
 *** 0.3.0-1 500
        500 http://packages.ros.org/ros2/ubuntu jammy/main amd64 Packages
        100 /var/lib/dpkg/status
```

Now added the ROS 2 ppa with https://github.com/autowarefoundation/autoware/pull/6187/commits/7393cee5f77d44e189bf05d31ec5d7a97c51b1d6

Testing again: https://github.com/autowarefoundation/autoware/actions/runs/15303715617 ✅

It was successful!

## Notes for reviewers

None.

## Effects on system behavior

None.
