### PR TITLE
fix(Dockerfile.base): workaround of ROS signing key migration

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -1,38 +1,34 @@
-- name: Install dependencies for setting up apt sources
-  become: true
-  ansible.builtin.apt:
-    name:
-      - curl
-      - gnupg
-      - lsb-release
-    update_cache: true
+- name: Get latest release information of ros-apt-source package
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest
+    method: GET
+    return_content: yes
+  register: ros_apt_release_info
 
-# sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-- name: Authorize ROS GPG key
-  become: true
-  ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
-    dest: /usr/share/keyrings/ros-archive-keyring.gpg
-    mode: 644
-
-- name: Save result of 'dpkg --print-architecture'
-  ansible.builtin.command: dpkg --print-architecture
-  register: ros2__deb_architecture
-  changed_when: false
+- name: Extract latest version of ros-apt-source package
+  ansible.builtin.set_fact:
+    ros_apt_source_version: "{{ (ros_apt_release_info.content | from_json).tag_name }}"
 
 - name: Save result of 'source /etc/os-release && echo $UBUNTU_CODENAME'
   ansible.builtin.shell: bash -c 'source /etc/os-release && echo $UBUNTU_CODENAME'
   register: ros2__ubuntu_codename
   changed_when: false
 
-# echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-- name: Add ROS 2 apt repository to source list
-  become: true
-  ansible.builtin.apt_repository:
-    repo: deb [arch={{ ros2__deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ ros2__ubuntu_codename.stdout }} main
-    filename: ros2
+- name: Get ros2-apt-source package
+  ansible.builtin.get_url:
+    url: "https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros_apt_source_version }}/ros2-apt-source_{{ ros_apt_source_version }}.{{ ros2__ubuntu_codename.stdout }}_all.deb"
+    dest: /tmp/ros2-apt-source.deb
+
+- name: Install ros2-apt-source package
+  ansible.builtin.apt:
+    deb: /tmp/ros2-apt-source.deb
     state: present
-    update_cache: true
+  become: yes
+
+- name: Delete installed .deb file
+  ansible.builtin.file:
+    path: /tmp/ros2-apt-source.deb
+    state: absent
 
 - name: Hold check of ros-{{ rosdistro + '-' + ros2_installation_type }}
   ansible.builtin.command: apt-mark showhold

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -18,6 +18,7 @@
   ansible.builtin.get_url:
     url: https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros_apt_source_version }}/ros2-apt-source_{{ ros_apt_source_version }}.{{ ros2__ubuntu_codename.stdout }}_all.deb
     dest: /tmp/ros2-apt-source.deb
+    mode: "0644"
 
 - name: Install ros2-apt-source package
   ansible.builtin.apt:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -2,7 +2,7 @@
   ansible.builtin.uri:
     url: https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest
     method: GET
-    return_content: yes
+    return_content: true
   register: ros_apt_release_info
 
 - name: Extract latest version of ros-apt-source package
@@ -16,14 +16,14 @@
 
 - name: Get ros2-apt-source package
   ansible.builtin.get_url:
-    url: "https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros_apt_source_version }}/ros2-apt-source_{{ ros_apt_source_version }}.{{ ros2__ubuntu_codename.stdout }}_all.deb"
+    url: https://github.com/ros-infrastructure/ros-apt-source/releases/download/{{ ros_apt_source_version }}/ros2-apt-source_{{ ros_apt_source_version }}.{{ ros2__ubuntu_codename.stdout }}_all.deb
     dest: /tmp/ros2-apt-source.deb
 
 - name: Install ros2-apt-source package
   ansible.builtin.apt:
     deb: /tmp/ros2-apt-source.deb
     state: present
-  become: yes
+  become: true
 
 - name: Delete installed .deb file
   ansible.builtin.file:

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -25,14 +25,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && mkdir -p ~/.ssh \
   && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
+# TODO(youtalk): Remove these once ros:humble image is update
 RUN rm /etc/apt/sources.list.d/ros2-latest.list \
   && rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-
 RUN apt-get update \
   && apt-get install -y ca-certificates curl
-
+# hadolint ignore=SC1091
 RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-  curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+  curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo "$VERSION_CODENAME")_all.deb" \
   && apt-get update \
   && apt-get install -y /tmp/ros2-apt-source.deb \
   && rm -f /tmp/ros2-apt-source.deb

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -25,6 +25,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && mkdir -p ~/.ssh \
   && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
+RUN rm /etc/apt/sources.list.d/ros2-latest.list \
+  && rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+  curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+  && apt-get update \
+  && apt-get install -y /tmp/ros2-apt-source.deb \
+  && rm -f /tmp/ros2-apt-source.deb
+
 # Set up base environment
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,17 +14,6 @@ COPY docker/scripts/cleanup_system.sh /autoware/cleanup_system.sh
 RUN chmod +x /autoware/cleanup_system.sh
 WORKDIR /autoware
 
-# Install apt packages and add GitHub to known hosts for private repositories
-RUN rm -f /etc/apt/apt.conf.d/docker-clean \
-  && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-  gosu \
-  ssh \
-  && /autoware/cleanup_apt.sh \
-  && mkdir -p ~/.ssh \
-  && ssh-keyscan github.com >> ~/.ssh/known_hosts
-
 # TODO(youtalk): Remove these once ros:humble image is update
 RUN rm /etc/apt/sources.list.d/ros2-latest.list \
   && rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
@@ -36,6 +25,17 @@ RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-inf
   && apt-get update \
   && apt-get install -y /tmp/ros2-apt-source.deb \
   && rm -f /tmp/ros2-apt-source.deb
+
+# Install apt packages and add GitHub to known hosts for private repositories
+RUN rm -f /etc/apt/apt.conf.d/docker-clean \
+  && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  gosu \
+  ssh \
+  && /autoware/cleanup_apt.sh \
+  && mkdir -p ~/.ssh \
+  && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 # Set up base environment
 RUN --mount=type=ssh \


### PR DESCRIPTION
## Description

This PR is a workaround of ROS signing key migration problem.
https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/23

Once `ros:humble` is updated, we will revert this PR.

## How was this PR tested?

- before: https://github.com/youtalk/autoware/actions/runs/15381756270/job/43273587499
- after: https://github.com/youtalk/autoware/actions/runs/15381927186/job/43274009504

## Notes for reviewers

None.

## Effects on system behavior

None.
