### PR TITLE
feat(artifacts): add artifact download process for SIMPL

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -540,3 +540,18 @@
     dest: "{{ data_dir }}/traffic_light_fine_detector/tlr_labels.txt"
     mode: "644"
     checksum: sha256:a2a91f5fe9c2e68e3e3647a272bb9bb25cd07631a1990a3fb15efddce7691131
+
+# simpl_prediction
+- name: Create simpl_prediction directory inside {{ data_dir }}
+  ansible.builtin.file:
+    path: "{{ data_dir }}/simpl_prediction"
+    mode: "755"
+    state: directory
+
+- name: Download simpl_prediction/simpl.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/simpl/v0.1.0/simpl.onnx
+    dest: "{{ data_dir }}/simpl_prediction/simpl.onnx"
+    mode: "644"
+    checksum: sha256:ad5e03983193c4d188432f314334697d6a216e7ffc91fb651eee5d6e4c42f492


### PR DESCRIPTION
## Description

Parent Issue: https://github.com/autowarefoundation/autoware_universe/issues/6348
Relevant PR: https://github.com/autowarefoundation/autoware_universe/pull/10824

This PR adds process to download artifact for ML-based motion prediction model called SIMPL.

## How was this PR tested?

- Confirmed `setup-dev-env.sh` worked
- Confirmed `autoware_simpl_prediction` worked without any problems using the latest `autoware_universe` and default parameters as follows:

```shell
$ ros2 launch autoware_simpl_prediction simpl.launch.xml
```

## Notes for reviewers

None.

## Effects on system behavior

None.
