### PR TITLE
fix(Dockerfile): copy `autoware_launch` to `universe-sening-perception` stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -532,6 +532,8 @@ RUN --mount=type=ssh \
   && /autoware/cleanup_system.sh $LIB_DIR $ROS_DISTRO
 
 COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
+# TODO(youtalk): Fix https://github.com/autowarefoundation/autoware/pull/6235 workaround
+COPY --from=universe-common-devel /opt/autoware/share/autoware_launch /opt/autoware/share/autoware_launch
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases


### PR DESCRIPTION
## Description

Only `universe-sensing-perception` image lacks `autoware_launch` for some reason even though it's being copied during the `universe-common-devel` stage.
https://github.com/autowarefoundation/autoware/blob/main/docker/Dockerfile#L245

This PR copies `autoware_launch` on `universe-sening-perception` stage to resolve the problem.

## How was this PR tested?

https://github.com/autowarefoundation/autoware/pull/6225

```
docker compose --env-file docker/logging-simulation.env -f docker/docker-compose.yaml up sensing
WARN[0000] Found orphan containers ([ros2-topic-list]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
[+] Running 2/2
 ✔ Container autoware-map      Running                                                                                                                                                                                                                                                                                                                                           0.0s
 ✔ Container autoware-sensing  Created                                                                                                                                                                                                                                                                                                                                           0.0s
Attaching to autoware-sensing
autoware-sensing  | Package 'autoware_launch' not found: "package 'autoware_launch' not found, searching: ['/opt/autoware', '/opt/ros/humble']"
autoware-sensing exited with code 1
```

## Notes for reviewers

None.

## Effects on system behavior

None.
