### PR TITLE
fix(ci): separate CUDA buildcache tags and add ignore-error to cache push

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -86,7 +86,7 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
         if: always()
@@ -160,7 +160,7 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
         if: always()
@@ -241,9 +241,9 @@ jobs:
             *.args.AUTOWARE_BASE_IMAGE=${{ steps.derive.outputs.autoware_base_image }}
             *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ steps.derive.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-${{ steps.sanitize.outputs.ref_name }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
         if: always()
@@ -359,7 +359,7 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ steps.sanitize.outputs.ref_name }},mode=max
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
           set-latest: false
           suffix: -jazzy
 
@@ -444,7 +444,7 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
           suffix: -jazzy
 
       - name: Show disk space

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -71,6 +71,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware' without CUDA
+        id: build
+        continue-on-error: true
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
@@ -86,6 +88,20 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
+
+      - name: Retry build 'Autoware' without CUDA (without cache)
+        if: ${{ steps.build.outcome == 'failure' }}
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          platform: ${{ matrix.platform }}
+          target-image: autoware
+          build-args: |
+            *.platform=${{ matrix.arch-platform }}
+            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
+            *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
@@ -147,6 +163,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'autoware-tools'
+        id: build-tools
+        continue-on-error: true
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
@@ -160,6 +178,18 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
+
+      - name: Retry build 'autoware-tools' (without cache)
+        if: ${{ steps.build-tools.outcome == 'failure' }}
+        uses: ./.github/actions/docker-build-and-push-tools
+        with:
+          platform: ${{ matrix.platform }}
+          target-image: autoware-tools
+          build-args: |
+            *.platform=${{ matrix.arch-platform }}
+            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
@@ -361,6 +391,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware Jazzy Universe' without CUDA
+        id: build-jazzy
+        continue-on-error: true
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
@@ -376,6 +408,22 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
+          set-latest: false
+          suffix: -jazzy
+
+      - name: Retry build 'Autoware Jazzy Universe' without CUDA (without cache)
+        if: ${{ steps.build-jazzy.outcome == 'failure' }}
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          platform: ${{ matrix.platform }}
+          target-image: autoware
+          build-args: |
+            *.platform=${{ matrix.arch-platform }}
+            *.args.ROS_DISTRO=${{ needs.load-env-jazzy.outputs.rosdistro }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
+            *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
           set-latest: false
           suffix: -jazzy

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -102,7 +102,6 @@ jobs:
             *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
             *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
         if: always()
@@ -190,7 +189,6 @@ jobs:
             *.platform=${{ matrix.arch-platform }}
             *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
         if: always()
@@ -290,7 +288,6 @@ jobs:
             *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
             *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
         if: always()
@@ -424,7 +421,6 @@ jobs:
             *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
             *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
           set-latest: false
           suffix: -jazzy
 
@@ -527,7 +523,6 @@ jobs:
             *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
             *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
           suffix: -jazzy
 
       - name: Show disk space

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -98,9 +98,9 @@ jobs:
           target-image: autoware
           build-args: |
             *.platform=${{ matrix.arch-platform }}
-            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
-            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
+            *.args.ROS_DISTRO=${{ steps.derive.outputs.rosdistro }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ steps.derive.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ steps.derive.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
 
       - name: Show disk space
@@ -187,7 +187,7 @@ jobs:
           target-image: autoware-tools
           build-args: |
             *.platform=${{ matrix.arch-platform }}
-            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            *.args.ROS_DISTRO=${{ steps.derive.outputs.rosdistro }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
 
       - name: Show disk space
@@ -283,10 +283,10 @@ jobs:
           target-image: autoware
           build-args: |
             *.platform=${{ matrix.arch-platform }}
-            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
-            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
-            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
+            *.args.ROS_DISTRO=${{ steps.derive.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ steps.derive.outputs.base_image }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ steps.derive.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ steps.derive.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
 
       - name: Show disk space
@@ -417,9 +417,9 @@ jobs:
           target-image: autoware
           build-args: |
             *.platform=${{ matrix.arch-platform }}
-            *.args.ROS_DISTRO=${{ needs.load-env-jazzy.outputs.rosdistro }}
-            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
-            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
+            *.args.ROS_DISTRO=${{ steps.derive.outputs.rosdistro }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ steps.derive.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ steps.derive.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
           set-latest: false
           suffix: -jazzy
@@ -518,10 +518,10 @@ jobs:
           target-image: autoware
           build-args: |
             *.platform=${{ matrix.arch-platform }}
-            *.args.ROS_DISTRO=${{ needs.load-env-jazzy.outputs.rosdistro }}
-            *.args.BASE_IMAGE=${{ needs.load-env-jazzy.outputs.base_image }}
-            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
-            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
+            *.args.ROS_DISTRO=${{ steps.derive.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ steps.derive.outputs.base_image }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ steps.derive.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ steps.derive.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
           suffix: -jazzy
 

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -227,6 +227,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware' with CUDA
+        id: build-cuda
+        continue-on-error: true
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
@@ -243,6 +245,21 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
+
+      - name: Retry build 'Autoware' with CUDA (without cache)
+        if: ${{ steps.build-cuda.outcome == 'failure' }}
+        uses: ./.github/actions/docker-build-and-push-cuda
+        with:
+          platform: ${{ matrix.platform }}
+          target-image: autoware
+          build-args: |
+            *.platform=${{ matrix.arch-platform }}
+            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
+            *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: Show disk space
@@ -428,6 +445,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware Jazzy Universe' with CUDA
+        id: build-jazzy-cuda
+        continue-on-error: true
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
@@ -444,6 +463,22 @@ jobs:
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ steps.sanitize.outputs.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
+          suffix: -jazzy
+
+      - name: Retry build 'Autoware Jazzy Universe' with CUDA (without cache)
+        if: ${{ steps.build-jazzy-cuda.outcome == 'failure' }}
+        uses: ./.github/actions/docker-build-and-push-cuda
+        with:
+          platform: ${{ matrix.platform }}
+          target-image: autoware
+          build-args: |
+            *.platform=${{ matrix.arch-platform }}
+            *.args.ROS_DISTRO=${{ needs.load-env-jazzy.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ needs.load-env-jazzy.outputs.base_image }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
+            *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ steps.sanitize.outputs.ref_name }},mode=max,ignore-error=true
           suffix: -jazzy
 

--- a/.github/workflows/keep-build-cache-small.yaml
+++ b/.github/workflows/keep-build-cache-small.yaml
@@ -19,6 +19,18 @@ jobs:
             cache_threshold_gb: 7.0
           - image_tag: arm64-main
             cache_threshold_gb: 9.0
+          - image_tag: amd64-cuda-main
+            cache_threshold_gb: 7.0
+          - image_tag: arm64-cuda-main
+            cache_threshold_gb: 9.0
+          - image_tag: amd64-jazzy-main
+            cache_threshold_gb: 7.0
+          - image_tag: arm64-jazzy-main
+            cache_threshold_gb: 9.0
+          - image_tag: amd64-jazzy-cuda-main
+            cache_threshold_gb: 7.0
+          - image_tag: arm64-jazzy-cuda-main
+            cache_threshold_gb: 9.0
 
     env:
       IMAGE_NAME: autoware-buildcache


### PR DESCRIPTION
- **Closes** #6959
- Separate CUDA builds into their own buildcache registry tag (`{platform}-cuda-*`) to prevent concurrent write races with non-CUDA/tools builds
- Add `ignore-error=true` to all `cache-to` lines so cache push failures don't fail the entire build
  - Reference: https://github.com/moby/buildkit/blob/8a412488df124db59682464791d8e3a29de6ecdd/README.md#registry-push-image-and-cache-separately
- Add missing jazzy and CUDA cache tags to [`keep-build-cache-small.yaml`](https://github.com/autowarefoundation/autoware/blob/56bacbf15036920891f7a430f9c89ea8fb16c418/.github/workflows/keep-build-cache-small.yaml)

## Why

The CUDA and non-CUDA humble builds were writing to the same `{platform}-main` buildcache tag concurrently. This corrupted the cache manifest, causing GHCR to return `400 Bad Request` on layer blob uploads. Once corrupted, subsequent builds also failed until the buildcache images were manually deleted. Adding `ignore-error=true` ensures that even transient GHCR issues during cache export never fail the build (since the actual images are already pushed at that point).

---

- The `keep-build-cache-small` workflow was also only monitoring `amd64-main` and `arm64-main`, missing jazzy and CUDA caches entirely.

## Test plan

- [ ] Trigger `docker-build-and-push` workflow manually and verify all jobs pass
  - Test run: https://github.com/autowarefoundation/autoware/actions/runs/23685481890
- [ ] Verify CUDA builds write to `{platform}-cuda-main` cache tags (visible in the `docker buildx bake` logs under `cache-to`)
- [ ] Verify non-CUDA and tools builds still write to `{platform}-main`
- [ ] Trigger `keep-build-cache-small` workflow manually and verify it checks all 8 cache tags (visible in workflow summary)