### PR TITLE
fix(tools-nightly.repos): use `2.1.2-humble`

### DIFF
--- a/tools-nightly.repos
+++ b/tools-nightly.repos
@@ -7,4 +7,4 @@ repositories:
   plotjuggler_ros:
     type: git
     url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-    version: humble
+    version: 2.1.2-humble


### PR DESCRIPTION
## Description

- It seems the `humble` branch has disappeared from the following repository:
  - https://github.com/PlotJuggler/plotjuggler-ros-plugins
-  I verified that using `2.1.2-humble` makes build succeed

## How was this PR tested?

```
$ git clone https://github.com/autowarefoundation/autoware.git
$ cd autoware
$ mkdir src
$ vcs import src < autoware.repos && vcs import src < simulator.repos && vcs import src < tools.repos
$ vcs import src < autoware-nightly.repos && vcs import src < simulator-nightly.repos && vcs import src < tools-nightly.repos
```

Then I met an following error:
```
=== src/plotjuggler_ros (git) ===
Could not checkout ref 'humble': fatal: invalid reference: humble
```

I fixed the `tools-nightly.repos` as this PR. Then I ran the following commands:
```
$ vcs import src < autoware-nightly.repos && vcs import src < simulator-nightly.repos && vcs import src < tools-nightly.repos

(Succeeded)

$ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
$ colcon build --base-paths src --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
$ source install/setup.bash
$ ros2 run plotjuggler plotjuggler
```

## Notes for reviewers

Please feel free to share your comment. I'm happy doing provided checks and so on :+1: 

## Effects on system behavior

The procedure using `*-nightly.repos` will work.
