### PR TITLE
fix(Dockerfile): copy `sensor_component` to `universe-sensing-perception-devel`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -146,6 +146,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 COPY src/launcher /autoware/src/launcher
+COPY src/sensor_component /autoware/src/sensor_component
 COPY src/universe /autoware/src/universe
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-depend-packages.txt \
@@ -459,6 +460,7 @@ COPY --from=universe-vehicle-system-devel /opt/autoware /opt/autoware
 COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
+  --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
   --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \
   --mount=type=bind,source=src/universe/autoware_universe/simulator,target=/autoware/src/universe/autoware_universe/simulator \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,6 +74,7 @@ COPY src/universe/autoware_universe/launch/tier4_sensing_launch /autoware/src/un
 COPY src/universe/autoware_universe/perception /autoware/src/universe/autoware_universe/perception
 COPY src/universe/autoware_universe/sensing /autoware/src/universe/autoware_universe/sensing
 COPY src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator /autoware/src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator
+COPY src/sensor_component /autoware/src/sensor_component
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-sensing-perception-depend-packages.txt \
   && cat /rosdep-universe-sensing-perception-depend-packages.txt
@@ -145,7 +146,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 COPY src/launcher /autoware/src/launcher
-COPY src/sensor_component /autoware/src/sensor_component
 COPY src/universe /autoware/src/universe
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-depend-packages.txt \
@@ -285,6 +285,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/autoware_universe/perception,target=/autoware/src/universe/autoware_universe/perception \
   --mount=type=bind,source=src/universe/autoware_universe/sensing,target=/autoware/src/universe/autoware_universe/sensing \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator,target=/autoware/src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator \
+  --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
@@ -458,7 +459,6 @@ COPY --from=universe-vehicle-system-devel /opt/autoware /opt/autoware
 COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
   --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \
   --mount=type=bind,source=src/universe/autoware_universe/simulator,target=/autoware/src/universe/autoware_universe/simulator \


### PR DESCRIPTION
## Description

`nebula` was originally built during the `universe-devel` stage, but it should have been built during the `universe-sensing-perception-devel` stage.
This PR fixes the problem.

## How was this PR tested?

https://github.com/autowarefoundation/autoware/pull/6225

```
docker compose --env-file docker/logging-simulation.env -f docker/docker-compose.yaml up sensing
WARN[0000] Found orphan containers ([autoware-sensing-perception ros2-topic-list]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
[+] Running 3/3
 ✔ Container autoware-map      Running                                                                                                                                                                                                                                                                                                                                           0.0s
 ✔ Container autoware-system   Running                                                                                                                                                                                                                                                                                                                                           0.0s
 ✔ Container autoware-sensing  Created                                                                                                                                                                                                                                                                                                                                           0.0s
Attaching to autoware-sensing
autoware-sensing  | [INFO] [launch]: All log files can be found below /root/.ros/log/2025-06-23-06-21-13-794932-cfa6d87b2a0c-2195
autoware-sensing  | [INFO] [launch]: Default logging verbosity is set to INFO
autoware-sensing  | [ERROR] [launch]: Caught exception in launch (see debug for traceback): "package 'nebula_decoders' not found, searching: ['/opt/autoware', '/opt/ros/humble']"
autoware-sensing exited with code 1
```

## Notes for reviewers

None.

## Effects on system behavior

None.
