### PR TITLE
feat(ansible): improve rmw installation

### DIFF
--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -20,6 +20,9 @@
     # Autoware base dependencies
     - role: autoware.dev_env.rmw_implementation
       when: module == 'base'
+      vars:
+        rmw_implementation__rosdistro: "{{ rosdistro }}"
+        rmw_implementation__name: "{{ rmw_implementation }}"
     - role: autoware.dev_env.gdown
       when: module == 'base'
     - role: autoware.dev_env.kisak_mesa

--- a/ansible/playbooks/role_rmw_implementation.yaml
+++ b/ansible/playbooks/role_rmw_implementation.yaml
@@ -1,0 +1,7 @@
+- name: Install RMW implementation
+  hosts: localhost
+  roles:
+    - role: autoware.dev_env.rmw_implementation
+      vars:
+        rmw_implementation__rosdistro: "{{ rosdistro }}"
+        rmw_implementation__name: "{{ rmw_implementation }}"

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -43,6 +43,9 @@
     - role: autoware.dev_env.ros2
     - role: autoware.dev_env.ros2_dev_tools
     - role: autoware.dev_env.rmw_implementation
+      vars:
+        rmw_implementation__rosdistro: "{{ rosdistro }}"
+        rmw_implementation__name: "{{ rmw_implementation }}"
     - role: autoware.dev_env.gdown
     - role: autoware.dev_env.build_tools
     - role: autoware.dev_env.agnocast

--- a/ansible/roles/rmw_implementation/README.md
+++ b/ansible/roles/rmw_implementation/README.md
@@ -19,8 +19,7 @@ wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/auto
 
 # For details: https://docs.ros.org/en/humble/How-To-Guides/Working-with-multiple-RMW-implementations.html
 sudo apt update
