### PR TITLE
chore: update nebula version to v1.1.0 for autoware system designer

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -103,7 +103,7 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: v0.4.0
+    version: v1.1.0
   sensor_component/external/sync_tooling_msgs:
     type: git
     url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
## Description

update the dependency version of nebula to v1.1.0 including driver node descriptions for autoware system designer
https://github.com/tier4/nebula/releases/tag/v1.1.0

## How was this PR tested?

[Evaluator Test based on TIER IV Integration](https://evaluation.ci.tier4.jp/evaluation/reports/f33c1c0b-e4ad-5007-b3f2-58f15bd70210?project_id=prd_jt)