### PR TITLE
fix(build): resolve TensorRT header package issues

### DIFF
--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -20,6 +20,8 @@
       - libnvinfer-plugin-dev={{ tensorrt_version }}
       - libnvparsers-dev={{ tensorrt_version }}
       - libnvonnxparsers-dev={{ tensorrt_version }}
+      - libnvinfer-headers-dev={{ tensorrt_version }}
+      - libnvinfer-headers-plugin-dev={{ tensorrt_version }}
     allow_change_held_packages: true
     allow_downgrade: true
     update_cache: true


### PR DESCRIPTION
:Details:
 - Ansible Task Name: "Install cuDNN and TensorRT Dev"
 - add support for libnvinfer-headers-dev and libnvinfer-headers-plugin-dev packages

## Description
When trying to follow steps described in [Source installation](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/), I got this error on "Install cuDNN and TensorRT Dev" ansible task. This task is defined in [ansible/roles/tensorrt/tasks/main.yaml#L14](https://github.com/autowarefoundation/autoware/blob/release/v1.0/ansible/roles/tensorrt/tasks/main.yaml#L14)

```json
{
    "cache_update_time": 1755052261,
    "cache_updated": false,
    "changed": false,
    "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'libcudnn8-dev=8.9.5.29-1+cuda12.2' 'libnvinfer-dev=8.6.1.6-1+cuda12.0' 'libnvinfer-plugin-dev=8.6.1.6-1+cuda12.0' 'libnvparsers-dev=8.6.1.6-1+cuda12.0' 'libnvonnxparsers-dev=8.6.1.6-1+cuda12.0' --allow-downgrades --allow-change-held-packages' failed: E: Unable to correct problems, you have held broken packages.\n",
    "rc": 100,
    "stderr": "E: Unable to correct problems, you have held broken packages.\n",
    "stderr_lines": [
        "E: Unable to correct problems, you have held broken packages."
    ],
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n libnvinfer-dev : Depends: libnvinfer-headers-dev (= 8.6.1.6-1+cuda12.0) but 10.13.2.6-1+cuda13.0 is to be installed\n libnvinfer-plugin-dev : Depends: libnvinfer-headers-plugin-dev (= 8.6.1.6-1+cuda12.0) but 10.13.2.6-1+cuda13.0 is to be installed\n",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "Some packages could not be installed. This may mean that you have",
        "requested an impossible situation or if you are using the unstable",
        "distribution that some required packages have not yet been created",
        "or been moved out of Incoming.",
        "The following information may help to resolve the situation:",
        "",
        "The following packages have unmet dependencies:",
        " libnvinfer-dev : Depends: libnvinfer-headers-dev (= 8.6.1.6-1+cuda12.0) but 10.13.2.6-1+cuda13.0 is to be installed",
        " libnvinfer-plugin-dev : Depends: libnvinfer-headers-plugin-dev (= 8.6.1.6-1+cuda12.0) but 10.13.2.6-1+cuda13.0 is to be installed"
    ]
}
```

## How was this PR tested?
Create `Dockerfile` and use it to initiaze the environment for building autoware
```
FROM ubuntu:22.04
RUN apt-get update -y && apt-get install -y \
    build-essential \
    cmake \
    git \
    libboost-all-dev \
    libssl-dev \
    libzmq3-dev \
    pkg-config \
    python3-dev \
    python3-pip
WORKDIR /workspace
RUN git clone release/v1.0 https://github.com/all4dich/autoware.git
WORKDIR /workspace/autoware
RUN apt-get install -y python3-venv
RUN ./setup-dev-env.sh -y
```

## Notes for reviewers

None.

## Effects on system behavior

None.
