### PR TITLE
fix(ansible): align agnocast version with autoware.repos (v2.1.2)

### DIFF
--- a/ansible/roles/agnocast/README.md
+++ b/ansible/roles/agnocast/README.md
@@ -9,7 +9,7 @@ None.
 ## Manual Installation
 
 ```bash
-agnocast_version="2.1.1"
+agnocast_version="2.1.2"
 agnocast_heaphook_package="agnocast-heaphook-v${agnocast_version}"
 agnocast_kmod_package="agnocast-kmod-v${agnocast_version}"
 

--- a/ansible/roles/agnocast/defaults/main.yaml
+++ b/ansible/roles/agnocast/defaults/main.yaml
@@ -1,3 +1,3 @@
-agnocast_version: 2.1.1
+agnocast_version: 2.1.2
 agnocast_heaphook_package: agnocast-heaphook-v{{ agnocast_version }}
 agnocast_kmod_package: agnocast-kmod-v{{ agnocast_version }}


### PR DESCRIPTION
## Description
Agnocast is updated to v2.1.2 by the Github Action ([commit](https://github.com/autowarefoundation/autoware/pull/6412)), but this update is not applied to the ansible settings.

## How was this PR tested?

## Notes for reviewers

v2.1.0 -> v2.1.1: https://github.com/autowarefoundation/autoware/pull/6332
related: https://github.com/autowarefoundation/autoware_universe/pull/11231

## Effects on system behavior

None.
