### PR TITLE
fix: fix jq script for calculating cache size

### DIFF
--- a/.github/workflows/keep-build-cache-small.yaml
+++ b/.github/workflows/keep-build-cache-small.yaml
@@ -1,7 +1,7 @@
 name: keep-build-cache-small
 
 on:
-  workflow_call:
+  workflow_dispatch:
   schedule:
     - cron: 0 6 * * *
 

--- a/.github/workflows/keep-build-cache-small.yaml
+++ b/.github/workflows/keep-build-cache-small.yaml
@@ -55,7 +55,7 @@ jobs:
         if: steps.check_image.outputs.exists == 'true'
         run: |
           echo "🔍 Inspecting build cache size for image: ${{ env.BUILD_CACHE_IMAGE }}..."
-          SIZE_BYTES=$(skopeo inspect --raw docker://${{ env.BUILD_CACHE_IMAGE }} | jq '[.manifests[].size] | add')
+          SIZE_BYTES=$(skopeo inspect --raw docker://${{ env.BUILD_CACHE_IMAGE }} | jq '.layers | map(.size) | add')
           SIZE_GB=$(echo "scale=2; $SIZE_BYTES / (1024 * 1024 * 1024)" | bc)
           echo "Cache size: ${SIZE_GB} GB"
           echo "size_gb=${SIZE_GB}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/keep-build-cache-small.yaml
+++ b/.github/workflows/keep-build-cache-small.yaml
@@ -1,6 +1,7 @@
 name: keep-build-cache-small
 
 on:
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: 0 6 * * *


### PR DESCRIPTION
## Description
It seems like the keep-build-cache-small workflow fails to retrieve the size of cache and failing: https://github.com/autowarefoundation/autoware/actions/runs/15725172321/job/44313474792
![image](https://github.com/user-attachments/assets/8f20f632-c5e7-45c0-bee4-dee8794d290d)

I also tried running `skopeo inspect --raw docker://ghcr.io/autowarefoundation/autoware-buildcache:amd64-main | jq '[.manifests[].size] | add'` locally and confirmed that it fails. I don't know why the format of the json output changed, but I have jq script to match with the current output format.

I have also modified the triggering from workflow_call to worfklow_dispatch since I think that was the original intention (no other workflow calls this job)

## How was this PR tested?
I ran the following commands and made sure that cache size can be retrieved:
```
skopeo inspect --raw docker://ghcr.io/autowarefoundation/autoware-buildcache:arm64-main | jq '.layers | map(.size) | add'
skopeo inspect --raw docker://ghcr.io/autowarefoundation/autoware-buildcache:amd64-main | jq '.layers | map(.size) | add'
```


## Notes for reviewers

None.

## Effects on system behavior

None.
