### PR TITLE
ci(webauto-ci): use sudo to fix permission in autoware-build/run.sh

### DIFF
--- a/.webauto-ci/main/autoware-build/run.sh
+++ b/.webauto-ci/main/autoware-build/run.sh
@@ -24,7 +24,7 @@ if [ -n "$CCACHE_DIR" ]; then
 fi
 
 # install xmlschema<4.0.0 before rosdep install as workaround for scenario_simulator_v2
-sudo pip3 install --user xmlschema==3.4.5
+sudo pip3 install xmlschema==3.4.5
 
 sudo -E apt-get -y update
 

--- a/.webauto-ci/main/autoware-build/run.sh
+++ b/.webauto-ci/main/autoware-build/run.sh
@@ -24,7 +24,7 @@ if [ -n "$CCACHE_DIR" ]; then
 fi
 
 # install xmlschema<4.0.0 before rosdep install as workaround for scenario_simulator_v2
-pip3 install --user xmlschema==3.4.5
+sudo pip3 install --user xmlschema==3.4.5
 
 sudo -E apt-get -y update
 


### PR DESCRIPTION
## Description

The workaround for `xmlschema` library has introduced by https://github.com/autowarefoundation/autoware/pull/6064.
It works well for normal Autoware Evaluator execution, but occurs an error for on-demand execution.
This pull-request fixes errors on on-demand execution.

## How was this PR tested?

This pull-request has same content with [this pull-request(internal)](https://github.com/tier4/pilot-auto/pull/1326).
In TIER IV, any on-demand scenario executions on Autoware Evaluator are works well due to this pull-request.

## Notes for reviewers

None.

## Effects on system behavior

None.
