### PR TITLE
feat(ansible): load agnocast module at boot

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -71,3 +71,12 @@
     state: present
   become: true
   when: dkms_status.rc != 0
+
+- name: Ensure agnocast module is loaded at boot via modules-load.d
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/agnocast.conf
+    content: "agnocast\n"
+    owner: root
+    group: root
+    mode: "0644"
+  become: true


### PR DESCRIPTION
## Description
Currently, the agnocast Ansible role installs the agnocast kernel module, but it is not automatically loaded at boot.
This PR adds a configuration to the ansible role to ensure the kernel module is automatically loaded during system startup.

## How was this PR tested?
I created the following playbook and executed by `ansible-playbook test.yaml -K`.
```
- name: Test agnocast role
  hosts: localhost
  roles:
    - { role: agnocast }
````


I confirmed the file was created and kernel module was loaded properly at boot.
```
$ cat /etc/modules-load.d/agnocast.conf 
agnocast
```

```
$ lsmod | grep agnocast
agnocast              835584  0
```

## Notes for reviewers

None.

## Effects on system behavior

None.