-rmw_implementation_dashed=$(eval sed -e "s/_/-/g" <<< "${rmw_implementation}")
-sudo apt install ros-${rosdistro}-${rmw_implementation_dashed}
+sudo apt install ros-${rosdistro}-${rmw_implementation//_/-}
 
 # (Optional) You set the default RMW implementation in the ~/.bashrc file.
 echo '' >> ~/.bashrc && echo "export RMW_IMPLEMENTATION=${rmw_implementation}" >> ~/.bashrc

--- a/ansible/roles/rmw_implementation/defaults/main.yaml
+++ b/ansible/roles/rmw_implementation/defaults/main.yaml
@@ -1,0 +1,2 @@
+rmw_implementation__rosdistro: null
+rmw_implementation__name: null

--- a/ansible/roles/rmw_implementation/tasks/main.yaml
+++ b/ansible/roles/rmw_implementation/tasks/main.yaml
@@ -7,7 +7,7 @@
 - name: Build target package name
   ansible.builtin.set_fact:
     rmw_implementation__pkg: >-
-      ros-{{ (rmw_implementation__rosdistro | default(rosdistro)) }}-{{ (rmw_implementation__name | default(rmw_implementation)) | replace('_', '-') }}
+      ros-{{ rmw_implementation__rosdistro }}-{{ rmw_implementation__name | replace('_', '-') }}
 
 - name: List held packages
   ansible.builtin.command: apt-mark showhold
@@ -21,18 +21,21 @@
     state: latest
     update_cache: true
     cache_valid_time: 3600
-  when: rmw_implementation__pkg not in (rmw_implementation__held_pkgs.stdout_lines | default([]))
+  when: rmw_implementation__pkg not in rmw_implementation__held_pkgs.stdout_lines
 
-- name: Ensure RMW_IMPLEMENTATION in bashrc files
+- name: Ensure RMW_IMPLEMENTATION in user bashrc
   ansible.builtin.lineinfile:
-    path: "{{ item }}"
-    line: export RMW_IMPLEMENTATION={{ rmw_implementation | default(rmw_implementation__name) }}
+    path: "{{ lookup('env', 'HOME') }}/.bashrc"
+    line: export RMW_IMPLEMENTATION={{ rmw_implementation__name }}
     state: present
     create: true
-    mode: 0644
-  loop:
-    - "{{ lookup('env', 'HOME') }}/.bashrc"
-    - /etc/skel/.bashrc
-  loop_control:
-    label: "{{ item }}"
-  become: "{{ '/etc/skel' in item }}"
+    mode: "0644"
+
+- name: Ensure RMW_IMPLEMENTATION in skeleton bashrc (for new users)
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/skel/.bashrc
+    line: export RMW_IMPLEMENTATION={{ rmw_implementation__name }}
+    state: present
+    create: true
+    mode: "0644"

--- a/ansible/roles/rmw_implementation/tasks/main.yaml
+++ b/ansible/roles/rmw_implementation/tasks/main.yaml
@@ -1,36 +1,38 @@
-- name: Get dash-case name of rmw_implementation
-  ansible.builtin.shell: bash -c 'sed -e "s/_/-/g" <<< $(echo {{ rmw_implementation }})'
-  register: rmw_implementation__dash_case_rmw_implementation
-  changed_when: false
+- name: Validate inputs
+  ansible.builtin.assert:
+    that:
+      - rmw_implementation__rosdistro | length > 0
+      - rmw_implementation__name | length > 0
 
-- name: Hold check of ros-{{ rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout }}
+- name: Build target package name
+  ansible.builtin.set_fact:
+    rmw_implementation__pkg: >-
+      ros-{{ (rmw_implementation__rosdistro | default(rosdistro)) }}-{{ (rmw_implementation__name | default(rmw_implementation)) | replace('_', '-') }}
+
+- name: List held packages
   ansible.builtin.command: apt-mark showhold
-  register: rmw_implementation_held_ros_packages
+  register: rmw_implementation__held_pkgs
   changed_when: false
 
-- name: Install ros-{{ rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout }}
+- name: Install latest (skip if held) {{ rmw_implementation__pkg }}
   become: true
   ansible.builtin.apt:
-    name: ros-{{ rosdistro }}-{{ rmw_implementation__dash_case_rmw_implementation.stdout }}
+    name: "{{ rmw_implementation__pkg }}"
     state: latest
     update_cache: true
-  when: "'ros-' + rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout not in rmw_implementation_held_ros_packages.stdout"
-  register: rmw_implementation_install_result
-  failed_when: false
+    cache_valid_time: 3600
+  when: rmw_implementation__pkg not in (rmw_implementation__held_pkgs.stdout_lines | default([]))
 
-- name: Display warning if ROS 2 RMW package is held
-  ansible.builtin.debug:
-    msg: ROS 2 RMW package 'ros-{{ rosdistro + '-' + rmw_implementation__dash_case_rmw_implementation.stdout }}' is apt-mark hold. Skipping installation.
-  when: not rmw_implementation_install_result.changed
-
-- name: Add RMW_IMPLEMENTATION to .bashrc
-  become: true
+- name: Ensure RMW_IMPLEMENTATION in bashrc files
   ansible.builtin.lineinfile:
-    dest: "{{ item }}"
-    line: export RMW_IMPLEMENTATION={{ rmw_implementation }}
+    path: "{{ item }}"
+    line: export RMW_IMPLEMENTATION={{ rmw_implementation | default(rmw_implementation__name) }}
     state: present
     create: true
     mode: 0644
   loop:
-    - ~/.bashrc
+    - "{{ lookup('env', 'HOME') }}/.bashrc"
     - /etc/skel/.bashrc
+  loop_control:
+    label: "{{ item }}"
+  become: "{{ '/etc/skel' in item }}"


### PR DESCRIPTION
## Summary

- 🐞: The ~/.bashrc modification was being made for root, this PR fixes that.
- 🌀: Inputs were not clear, global `rosdistro=humble` and `rmw_implementation=rmw_cyclonedds_cpp` were being used. Now they are explicit.
- ⏩: Simplified the whole `rmw_implementation__dash_case_rmw_implementation` stuff in general.
- ➕: Added `cache_valid_time: 3600` to prevent unnecessarily updating the cache within 1h.
- ➕: Added a new playbook that only installs this role to test it easily.
  - Can be tested with:
    - `ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"`
    - `ansible-playbook autoware.dev_env.role_rmw_implementation --ask-become-pass -e rosdistro=humble -e rmw_implementation=rmw_cyclonedds_cpp`
  - I didn't add this to readme in this PR just yet, will consider in the future.

This pull request refactors the installation and configuration process for the ROS 2 RMW implementation in the Ansible playbooks and roles. The main improvements include standardizing variable usage, simplifying package name handling, and enhancing input validation and configuration steps.

## Description

**Refactoring and Standardization:**

* Updated all playbooks (`openadkit.yaml`, `universe.yaml`, and the new `role_rmw_implementation.yaml`) to pass `rmw_implementation__rosdistro` and `rmw_implementation__name` variables to the `autoware.dev_env.rmw_implementation` role, ensuring consistent configuration across environments. [[1]](diffhunk://#diff-ce51f6732047e3ba1600bef9eb8c6d5ecd5463024b9a46f1b1bf3615208a5750R23-R25) [[2]](diffhunk://#diff-8f7737975e943a64d1762fb0aa32743f603006d0ed1a36b3583057f49732a757R46-R48) [[3]](diffhunk://#diff-0f373759e6666a72f9c6897532c63cd84a677be965fdea151d8253c764acc9deR1-R7)
* Added default values for `rmw_implementation__rosdistro` and `rmw_implementation__name` in `defaults/main.yaml` to support the new variable structure.

**Task and Package Handling Improvements:**

* Refactored `tasks/main.yaml` to validate input variables, build the package name using the new variables, and install the package only if it is not already held. This replaces the previous dash-case conversion and manual package name construction.
* Updated documentation in `README.md` to use the simplified bash string substitution for package name generation, replacing the previous `sed` command.

**Configuration Enhancements:**

* Improved the logic for setting the `RMW_IMPLEMENTATION` environment variable in bashrc files, ensuring it uses the correct variable and applies changes to both user and skeleton bashrc files with proper permissions.

## How was this PR tested?

Tested locally by hard-assigning `rmw_implementation__pkg` to `gimp` [at Line 9 of the role.](https://github.com/autowarefoundation/autoware/pull/6492/files#diff-7f1c2f900eef049929d3c120f9a451ca00eb98d4ee8903fa9608585d99ea5f94R9-R10)

Then `sudo apt-get install gimp=2.10.30-1build1` to install an older version of gimp.

`sudo apt-mark hold gimp`

`ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"`

`ansible-playbook autoware.dev_env.role_rmw_implementation --ask-become-pass -e rosdistro=humble -e rmw_implementation=rmw_cyclonedds_cpp`

This will skip and not fail fatally. ✅

`sudo apt-mark unhold gimp`

`ansible-playbook autoware.dev_env.role_rmw_implementation --ask-become-pass -e rosdistro=humble -e rmw_implementation=rmw_cyclonedds_cpp` again.

It will upgrade gimp. ✅

## Notes for reviewers

None.

## Effects on system behavior

None.
