### PR TITLE
fix: use autoware_cuda_dependency_meta for cuda build dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -320,7 +320,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/autoware_universe/sensing,target=/autoware/src/universe/autoware_universe/sensing \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware "--packages-above-and-dependencies autoware_tensorrt_common"
+  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware "--packages-above-and-dependencies autoware_cuda_dependency_meta"
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -318,6 +318,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/external/cuda_blackboard,target=/autoware/src/universe/external/cuda_blackboard \
   --mount=type=bind,source=src/universe/autoware_universe/perception,target=/autoware/src/universe/autoware_universe/perception \
   --mount=type=bind,source=src/universe/autoware_universe/sensing,target=/autoware/src/universe/autoware_universe/sensing \
+  --mount=type=bind,source=src/universe/autoware_universe/common/autoware_cuda_dependency_meta,target=/autoware/src/universe/autoware_universe/common/autoware_cuda_dependency_meta \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware "--packages-above-and-dependencies autoware_cuda_dependency_meta"


### PR DESCRIPTION
## Description
Currently, Autoware Dockerfile builds packages depends on autoware_tensorrt_common for universe-sensing-perception-devel-cuda image. However, there are packages that only depends on CUDA and not on TensorRT in Autoware ([for example occupancy_grid_map_node](https://github.com/autowarefoundation/autoware/issues/6357#issuecomment-3171819450)), and these packages won't be built in docker. 

This PR instead uses autoware_cuda_dependency_meta to select packages that depends on CUDA and TensorRT so that all packages that depends on CUDA will be built in Docker.  

## How was this PR tested?
https://github.com/autowarefoundation/autoware/actions/runs/16956595868

## Notes for reviewers

None.

## Effects on system behavior

None.
