### PR TITLE
fix(tools*.repos): update the plotjuggler version for humble

### DIFF
--- a/tools-nightly.repos
+++ b/tools-nightly.repos
@@ -7,4 +7,4 @@ repositories:
   plotjuggler_ros:
     type: git
     url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-    version: main
+    version: humble

--- a/tools.repos
+++ b/tools.repos
@@ -7,4 +7,4 @@ repositories:
   plotjuggler_ros:
     type: git
     url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-    version: 2.1.3
+    version: 2.1.2-humble


### PR DESCRIPTION
## Description

Related PRs (follow up from):
- https://github.com/autowarefoundation/autoware/pull/6153#issuecomment-2917592325
- https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/97

Right now neither `2.1.3` nor the `main` branch of `plotjuggler_ros` package compiles in `humble`.

This should make things easier to understand:

![image](https://github.com/user-attachments/assets/35dd30da-1864-460a-b34a-43c02d710b02)

- Back when https://github.com/autowarefoundation/autoware/pull/6153 was merged, `main` used to compile but `2.1.3` shouldn't have.

This PR aims to make both versions humble compatible.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
