### PR TITLE
feat(autoware.repos): add digestible repo

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -120,3 +120,8 @@ repositories:
     type: git
     url: https://github.com/tier4/agnocast.git
     version: 2.1.1
+  # TODO(TIER IV): Remove the source build once the digestible vendor package is released in the official ROS repository.
+  vendor/digestible:
+    type: git
+    url: https://github.com/tier4/digestible.git
+    version: 0.1.0


### PR DESCRIPTION
## Description

Add this repo for the needs of autoware_utils_math(https://github.com/autowarefoundation/autoware_utils/pull/71)

Discussion: https://star4.slack.com/archives/C4P0NSMB5/p1749182597397049

PR merging order:
- pilot-auto : https://github.com/tier4/pilot-auto/pull/1473
- OSS autoware: https://github.com/autowarefoundation/autoware/pull/6218 
- autoware_utils:https://github.com/autowarefoundation/autoware_utils/pull/71
- autoware_universe:https://github.com/autowarefoundation/autoware_universe/pull/10769


## How was this PR tested?

All related information is summarized at [autoware_utils' PR](https://github.com/autowarefoundation/autoware_utils/pull/71).

## Notes for reviewers

None.

## Effects on system behavior

None.
