### PR TITLE
feat: add use_sim_time option for visualization container

### DIFF
--- a/docker/tools/visualizer/entrypoint.sh
+++ b/docker/tools/visualizer/entrypoint.sh
@@ -40,7 +40,7 @@ EOF
 #!/bin/bash
 source /opt/ros/"$ROS_DISTRO"/setup.bash
 source /opt/autoware/setup.bash
-exec rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:=$USE_SIM_TIME
+exec rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:="$USE_SIM_TIME"
 EOF
     chmod +x /usr/local/bin/start-rviz2.sh
     echo "echo 'Autostart executed at $(date)' >> /tmp/autostart.log" >>/etc/xdg/openbox/autostart
@@ -90,7 +90,7 @@ source "/opt/autoware/setup.bash"
 
 # Execute passed command if provided, otherwise launch rviz2
 if [ "$REMOTE_DISPLAY" == "false" ]; then
-    [ $# -eq 0 ] && rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:=$USE_SIM_TIME
+    [ $# -eq 0 ] && rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:="$USE_SIM_TIME"
     exec "$@"
 else
     configure_vnc

--- a/docker/tools/visualizer/entrypoint.sh
+++ b/docker/tools/visualizer/entrypoint.sh
@@ -9,6 +9,12 @@ if [ -z "$RVIZ_CONFIG" ]; then
     export RVIZ_CONFIG
 fi
 
+if [ -z "$USE_SIM_TIME" ]; then
+    echo -e "\e[31mUSE_SIM_TIME is not set defaulting to false\e[0m"
+    USE_SIM_TIME="false"
+    export USE_SIM_TIME
+fi
+
 configure_vnc() {
     # Create Openbox application configuration
     mkdir -p /etc/xdg/openbox
@@ -34,7 +40,7 @@ EOF
 #!/bin/bash
 source /opt/ros/"$ROS_DISTRO"/setup.bash
 source /opt/autoware/setup.bash
-exec rviz2 -d "$RVIZ_CONFIG"
+exec rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:=$USE_SIM_TIME
 EOF
     chmod +x /usr/local/bin/start-rviz2.sh
     echo "echo 'Autostart executed at $(date)' >> /tmp/autostart.log" >>/etc/xdg/openbox/autostart
@@ -84,7 +90,7 @@ source "/opt/autoware/setup.bash"
 
 # Execute passed command if provided, otherwise launch rviz2
 if [ "$REMOTE_DISPLAY" == "false" ]; then
-    [ $# -eq 0 ] && rviz2 -d "$RVIZ_CONFIG"
+    [ $# -eq 0 ] && rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:=$USE_SIM_TIME
     exec "$@"
 else
     configure_vnc


### PR DESCRIPTION
## Description
This adds use_sim_time argument when launching rviz in visualizer container so that we can use it with logging_simulator.

## How was this PR tested?
I have locally generated the docker image and tested with the logging_simulator docker compose PR https://github.com/autowarefoundation/autoware/pull/6225. 

Example 1. If no USE_SIM_TIME is given, it says that it will use false as default value
<img width="1661" height="364" alt="image" src="https://github.com/user-attachments/assets/25c33921-fcdd-4043-8c76-f08bb8f2076c" />

Example 2: If USE_SIM_TIME is given, it runs with sim time true
<img width="1785" height="173" alt="image" src="https://github.com/user-attachments/assets/ea19b589-deda-4a1d-862e-bd46bba7f528" />


## Notes for reviewers

None.

## Effects on system behavior

None.
