### PR TITLE
ci(pre-commit-ansible): update runner, actions, and ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 skip_list:
   - galaxy # We don't publish to Ansible Galaxy.
   - package-latest # Since this is a development environment, we allow the latest versions.
+  - complexity # Large task files are acceptable for our setup roles.
 
 warn_list: []

--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -9,10 +9,15 @@ concurrency:
 
 jobs:
   pre-commit-ansible:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
 
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v25.8.2
+    rev: v26.3.0
     hooks:
       - id: ansible-lint
         args:


### PR DESCRIPTION
- Update runner from `ubuntu-22.04` to `ubuntu-latest`, `actions/checkout` from v4 to v6, and `ansible-lint` from v25.8.2 to v26.3.0
- Add `actions/setup-python@v5` with Python 3.14 to fix virtualenv compatibility on `ubuntu-latest`
- Ignore `complexity` rule in [`.ansible-lint`](https://github.com/autowarefoundation/autoware/blob/7404aa9ee0a244cf5344ac4d41269ee13fbeb439/.ansible-lint)

## Why

The `ubuntu-latest` runner ships with Python 3.14 as the system Python, but the pre-installed `virtualenv` (v21.2.0) is too old to create environments for it, causing `pre-commit` to fail. Adding `actions/setup-python` ensures a properly configured Python 3.14 environment. The updated `ansible-lint` v26.3.0 also [requires Python 3.14](https://github.com/ansible/ansible-lint/blob/main/.pre-commit-hooks.yaml) via `language_version: python3.14` in its pre-commit hook config.

The `complexity` rule (new in v26.3.0) flags files with more than 100 tasks. [`ansible/roles/artifacts/tasks/main.yaml`](https://github.com/autowarefoundation/autoware/blob/7404aa9ee0a244cf5344ac4d41269ee13fbeb439/ansible/roles/artifacts/tasks/main.yaml) has 103 tasks and triggers this rule. Splitting the file would add unnecessary churn for marginal benefit, so the rule is skipped.

To run this pre-commit hook locally, Python 3.14 is required:

```bash
sudo add-apt-repository -y ppa:deadsnakes/ppa && sudo apt install -y python3.14
```

This installs Python 3.14 alongside your existing system Python without affecting it.

- Supersedes #6781
- Supersedes #6964

---

## Test plan

- [x] CI `pre-commit-ansible` job passes on this PR
- [x] Local run passes:
  ```bash
  pre-commit run --config .pre-commit-config-ansible.yaml --all-files
  ```