### PR TITLE
chore: update version of nebula to incorporate CIE changes 

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -103,7 +103,7 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: da35f1fcb249d2afc209fff5f843a9e38c7e4f47
+    version: v0.4.0
   sensor_component/external/sync_tooling_msgs:
     type: git
     url: https://github.com/tier4/sync_tooling_msgs.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -103,7 +103,7 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: v0.3.2.2
+    version: da35f1fcb249d2afc209fff5f843a9e38c7e4f47
   sensor_component/external/sync_tooling_msgs:
     type: git
     url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
## Description

Update the dependency version of nebula to `v0.4.0` to incorporate the following CIE (Callback Isolated Executor) application for the nebula nodes:

- https://github.com/tier4/nebula/commit/431f8fe91fc3c3291046eb95f9ca31eff49234a5
- https://github.com/tier4/nebula/commit/da35f1fcb249d2afc209fff5f843a9e38c7e4f47

This changes will be merged to pilot-auto.x2 beta/v4.4.

## How was this PR tested?

- [Evaluator Test based on pilot-auto staging passed](https://evaluation.tier4.jp/evaluation/reports/f6d9d0a5-b832-544e-94b3-bd11e7ed12d7?project_id=autoware_dev)
- [Evaluator Test based on pilot-auto.x2 beta/v4.4 passed](https://evaluation.tier4.jp/evaluation/reports/e4203fb4-5e8c-5e32-bfc9-73cf82974cf5?project_id=x2_dev)