### PR TITLE
fix: copy order of autoware install directory for cuda images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -487,8 +487,8 @@ RUN --mount=type=ssh \
   && cat /tmp/rosdep-universe-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
   && /autoware/cleanup_apt.sh
 
-COPY --from=universe-sensing-perception-devel-cuda /opt/autoware /opt/autoware
 COPY --from=universe-devel /opt/autoware /opt/autoware
+COPY --from=universe-sensing-perception-devel-cuda /opt/autoware /opt/autoware
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description
This resolves part of https://github.com/autowarefoundation/autoware/issues/6357

This fixes the copy order of /opt/autoware directory to create universe-devel-cuda image.
We should be copying unvierse-sensing-perception-devel-cuda execution files **after** universe-devel execution files. Otherwise, non-cuda execution files will overwrite the cuda dependent execution files if they have the same name. 

## How was this PR tested?
I have built the image locally and launch traffic_light_classifier node with the following commands:

```
docker run -it --rm --net=host --gpus all -v /home/mitsudome-r/autoware_map/sample-map-rosbag:/autoware_map:ro -v /home/mitsudome-r/autoware_data:/autoware_data:rw ghcr.io/autowarefoundation/autoware:universe-cuda /bin/bash

source /opt/autoware/setup.bash

ros2 launch autoware_traffic_light_classifier car_traffic_light_classifier.launch.xml   param_path:=$(ros2 pkg prefix autoware_traffic_light_classifier --share)/config/car_traffic_light_classifier.param.yaml   model_path:=/autoware_data/traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_6.onnx   label_path:=/autoware_data/traffic_light_classifier/lamp_labels.txt   build_only:=true
```

Before
<img width="1765" height="266" alt="image" src="https://github.com/user-attachments/assets/888de8f3-00e3-4a97-949d-250eb480d01c" />

After:
<img width="1974" height="546" alt="image" src="https://github.com/user-attachments/assets/25790a4e-33d7-48af-8117-0502c383105c" />


## Notes for reviewers

We still have some runtime errors, but they can be fixed through other PRs. (My error is due to old GPU. I will try with another PC with newer GPU later)

## Effects on system behavior

None.
