### PR TITLE
feat: add autoware_rviz_plugins to autoware.repos

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -29,6 +29,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
     version: 1.2.0
+  core/autoware_rviz_plugins:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
+    version: 0.1.0
   # universe
   universe/autoware_universe:
     type: git


### PR DESCRIPTION
## Description
This adds autoware_rviz_plugins to autoware.repos file.
Due to [this](https://github.com/autowarefoundation/autoware/pull/6220) change, RViz fails to load some autoware plugins since they were moved from autoware_universe to autoware_rviz_plugins repository. This PR fixes the error.

![image](https://github.com/user-attachments/assets/3b7ebd06-0d05-4bb4-b5ce-44087a364e4b)

## How was this PR tested?

I have confirmed that the error disappeared, and I checked that rviz can now visualize trajectory again. 
![image](https://github.com/user-attachments/assets/bec142c7-32cb-4a4a-a289-95728b38da72)


## Notes for reviewers

None.

## Effects on system behavior

None.
