### PR TITLE
fix(ansible): align agnocast version with autoware.repos (v2.1.1)

### DIFF
--- a/ansible/roles/agnocast/README.md
+++ b/ansible/roles/agnocast/README.md
@@ -9,7 +9,7 @@ None.
 ## Manual Installation
 
 ```bash
-agnocast_version="2.1.0"
+agnocast_version="2.1.1"
 agnocast_heaphook_package="agnocast-heaphook-v${agnocast_version}"
 agnocast_kmod_package="agnocast-kmod-v${agnocast_version}"
 

--- a/ansible/roles/agnocast/defaults/main.yaml
+++ b/ansible/roles/agnocast/defaults/main.yaml
@@ -1,3 +1,3 @@
-agnocast_version: 2.1.0
+agnocast_version: 2.1.1
 agnocast_heaphook_package: agnocast-heaphook-v{{ agnocast_version }}
 agnocast_kmod_package: agnocast-kmod-v{{ agnocast_version }}


### PR DESCRIPTION
## Description
Agnocast has been automatically updated to v2.1.1 by the Github Action ([commit](https://github.com/autowarefoundation/autoware/commit/c378f1858174c599b03d7a04a50004e67ad26091)), but this update is not applied to the ansible settings.

## How was this PR tested?

Evaluator build passed: [TIER IV Internal Link](https://evaluation.tier4.jp/evaluation/reports/4d79bcb7-00c6-5536-91d0-3ed851eed6b3?project_id=prd_jt)

## Notes for reviewers

related: https://github.com/autowarefoundation/autoware_universe/pull/11056

## Effects on system behavior

None.
