### PR TITLE
ci(pre-commit-ansible): use ubuntu-latest and update checkout to v6

### DIFF
--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -9,10 +9,10 @@ concurrency:
 
 jobs:
   pre-commit-ansible:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1


### PR DESCRIPTION
- Update runner from `ubuntu-22.04` to `ubuntu-latest`
- Update `actions/checkout` from v4 to v6

## Why

The runner was pinned to an older Ubuntu version. Using `ubuntu-latest` keeps the workflow on a supported runner without manual updates. `actions/checkout` v6 is the latest major version with improvements over v4.

---

## Test plan

- [ ] CI `pre-commit-ansible` job passes on this PR