### PR TITLE
docs(cuda-installation): fix CUDA repo arch dir for Jetson/ARM64

### DIFF
--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -37,7 +37,15 @@ From: <https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#net
 wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && source /tmp/amd64.env
 
 os=ubuntu2204
-wget https://developer.download.nvidia.com/compute/cuda/repos/$os/$(uname -m)/cuda-keyring_1.1-1_all.deb
+arch_dir=$(
+  case "$(dpkg --print-architecture)" in
+    amd64) echo x86_64 ;;
+    aarch64) echo arm64 ;;
+    *) echo "$(dpkg --print-architecture)";;
+  esac
+)
+
+wget "https://developer.download.nvidia.com/compute/cuda/repos/${os}/${arch_dir}/cuda-keyring_1.1-1_all.deb"
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 cuda_version_dashed=$(eval sed -e "s/[.]/-/g" <<< "${cuda_version}")


### PR DESCRIPTION
`uname -m` returns `aarch64` on Jetson, but NVIDIA’s repo uses `arm64/`. Also map `amd64` → `x86_64` for PCs. This prevents 404s when fetching `cuda-keyring_1.1-1_all.deb`.

## How was this PR tested?
The fix regarding the `wget 404 error` was tested both on an `amd64` and on an `arm64` machine which had `ubuntu-22.04` installed on them. In both machines, the `wget` command worked and the `cuda-keyring_1.1-1_all.deb` file was successfully downloaded

## Notes for reviewers
I've elaborated the problem in the related [Github Issue](https://github.com/autowarefoundation/autoware/issues/6430).

Simply put, I've added a simple mapping logic to comply with NVIDIA's repositories for a `wget` command that was downloading a `.deb` file from an NVIDIA repo.

This closes #6430
