### PR TITLE
feat(docker): add RHEL 9 (AlmaLinux 9) Docker build support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@ docker
 !docker/etc
 !docker/scripts
 !docker/tools
+!docker/rhel-extra-deps.repos
+!docker/boost175_area_strategy_patch.hpp
 
 # Ignore a part of files under src
 src/**/.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@ docker
 !docker/scripts
 !docker/tools
 !docker/rhel-extra-deps.repos
-!docker/boost175_area_strategy_patch.hpp
 
 # Ignore a part of files under src
 src/**/.*

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -1,0 +1,479 @@
+ARG ROS_DISTRO=jazzy
+
+# =============================================================================
+# Stage: base
+# AlmaLinux 9 + ROS 2 Jazzy binary + Autoware system dependencies
+# =============================================================================
+FROM almalinux:9 AS base
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+
+# System setup
+RUN dnf install -y epel-release 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb && \
+    dnf install -y --skip-broken \
+      bzip2 tar wget curl git cmake gcc-c++ make ccache sudo \
+      python3-devel python3-pip python3-colcon-common-extensions \
+      python3-rosdep python3-vcstool python3-empy python3-lark-parser \
+      python3-numpy python3-pytest python3-setuptools \
+      pcl-devel fmt-devel tbb-devel opencv-devel \
+      protobuf-devel protobuf-compiler \
+      json-devel libcap-devel \
+      libuuid-devel libpng-devel libyaml-devel yaml-cpp-devel \
+      eigen3-devel boost-devel assimp-devel \
+      spdlog-devel sqlite-devel tinyxml2-devel libxml2-devel \
+      libcurl-devel openssl-devel CUnit-devel \
+      qt5-qtbase-devel console-bridge-devel orocos-kdl-devel \
+      bullet-devel freetype-devel libX11-devel mesa-libGL-devel libpcap-devel asio-devel \
+      --refresh && \
+    dnf install -y --skip-broken \
+      GeographicLib-devel range-v3-devel octomap-devel expected-devel 2>/dev/null || true && \
+    dnf clean all
+
+# Install ROS 2 Jazzy RHEL9 binary
+RUN cd /tmp && \
+    wget -q https://github.com/ros2/ros2/releases/download/release-jazzy-20260128/ros2-jazzy-20260128-linux-rhel9-amd64.tar.bz2 && \
+    mkdir -p /opt/ros/jazzy && \
+    tar xf ros2-jazzy-20260128-linux-rhel9-amd64.tar.bz2 --strip-components=1 -C /opt/ros/jazzy && \
+    rm -f /tmp/ros2-jazzy-*.tar.bz2
+
+# rosdep init + update
+RUN rosdep init 2>/dev/null || true && rosdep update
+
+# Install rosdep deps for the ROS 2 binary
+RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    rosdep install --from-paths /opt/ros/${ROS_DISTRO}/share --ignore-src -y --skip-keys "rti-connext-dds-6.0.1" 2>&1 || true
+
+# Python deps for generate_parameter_library
+RUN pip3 install jinja2 typeguard 2>/dev/null || true
+
+# colcon mixin
+RUN pip3 install colcon-mixin 2>/dev/null || true && \
+    colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml 2>/dev/null || true && \
+    colcon mixin update default 2>/dev/null || true
+
+# yaml-cpp alias (RHEL 9 yaml-cpp 0.6.3 exports "yaml-cpp", ROS 2 expects "yaml-cpp::yaml-cpp")
+RUN if [ -f /usr/lib64/cmake/yaml-cpp/yaml-cpp-config.cmake ]; then \
+    echo -e '\nif(TARGET yaml-cpp AND NOT TARGET yaml-cpp::yaml-cpp)\n  add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)\nendif()' \
+    >> /usr/lib64/cmake/yaml-cpp/yaml-cpp-config.cmake; fi
+
+# magic_enum (header-only, not in RHEL repos)
+RUN cd /tmp && \
+    wget -q https://github.com/Neargye/magic_enum/archive/refs/tags/v0.9.7.tar.gz && \
+    tar xf v0.9.7.tar.gz && \
+    cp -r magic_enum-0.9.7/include/magic_enum /usr/include/ && \
+    ln -sf /usr/include/magic_enum/magic_enum.hpp /usr/include/magic_enum.hpp && \
+    rm -rf /tmp/v0.9.7.tar.gz /tmp/magic_enum-0.9.7
+
+# png++ (header-only C++ wrapper for libpng, not in RHEL repos)
+RUN cd /tmp && \
+    wget -q https://download.savannah.nongnu.org/releases/pngpp/png++-0.2.10.tar.gz && \
+    tar xf png++-0.2.10.tar.gz && \
+    mkdir -p /usr/include/png++ && \
+    cp png++-0.2.10/*.hpp /usr/include/png++/ && \
+    rm -rf /tmp/png++-0.2.10.tar.gz /tmp/png++-0.2.10
+
+ENV LANG=en_US.UTF-8
+WORKDIR /autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: source-deps
+# Clone extra ROS packages not in the RHEL binary (ros-base only, no desktop)
+# =============================================================================
+FROM base AS source-deps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /autoware
+COPY docker/rhel-extra-deps.repos /autoware/rhel-extra-deps.repos
+RUN mkdir -p src && vcs import --shallow src --retry 3 < rhel-extra-deps.repos 2>&1 || true
+# nav2 repo: only keep nav2_msgs and nav2_common
+RUN find src/nav2_msgs -type f -name 'package.xml' \
+  ! -path '*/nav2_msgs/package.xml' \
+  ! -path '*/nav2_common/package.xml' \
+  -exec sh -c 'touch "$(dirname "$1")"/COLCON_IGNORE' _ {} \; 2>/dev/null || true
+# ros_canopen repo: only keep can_msgs
+RUN find src/ros_canopen -type f -name 'package.xml' \
+  ! -path '*/can_msgs/package.xml' \
+  -exec sh -c 'touch "$(dirname "$1")"/COLCON_IGNORE' _ {} \; 2>/dev/null || true
+# foxglove-sdk repo: only keep foxglove_msgs
+RUN find src/foxglove_sdk -type f -name 'package.xml' \
+  ! -path '*/foxglove_msgs/package.xml' \
+  -exec sh -c 'touch "$(dirname "$1")"/COLCON_IGNORE' _ {} \; 2>/dev/null || true
+# generate_parameter_library: ignore examples (need ros2_control_cmake)
+RUN for d in example example_python example_cmake_python example_external; do \
+    [ -d "src/generate_parameter_library/$d" ] && touch "src/generate_parameter_library/$d/COLCON_IGNORE"; \
+    done 2>/dev/null || true
+# grid_map_costmap_2d: needs nav2_costmap_2d which is COLCON_IGNOREd
+RUN find src/grid_map -name 'grid_map_costmap_2d' -type d \
+  -exec touch {}/COLCON_IGNORE \; 2>/dev/null || true
+# vision_msgs_rviz_plugins: needs rviz which is not on RHEL headless
+RUN find src/vision_msgs -name 'vision_msgs_rviz_plugins' -type d \
+  -exec touch {}/COLCON_IGNORE \; 2>/dev/null || true
+# joystick_drivers: ignore spacenav and wiimote (need system libs not on RHEL)
+RUN for pkg in spacenav wiimote wiimote_msgs; do \
+    find src/joystick_drivers -name "$pkg" -type d -exec touch {}/COLCON_IGNORE \; 2>/dev/null; done || true
+
+# =============================================================================
+# Stage: rosdep-depend
+# =============================================================================
+FROM source-deps AS rosdep-depend
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+
+COPY docker/scripts/resolve_rosdep_keys_rhel.sh /autoware/resolve_rosdep_keys.sh
+RUN chmod +x /autoware/resolve_rosdep_keys.sh
+
+COPY src /autoware/autoware_src
+RUN rm -rf /autoware/autoware_src/universe/external/trt_batched_nms \
+  /autoware/autoware_src/universe/external/cuda_blackboard \
+  /autoware/autoware_src/universe/external/bevdet_vendor \
+  /autoware/autoware_src/universe/external/negotiated
+# Resolve rosdep for both extra deps (src/) and Autoware (autoware_src/)
+RUN rosdep update && \
+    /autoware/resolve_rosdep_keys.sh /autoware/autoware_src "${ROS_DISTRO}" \
+    > /rosdep-all-depend-packages.txt && \
+    /autoware/resolve_rosdep_keys.sh /autoware/src "${ROS_DISTRO}" \
+    >> /rosdep-all-depend-packages.txt && \
+    sort -u -o /rosdep-all-depend-packages.txt /rosdep-all-depend-packages.txt && \
+    cat /rosdep-all-depend-packages.txt
+# Resolve exec-only (runtime) rosdep dependencies
+RUN /autoware/resolve_rosdep_keys.sh /autoware/autoware_src "${ROS_DISTRO}" "--dependency-types=exec" \
+    > /rosdep-exec-depend-packages.txt && \
+    /autoware/resolve_rosdep_keys.sh /autoware/src "${ROS_DISTRO}" "--dependency-types=exec" \
+    >> /rosdep-exec-depend-packages.txt && \
+    sort -u -o /rosdep-exec-depend-packages.txt /rosdep-exec-depend-packages.txt && \
+    echo "=== Runtime (exec) packages ===" && cat /rosdep-exec-depend-packages.txt && \
+    rm -rf /autoware/autoware_src
+
+# =============================================================================
+# Stage: core-common-devel
+# =============================================================================
+FROM base AS core-common-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+COPY docker/scripts/build_and_clean_rhel.sh /autoware/build_and_clean.sh
+RUN chmod +x /autoware/build_and_clean.sh
+
+# Copy extra ROS dependency sources (not in RHEL binary)
+COPY --from=source-deps /autoware/src /autoware/deps_src
+
+# Patch deps_src: M_PIf, CUDA COLCON_IGNORE, duplicates
+RUN grep -rl 'M_PIf' /autoware/deps_src/ --include='*.hpp' --include='*.cpp' 2>/dev/null | \
+    xargs -r sed -i '1i #ifndef M_PIf\n#define M_PIf static_cast<float>(M_PI)\n#endif' 2>/dev/null || true
+RUN for pkg in autoware_cuda_dependency_meta autoware_cuda_utils cuda_blackboard; do \
+    find /autoware/deps_src -name "$pkg" -type d -exec touch {}/COLCON_IGNORE \; 2>/dev/null; done || true
+RUN find /autoware/deps_src -path "*/autoware_agnocast_wrapper/package.xml" \
+    -exec sh -c 'touch $(dirname {})/COLCON_IGNORE' \; 2>/dev/null || true
+
+# Install rosdep system deps
+COPY --from=rosdep-depend /rosdep-all-depend-packages.txt /tmp/rosdep-all-depend-packages.txt
+RUN PKGS=$(cat /tmp/rosdep-all-depend-packages.txt | tr '\n' ' ' | xargs) && \
+    if [ -n "$PKGS" ]; then dnf install -y --skip-broken $PKGS 2>&1 || true; fi && \
+    dnf clean all 2>/dev/null || true
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/core/autoware_adapi_msgs,target=/autoware/src/core/autoware_adapi_msgs \
+  --mount=type=bind,source=src/core/autoware_cmake,target=/autoware/src/core/autoware_cmake \
+  --mount=type=bind,source=src/core/autoware_internal_msgs,target=/autoware/src/core/autoware_internal_msgs \
+  --mount=type=bind,source=src/core/autoware_lanelet2_extension,target=/autoware/src/core/autoware_lanelet2_extension \
+  --mount=type=bind,source=src/core/autoware_msgs,target=/autoware/src/core/autoware_msgs \
+  --mount=type=bind,source=src/core/autoware_utils,target=/autoware/src/core/autoware_utils \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware "" "/autoware/src /autoware/deps_src"
+# Remove deps_src after build so child stages don't rediscover/rebuild them
+RUN rm -rf /autoware/deps_src
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: core-devel
+# =============================================================================
+FROM core-common-devel AS core-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/core/autoware_core,target=/autoware/src/core/autoware_core \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-common-devel
+# =============================================================================
+FROM core-devel AS universe-common-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/universe/autoware_universe/common,target=/autoware/src/universe/autoware_universe/common,rw \
+  --mount=type=bind,source=src/universe/external/eagleye,target=/autoware/src/universe/external/eagleye \
+  --mount=type=bind,source=src/universe/external/glog,target=/autoware/src/universe/external/glog \
+  --mount=type=bind,source=src/universe/external/llh_converter,target=/autoware/src/universe/external/llh_converter \
+  --mount=type=bind,source=src/universe/external/managed_transform_buffer,target=/autoware/src/universe/external/managed_transform_buffer \
+  --mount=type=bind,source=src/universe/external/morai_msgs,target=/autoware/src/universe/external/morai_msgs \
+  --mount=type=bind,source=src/universe/external/muSSP,target=/autoware/src/universe/external/muSSP \
+  --mount=type=bind,source=src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
+  --mount=type=bind,source=src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
+  --mount=type=bind,source=src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
+  --mount=type=bind,source=src/middleware/external,target=/autoware/src/middleware/external \
+  --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-sensing-perception-devel (no CUDA)
+# =============================================================================
+FROM universe-common-devel AS universe-sensing-perception-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/perception,target=/autoware/src/universe/autoware_universe/perception \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing,target=/autoware/src/universe/autoware_universe/sensing \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator,target=/autoware/src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator \
+  --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-localization-mapping-devel
+# =============================================================================
+FROM universe-common-devel AS universe-localization-mapping-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_localization_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_localization_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_map_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_map_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/localization,target=/autoware/src/universe/autoware_universe/localization \
+  --mount=type=bind,source=src/universe/autoware_universe/map,target=/autoware/src/universe/autoware_universe/map \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing/autoware_pcl_extensions,target=/autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor,target=/autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-planning-control-devel
+# =============================================================================
+FROM universe-common-devel AS universe-planning-control-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_control_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_control_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_planning_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_planning_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/control,target=/autoware/src/universe/autoware_universe/control \
+  --mount=type=bind,source=src/universe/autoware_universe/planning,target=/autoware/src/universe/autoware_universe/planning \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_control_evaluator,target=/autoware/src/universe/autoware_universe/evaluator/autoware_control_evaluator \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_planning_evaluator,target=/autoware/src/universe/autoware_universe/evaluator/autoware_planning_evaluator \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing/autoware_pcl_extensions,target=/autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions \
+  --mount=type=bind,source=src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor,target=/autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor \
+  --mount=type=bind,source=src/universe/autoware_universe/vehicle/autoware_external_cmd_converter,target=/autoware/src/universe/autoware_universe/vehicle/autoware_external_cmd_converter \
+  --mount=type=bind,source=src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter,target=/autoware/src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_command_mode_types,target=/autoware/src/universe/autoware_universe/system/autoware_command_mode_types \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-vehicle-system-devel
+# =============================================================================
+FROM universe-common-devel AS universe-vehicle-system-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_vehicle_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_vehicle_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_system_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_system_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/vehicle,target=/autoware/src/universe/autoware_universe/vehicle \
+  --mount=type=bind,source=src/universe/autoware_universe/system,target=/autoware/src/universe/autoware_universe/system \
+  --mount=type=bind,source=src/core/autoware_core/map/autoware_map_height_fitter,target=/autoware/src/core/autoware_core/map/autoware_map_height_fitter \
+  --mount=type=bind,source=src/universe/autoware_universe/localization/autoware_pose2twist,target=/autoware/src/universe/autoware_universe/localization/autoware_pose2twist \
+  --mount=type=bind,source=src/universe/autoware_universe/planning/planning_validator,target=/autoware/src/universe/autoware_universe/planning/planning_validator \
+  --mount=type=bind,source=src/sensor_component/external/sensor_component_description,target=/autoware/src/sensor_component/external/sensor_component_description \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-visualization-devel
+# =============================================================================
+FROM universe-common-devel AS universe-visualization-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/universe/autoware_universe/visualization,target=/autoware/src/universe/autoware_universe/visualization \
+  --mount=type=bind,source=src/core/autoware_rviz_plugins,target=/autoware/src/core/autoware_rviz_plugins \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-api-devel
+# =============================================================================
+FROM universe-common-devel AS universe-api-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_universe,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_evaluation_adapter,target=/autoware/src/universe/autoware_universe/evaluator/autoware_evaluation_adapter \
+  --mount=type=bind,source=src/core/autoware_core/api/autoware_adapi_adaptors,target=/autoware/src/core/autoware_core/api/autoware_adapi_adaptors \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \
+  --mount=type=bind,source=src/core/autoware_core/map/autoware_map_height_fitter,target=/autoware/src/core/autoware_core/map/autoware_map_height_fitter \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe-devel (aggregates all)
+# =============================================================================
+FROM universe-common-devel AS universe-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+COPY --from=universe-sensing-perception-devel /opt/autoware /opt/autoware
+COPY --from=universe-localization-mapping-devel /opt/autoware /opt/autoware
+COPY --from=universe-planning-control-devel /opt/autoware /opt/autoware
+COPY --from=universe-vehicle-system-devel /opt/autoware /opt/autoware
+COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
+COPY --from=universe-api-devel /opt/autoware /opt/autoware
+
+RUN find /opt/autoware -type f \( -executable -o -name "*.so" \) -exec strip --strip-unneeded --remove-section=.comment --remove-section=.note {} \; 2>/dev/null || true
+
+RUN --mount=type=cache,target="${CCACHE_DIR}" \
+  --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component,rw \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/simulator,target=/autoware/src/universe/autoware_universe/simulator \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: runtime-base
+# Minimal AlmaLinux 9 + ROS 2 binary (runtime libraries only, no build tools)
+# =============================================================================
+FROM almalinux:9 AS runtime-base
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO=jazzy
+
+RUN dnf install -y epel-release 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb && \
+    dnf install -y --skip-broken \
+      sudo which python3 python3-pip python3-pyyaml python3-numpy \
+      libatomic lttng-ust \
+      pcl-tools fmt tbb opencv \
+      protobuf \
+      json libuuid libpng libyaml yaml-cpp \
+      boost assimp \
+      spdlog sqlite tinyxml2 libxml2 \
+      libcurl openssl \
+      qt5-qtbase console-bridge orocos-kdl \
+      bullet freetype libX11 mesa-libGL libpcap \
+      GeographicLib octomap \
+      --refresh 2>&1 || true && \
+    dnf clean all
+
+# Copy ROS 2 Jazzy binary from build base
+COPY --from=base /opt/ros /opt/ros
+
+# Python runtime deps for ros2cli and ROS 2 tools
+RUN pip3 install packaging empy lark psutil argcomplete netifaces catkin_pkg 2>/dev/null || true
+
+# Install gosu for entrypoint UID remapping
+RUN curl -fsSL https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64 \
+      -o /usr/sbin/gosu && chmod +x /usr/sbin/gosu
+
+ENV ROS_DISTRO=${ROS_DISTRO}
+ENV LANG=en_US.UTF-8
+WORKDIR /autoware
+
+COPY docker/etc/ros_entrypoint.sh /ros_entrypoint.sh
+RUN chmod +x /ros_entrypoint.sh
+
+# =============================================================================
+# Stage: core (runtime)
+# =============================================================================
+FROM runtime-base AS core
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+
+COPY --from=rosdep-depend /rosdep-exec-depend-packages.txt /tmp/rosdep-exec-depend-packages.txt
+RUN PKGS=$(cat /tmp/rosdep-exec-depend-packages.txt | tr '\n' ' ' | xargs) && \
+    if [ -n "$PKGS" ]; then dnf install -y --skip-broken $PKGS 2>&1 || true; fi && \
+    dnf clean all 2>/dev/null || true && \
+    rm -f /tmp/rosdep-exec-depend-packages.txt
+
+COPY --from=core-devel /opt/autoware /opt/autoware
+
+# Remove broken package entries (build failures left partial share dirs without local_setup.bash)
+# Skip ament_index, colcon-core, and other special directories
+RUN for d in /opt/autoware/share/*/; do \
+      pkg=$(basename "$d"); \
+      case "$pkg" in ament_index|colcon-core) continue;; esac; \
+      [ ! -f "$d/local_setup.bash" ] && rm -rf "$d"; \
+    done 2>/dev/null || true
+
+COPY docker/etc/.bash_aliases /root/.bash_aliases
+RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
+# =============================================================================
+# Stage: universe (runtime)
+# =============================================================================
+FROM runtime-base AS universe
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+
+COPY --from=rosdep-depend /rosdep-exec-depend-packages.txt /tmp/rosdep-exec-depend-packages.txt
+RUN PKGS=$(cat /tmp/rosdep-exec-depend-packages.txt | tr '\n' ' ' | xargs) && \
+    if [ -n "$PKGS" ]; then dnf install -y --skip-broken $PKGS 2>&1 || true; fi && \
+    dnf clean all 2>/dev/null || true && \
+    rm -f /tmp/rosdep-exec-depend-packages.txt
+
+COPY --from=universe-devel /opt/autoware /opt/autoware
+
+# Remove broken package entries (build failures left partial share dirs without local_setup.bash)
+# Skip ament_index, colcon-core, and other special directories
+RUN for d in /opt/autoware/share/*/; do \
+      pkg=$(basename "$d"); \
+      case "$pkg" in ament_index|colcon-core) continue;; esac; \
+      [ ! -f "$d/local_setup.bash" ] && rm -rf "$d"; \
+    done 2>/dev/null || true
+
+COPY docker/etc/.bash_aliases /root/.bash_aliases
+RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/docker/README-rhel.md
+++ b/docker/README-rhel.md
@@ -1,0 +1,223 @@
+# Autoware on RHEL 9 (AlmaLinux 9): containerized build
+
+This document describes how to build Autoware container images on AlmaLinux 9 (RHEL 9 compatible) using `docker/Dockerfile.rhel`.
+
+## Key differences from Ubuntu build
+
+| Aspect | Ubuntu (`Dockerfile`) | RHEL (`Dockerfile.rhel`) |
+|--------|----------------------|--------------------------|
+| Base image | Pre-built `$AUTOWARE_BASE_IMAGE` | `almalinux:9` (from scratch) |
+| Package manager | apt-get | dnf |
+| ROS 2 installation | Inherited from base image | RHEL 9 binary tarball downloaded in `base` stage |
+| System setup | `setup-dev-env.sh` (Ansible) | Direct `dnf install` |
+| CUDA | Supported (devel-cuda / cuda stages) | Not supported (COLCON_IGNOREd) |
+| Extra ROS packages | Inherited from base image | `rhel-extra-deps.repos` (37 repos built from source) |
+
+## Prerequisites
+
+- Docker with BuildKit enabled
+- Autoware source cloned with `vcs import`:
+
+```bash
+git clone https://github.com/autowarefoundation/autoware.git
+cd autoware
+mkdir src
+vcs import src < autoware.repos
+```
+
+## Quick start
+
+### Build development image (all packages + build tools)
+
+```bash
+cd /path/to/autoware
+docker build \
+  --progress=plain \
+  --build-arg ROS_DISTRO=jazzy \
+  --target universe-devel \
+  -t autoware-rhel-universe-devel:latest \
+  -f docker/Dockerfile.rhel \
+  .
+```
+
+### Build runtime image (binaries only, no build tools)
+
+```bash
+docker build \
+  --progress=plain \
+  --build-arg ROS_DISTRO=jazzy \
+  --target universe \
+  -t autoware-rhel-universe:latest \
+  -f docker/Dockerfile.rhel \
+  .
+```
+
+### Run the container
+
+```bash
+# Runtime image
+docker run -it --rm autoware-rhel-universe:latest
+
+# Development image with volume mount
+docker run -it --rm \
+  -v $PWD/src/universe/autoware_universe/planning/autoware_path_optimizer:/autoware/src/autoware_path_optimizer \
+  autoware-rhel-universe-devel:latest
+
+# Runtime image with UID/GID remapping
+docker run -it --rm \
+  -e LOCAL_UID=$(id -u) -e LOCAL_USER=$(whoami) \
+  -e LOCAL_GID=$(id -g) -e LOCAL_GROUP=$(id -gn) \
+  -v /path/to/autoware_data:/autoware_data \
+  autoware-rhel-universe:latest
+```
+
+## Build targets
+
+| Target | Type | Size | Description |
+|--------|------|------|-------------|
+| `universe-devel` | Development | ~13.7 GB | All build tools, headers, source, and compiled artifacts |
+| `universe` | Runtime | ~7 GB | Runtime libraries and binaries only |
+| `core-devel` | Development | — | Core packages only (autoware_msgs, autoware_utils, autoware_core) |
+| `core` | Runtime | — | Runtime image for core packages only |
+| `universe-common-devel` | Development | — | Core + common/external/middleware packages |
+
+Specify the target with `--target`:
+
+```bash
+docker build --target core-devel -t autoware-rhel-core-devel -f docker/Dockerfile.rhel .
+```
+
+## Multi-stage Dockerfile structure
+
+```
+[base] almalinux:9 + ROS 2 Jazzy binary + dnf deps
+  │
+  ├─[source-deps] clone rhel-extra-deps.repos (37 ROS packages)
+  │   │
+  │   └─[rosdep-depend] resolve system deps for Autoware + extra deps
+  │       ├─ /rosdep-all-depend-packages.txt (build + runtime)
+  │       └─ /rosdep-exec-depend-packages.txt (runtime only)
+  │
+  ├─[core-common-devel] autoware_msgs, autoware_utils + deps_src
+  │   │
+  │   └─[core-devel] autoware_core packages
+  │       │
+  │       └─[universe-common-devel] external, common, middleware, launcher
+  │           │
+  │           ├─[universe-sensing-perception-devel]  ─┐
+  │           ├─[universe-localization-mapping-devel]  │ BuildKit runs
+  │           ├─[universe-planning-control-devel]      │ these 6 stages
+  │           ├─[universe-vehicle-system-devel]        │ in parallel
+  │           ├─[universe-visualization-devel]         │
+  │           └─[universe-api-devel]                 ─┘
+  │               │
+  │               └─[universe-devel] COPY --from all 6 + strip + final build
+  │
+  └─[runtime-base] almalinux:9 + runtime libs only (no build tools)
+      │
+      ├─[core] COPY from core-devel + exec rosdep deps
+      └─[universe] COPY from universe-devel + exec rosdep deps
+```
+
+### Stage descriptions
+
+#### `base`
+
+AlmaLinux 9 with EPEL and CRB repositories enabled. Installs system development libraries via `dnf`, downloads the [ROS 2 Jazzy RHEL 9 binary](https://github.com/ros2/ros2/releases) to `/opt/ros/jazzy/`, and applies RHEL-specific fixes (yaml-cpp CMake alias, magic\_enum and png++ header-only libraries).
+
+#### `source-deps`
+
+Clones 37 ROS 2 packages from `rhel-extra-deps.repos` that are not included in the RHEL binary (which is ros-base equivalent, 371 packages). Selectively applies COLCON\_IGNORE to sub-packages that cannot build on RHEL (e.g., rviz plugins, spacenav, wiimote).
+
+#### `rosdep-depend`
+
+Resolves rosdep keys to RHEL 9 system package names using `resolve_rosdep_keys_rhel.sh`. Generates two package lists: all dependencies (for devel stages) and exec-only dependencies (for runtime stages).
+
+#### `core-common-devel`
+
+Installs rosdep system packages via `dnf`. Copies extra dependency sources to `/autoware/deps_src/`. Applies runtime patches (M\_PIf, CUDA COLCON\_IGNORE, agnocast dedup). Builds core framework packages (autoware\_msgs, autoware\_utils, and all deps\_src) to `/opt/autoware/`.
+
+#### `core-devel`
+
+Builds `autoware_core` packages on top of `core-common-devel`.
+
+#### `universe-common-devel`
+
+Builds common, external, middleware, and launcher packages.
+
+#### `universe-{component}-devel`
+
+Six parallel stages that each build a specific subsystem: sensing/perception, localization/mapping, planning/control, vehicle/system, visualization, and API.
+
+#### `universe-devel`
+
+Aggregates all six parallel stages via `COPY --from`, strips debug symbols from binaries, and runs a final build pass for remaining packages (evaluator, simulator, sensor\_component).
+
+#### `runtime-base`
+
+Minimal AlmaLinux 9 image with only runtime libraries (no compilers, no `-devel` headers). Copies `/opt/ros/` from the `base` stage. Installs gosu for UID/GID remapping and Python runtime dependencies for `ros2` CLI.
+
+#### `core` / `universe`
+
+Runtime images that copy `/opt/autoware/` from corresponding devel stages and install exec-only rosdep dependencies. Broken ament\_index entries (from packages that failed to build) are automatically cleaned up.
+
+## RHEL-specific adaptations
+
+### ROS 2 Jazzy RHEL binary
+
+The official RHEL 9 binary provides ros-base equivalent (371 packages). Packages like `diagnostic_updater`, `geographic_msgs`, `pcl_ros`, `lanelet2_core`, `grid_map`, `filters`, etc. are not included and must be built from source via `rhel-extra-deps.repos`.
+
+### Build script patches (`build_and_clean_rhel.sh`)
+
+The build script applies runtime patches before each colcon build to handle RHEL 9 incompatibilities:
+
+| Patch | Reason |
+|-------|--------|
+| `M_PIf` / `M_PI_2f` / `M_PI_4f` guards | GCC 11 on RHEL 9 does not define C23 math float constants |
+| CUDA packages COLCON\_IGNORE | 30 CUDA-dependent packages excluded (no CUDA toolkit) |
+| `tl/expected.hpp` warning suppression | Deprecation `#warning` becomes error with `-Werror=cpp` |
+| Boost 1.75 `strategies/cartesian.hpp` include | `correct.hpp` and `is_valid.hpp` missing strategy includes |
+| `boost::geometry::is_valid()` bypass | Fails on custom Eigen-based Point2d with Boost < 1.77 |
+
+The build uses a **three-pass retry strategy**: if packages fail, their `build/` directories are deleted and colcon retries on the next pass. This handles dependency ordering issues.
+
+### Rosdep resolution (`resolve_rosdep_keys_rhel.sh`)
+
+Uses `--os=rhel:9` to resolve against RHEL packages instead of Ubuntu defaults. Filters out `ros-jazzy-*` package names (no RPM repository for ROS on RHEL).
+
+### yaml-cpp CMake alias
+
+RHEL 9 ships yaml-cpp 0.6.3 which exports the CMake target `yaml-cpp`, but ROS 2 expects `yaml-cpp::yaml-cpp`. The `base` stage appends an alias to the CMake config file.
+
+## Known limitations
+
+- **No CUDA support**: All TensorRT/CUDA packages are excluded via COLCON\_IGNORE. Perception nodes that require GPU inference will not be available.
+- **Boost 1.75 constraints**: `boost::geometry::is_valid()` is bypassed with a simpler polygon size check for custom Point types. This may affect geometric validation accuracy in edge cases.
+- **Build failures**: A small number of packages may fail to build (e.g., `autoware_control_evaluator` due to missing `boundary_departure_checker` header). These are automatically excluded from runtime images.
+- **No setup-dev-env.sh**: The Ubuntu Ansible-based environment setup is replaced with direct `dnf install`. Some development tools available in the Ubuntu image may be missing.
+
+## UID/GID remapping
+
+The runtime images use `ros_entrypoint.sh` with gosu for UID/GID remapping. Set the following environment variables to run as a non-root user:
+
+```bash
+docker run -it --rm \
+  -e LOCAL_UID=1000 -e LOCAL_USER=developer \
+  -e LOCAL_GID=1000 -e LOCAL_GROUP=developers \
+  -v /path/to/autoware_data:/autoware_data \
+  autoware-rhel-universe:latest
+```
+
+If these variables are not set, the container runs as root.
+
+## Files reference
+
+| File | Description |
+|------|-------------|
+| `docker/Dockerfile.rhel` | Multi-stage Dockerfile (16 stages) for RHEL 9 build |
+| `docker/rhel-extra-deps.repos` | VCS manifest of 37 ROS packages not in RHEL binary |
+| `docker/scripts/build_and_clean_rhel.sh` | Colcon build orchestration with RHEL patches and 3-pass retry |
+| `docker/scripts/resolve_rosdep_keys_rhel.sh` | Rosdep resolution with `--os=rhel:9` and `ros-*` filtering |
+| `docker/scripts/cleanup_dnf.sh` | DNF cache cleanup |
+| `docker/etc/ros_entrypoint.sh` | Container entrypoint with UID/GID remapping via gosu |
+| `.dockerignore` | Build context filter (includes `!docker/rhel-extra-deps.repos`) |

--- a/docker/README-rhel.md
+++ b/docker/README-rhel.md
@@ -10,7 +10,7 @@ This document describes how to build Autoware container images on AlmaLinux 9 (R
 | Package manager    | apt-get                              | dnf                                                  |
 | ROS 2 installation | Inherited from base image            | RHEL 9 binary tarball downloaded in `base` stage     |
 | System setup       | `setup-dev-env.sh` (Ansible)         | Direct `dnf install`                                 |
-| CUDA               | Supported (devel-cuda / cuda stages) | Not supported (COLCON_IGNOREd)                       |
+| CUDA               | Supported (devel-cuda / cuda stages) | Not supported (COLCON_IGNORE)                       |
 | Extra ROS packages | Inherited from base image            | `rhel-extra-deps.repos` (37 repos built from source) |
 
 ## Prerequisites

--- a/docker/README-rhel.md
+++ b/docker/README-rhel.md
@@ -10,7 +10,7 @@ This document describes how to build Autoware container images on AlmaLinux 9 (R
 | Package manager    | apt-get                              | dnf                                                  |
 | ROS 2 installation | Inherited from base image            | RHEL 9 binary tarball downloaded in `base` stage     |
 | System setup       | `setup-dev-env.sh` (Ansible)         | Direct `dnf install`                                 |
-| CUDA               | Supported (devel-cuda / cuda stages) | Not supported (COLCON_IGNORE)                       |
+| CUDA               | Supported (devel-cuda / cuda stages) | Not supported (COLCON_IGNORE)                        |
 | Extra ROS packages | Inherited from base image            | `rhel-extra-deps.repos` (37 repos built from source) |
 
 ## Prerequisites

--- a/docker/README-rhel.md
+++ b/docker/README-rhel.md
@@ -4,14 +4,14 @@ This document describes how to build Autoware container images on AlmaLinux 9 (R
 
 ## Key differences from Ubuntu build
 
-| Aspect | Ubuntu (`Dockerfile`) | RHEL (`Dockerfile.rhel`) |
-|--------|----------------------|--------------------------|
-| Base image | Pre-built `$AUTOWARE_BASE_IMAGE` | `almalinux:9` (from scratch) |
-| Package manager | apt-get | dnf |
-| ROS 2 installation | Inherited from base image | RHEL 9 binary tarball downloaded in `base` stage |
-| System setup | `setup-dev-env.sh` (Ansible) | Direct `dnf install` |
-| CUDA | Supported (devel-cuda / cuda stages) | Not supported (COLCON_IGNOREd) |
-| Extra ROS packages | Inherited from base image | `rhel-extra-deps.repos` (37 repos built from source) |
+| Aspect             | Ubuntu (`Dockerfile`)                | RHEL (`Dockerfile.rhel`)                             |
+| ------------------ | ------------------------------------ | ---------------------------------------------------- |
+| Base image         | Pre-built `$AUTOWARE_BASE_IMAGE`     | `almalinux:9` (from scratch)                         |
+| Package manager    | apt-get                              | dnf                                                  |
+| ROS 2 installation | Inherited from base image            | RHEL 9 binary tarball downloaded in `base` stage     |
+| System setup       | `setup-dev-env.sh` (Ansible)         | Direct `dnf install`                                 |
+| CUDA               | Supported (devel-cuda / cuda stages) | Not supported (COLCON_IGNOREd)                       |
+| Extra ROS packages | Inherited from base image            | `rhel-extra-deps.repos` (37 repos built from source) |
 
 ## Prerequisites
 
@@ -73,13 +73,13 @@ docker run -it --rm \
 
 ## Build targets
 
-| Target | Type | Size | Description |
-|--------|------|------|-------------|
-| `universe-devel` | Development | ~13.7 GB | All build tools, headers, source, and compiled artifacts |
-| `universe` | Runtime | ~7 GB | Runtime libraries and binaries only |
-| `core-devel` | Development | — | Core packages only (autoware_msgs, autoware_utils, autoware_core) |
-| `core` | Runtime | — | Runtime image for core packages only |
-| `universe-common-devel` | Development | — | Core + common/external/middleware packages |
+| Target                  | Type        | Size     | Description                                                       |
+| ----------------------- | ----------- | -------- | ----------------------------------------------------------------- |
+| `universe-devel`        | Development | ~13.7 GB | All build tools, headers, source, and compiled artifacts          |
+| `universe`              | Runtime     | ~7 GB    | Runtime libraries and binaries only                               |
+| `core-devel`            | Development | —        | Core packages only (autoware_msgs, autoware_utils, autoware_core) |
+| `core`                  | Runtime     | —        | Runtime image for core packages only                              |
+| `universe-common-devel` | Development | —        | Core + common/external/middleware packages                        |
 
 Specify the target with `--target`:
 
@@ -123,11 +123,11 @@ docker build --target core-devel -t autoware-rhel-core-devel -f docker/Dockerfil
 
 #### `base`
 
-AlmaLinux 9 with EPEL and CRB repositories enabled. Installs system development libraries via `dnf`, downloads the [ROS 2 Jazzy RHEL 9 binary](https://github.com/ros2/ros2/releases) to `/opt/ros/jazzy/`, and applies RHEL-specific fixes (yaml-cpp CMake alias, magic\_enum and png++ header-only libraries).
+AlmaLinux 9 with EPEL and CRB repositories enabled. Installs system development libraries via `dnf`, downloads the [ROS 2 Jazzy RHEL 9 binary](https://github.com/ros2/ros2/releases) to `/opt/ros/jazzy/`, and applies RHEL-specific fixes (yaml-cpp CMake alias, magic_enum and png++ header-only libraries).
 
 #### `source-deps`
 
-Clones 37 ROS 2 packages from `rhel-extra-deps.repos` that are not included in the RHEL binary (which is ros-base equivalent, 371 packages). Selectively applies COLCON\_IGNORE to sub-packages that cannot build on RHEL (e.g., rviz plugins, spacenav, wiimote).
+Clones 37 ROS 2 packages from `rhel-extra-deps.repos` that are not included in the RHEL binary (which is ros-base equivalent, 371 packages). Selectively applies COLCON_IGNORE to sub-packages that cannot build on RHEL (e.g., rviz plugins, spacenav, wiimote).
 
 #### `rosdep-depend`
 
@@ -135,7 +135,7 @@ Resolves rosdep keys to RHEL 9 system package names using `resolve_rosdep_keys_r
 
 #### `core-common-devel`
 
-Installs rosdep system packages via `dnf`. Copies extra dependency sources to `/autoware/deps_src/`. Applies runtime patches (M\_PIf, CUDA COLCON\_IGNORE, agnocast dedup). Builds core framework packages (autoware\_msgs, autoware\_utils, and all deps\_src) to `/opt/autoware/`.
+Installs rosdep system packages via `dnf`. Copies extra dependency sources to `/autoware/deps_src/`. Applies runtime patches (M_PIf, CUDA COLCON_IGNORE, agnocast dedup). Builds core framework packages (autoware_msgs, autoware_utils, and all deps_src) to `/opt/autoware/`.
 
 #### `core-devel`
 
@@ -151,7 +151,7 @@ Six parallel stages that each build a specific subsystem: sensing/perception, lo
 
 #### `universe-devel`
 
-Aggregates all six parallel stages via `COPY --from`, strips debug symbols from binaries, and runs a final build pass for remaining packages (evaluator, simulator, sensor\_component).
+Aggregates all six parallel stages via `COPY --from`, strips debug symbols from binaries, and runs a final build pass for remaining packages (evaluator, simulator, sensor_component).
 
 #### `runtime-base`
 
@@ -159,7 +159,7 @@ Minimal AlmaLinux 9 image with only runtime libraries (no compilers, no `-devel`
 
 #### `core` / `universe`
 
-Runtime images that copy `/opt/autoware/` from corresponding devel stages and install exec-only rosdep dependencies. Broken ament\_index entries (from packages that failed to build) are automatically cleaned up.
+Runtime images that copy `/opt/autoware/` from corresponding devel stages and install exec-only rosdep dependencies. Broken ament_index entries (from packages that failed to build) are automatically cleaned up.
 
 ## RHEL-specific adaptations
 
@@ -171,13 +171,13 @@ The official RHEL 9 binary provides ros-base equivalent (371 packages). Packages
 
 The build script applies runtime patches before each colcon build to handle RHEL 9 incompatibilities:
 
-| Patch | Reason |
-|-------|--------|
-| `M_PIf` / `M_PI_2f` / `M_PI_4f` guards | GCC 11 on RHEL 9 does not define C23 math float constants |
-| CUDA packages COLCON\_IGNORE | 30 CUDA-dependent packages excluded (no CUDA toolkit) |
-| `tl/expected.hpp` warning suppression | Deprecation `#warning` becomes error with `-Werror=cpp` |
+| Patch                                         | Reason                                                     |
+| --------------------------------------------- | ---------------------------------------------------------- |
+| `M_PIf` / `M_PI_2f` / `M_PI_4f` guards        | GCC 11 on RHEL 9 does not define C23 math float constants  |
+| CUDA packages COLCON_IGNORE                   | 30 CUDA-dependent packages excluded (no CUDA toolkit)      |
+| `tl/expected.hpp` warning suppression         | Deprecation `#warning` becomes error with `-Werror=cpp`    |
 | Boost 1.75 `strategies/cartesian.hpp` include | `correct.hpp` and `is_valid.hpp` missing strategy includes |
-| `boost::geometry::is_valid()` bypass | Fails on custom Eigen-based Point2d with Boost < 1.77 |
+| `boost::geometry::is_valid()` bypass          | Fails on custom Eigen-based Point2d with Boost < 1.77      |
 
 The build uses a **three-pass retry strategy**: if packages fail, their `build/` directories are deleted and colcon retries on the next pass. This handles dependency ordering issues.
 
@@ -191,7 +191,7 @@ RHEL 9 ships yaml-cpp 0.6.3 which exports the CMake target `yaml-cpp`, but ROS 2
 
 ## Known limitations
 
-- **No CUDA support**: All TensorRT/CUDA packages are excluded via COLCON\_IGNORE. Perception nodes that require GPU inference will not be available.
+- **No CUDA support**: All TensorRT/CUDA packages are excluded via COLCON_IGNORE. Perception nodes that require GPU inference will not be available.
 - **Boost 1.75 constraints**: `boost::geometry::is_valid()` is bypassed with a simpler polygon size check for custom Point types. This may affect geometric validation accuracy in edge cases.
 - **Build failures**: A small number of packages may fail to build (e.g., `autoware_control_evaluator` due to missing `boundary_departure_checker` header). These are automatically excluded from runtime images.
 - **No setup-dev-env.sh**: The Ubuntu Ansible-based environment setup is replaced with direct `dnf install`. Some development tools available in the Ubuntu image may be missing.
@@ -212,12 +212,12 @@ If these variables are not set, the container runs as root.
 
 ## Files reference
 
-| File | Description |
-|------|-------------|
-| `docker/Dockerfile.rhel` | Multi-stage Dockerfile (16 stages) for RHEL 9 build |
-| `docker/rhel-extra-deps.repos` | VCS manifest of 37 ROS packages not in RHEL binary |
-| `docker/scripts/build_and_clean_rhel.sh` | Colcon build orchestration with RHEL patches and 3-pass retry |
-| `docker/scripts/resolve_rosdep_keys_rhel.sh` | Rosdep resolution with `--os=rhel:9` and `ros-*` filtering |
-| `docker/scripts/cleanup_dnf.sh` | DNF cache cleanup |
-| `docker/etc/ros_entrypoint.sh` | Container entrypoint with UID/GID remapping via gosu |
-| `.dockerignore` | Build context filter (includes `!docker/rhel-extra-deps.repos`) |
+| File                                         | Description                                                     |
+| -------------------------------------------- | --------------------------------------------------------------- |
+| `docker/Dockerfile.rhel`                     | Multi-stage Dockerfile (16 stages) for RHEL 9 build             |
+| `docker/rhel-extra-deps.repos`               | VCS manifest of 37 ROS packages not in RHEL binary              |
+| `docker/scripts/build_and_clean_rhel.sh`     | Colcon build orchestration with RHEL patches and 3-pass retry   |
+| `docker/scripts/resolve_rosdep_keys_rhel.sh` | Rosdep resolution with `--os=rhel:9` and `ros-*` filtering      |
+| `docker/scripts/cleanup_dnf.sh`              | DNF cache cleanup                                               |
+| `docker/etc/ros_entrypoint.sh`               | Container entrypoint with UID/GID remapping via gosu            |
+| `.dockerignore`                              | Build context filter (includes `!docker/rhel-extra-deps.repos`) |

--- a/docker/rhel-extra-deps.repos
+++ b/docker/rhel-extra-deps.repos
@@ -1,0 +1,154 @@
+repositories:
+  geographic_info:
+    type: git
+    url: https://github.com/ros-geographic-info/geographic_info.git
+    version: ros2
+  perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl.git
+    version: jazzy
+  pcl_msgs:
+    type: git
+    url: https://github.com/ros-perception/pcl_msgs.git
+    version: ros2
+  vision_opencv:
+    type: git
+    url: https://github.com/ros-perception/vision_opencv.git
+    version: rolling
+  image_common:
+    type: git
+    url: https://github.com/ros-perception/image_common.git
+    version: jazzy
+  diagnostics:
+    type: git
+    url: https://github.com/ros/diagnostics.git
+    version: ros2
+  bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: ros2
+  laser_geometry:
+    type: git
+    url: https://github.com/ros-perception/laser_geometry.git
+    version: ros2
+  grid_map:
+    type: git
+    url: https://github.com/ANYbotics/grid_map.git
+    version: jazzy
+  Lanelet2:
+    type: git
+    url: https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git
+    version: master
+  mrt_cmake_modules:
+    type: git
+    url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+    version: master
+  osqp_vendor:
+    type: git
+    url: https://github.com/tier4/osqp_vendor.git
+    version: main
+  topic_tools:
+    type: git
+    url: https://github.com/ros-tooling/topic_tools.git
+    version: main
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
+  filters:
+    type: git
+    url: https://github.com/ros/filters.git
+    version: ros2
+  octomap_msgs:
+    type: git
+    url: https://github.com/OctoMap/octomap_msgs.git
+    version: ros2
+  radar_msgs:
+    type: git
+    url: https://github.com/ros-perception/radar_msgs.git
+    version: ros2
+  vision_msgs:
+    type: git
+    url: https://github.com/ros-perception/vision_msgs.git
+    version: ros2
+  ros_canopen:
+    type: git
+    url: https://github.com/ros-industrial/ros_canopen.git
+    version: dashing-devel
+  foxglove_sdk:
+    type: git
+    url: https://github.com/foxglove/foxglove-sdk.git
+    version: main
+  udp_msgs:
+    type: git
+    url: https://github.com/flynneva/udp_msgs.git
+    version: main
+  xacro:
+    type: git
+    url: https://github.com/ros/xacro.git
+    version: ros2
+  joystick_drivers:
+    type: git
+    url: https://github.com/ros-drivers/joystick_drivers.git
+    version: ros2
+  tf_transformations:
+    type: git
+    url: https://github.com/DLu/tf_transformations.git
+    version: main
+  cpp_polyfills:
+    type: git
+    url: https://github.com/PickNikRobotics/cpp_polyfills.git
+    version: main
+  RSL:
+    type: git
+    url: https://github.com/PickNikRobotics/RSL.git
+    version: main
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version: humble
+  rviz_2d_overlay_plugins:
+    type: git
+    url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+    version: main
+  ublox:
+    type: git
+    url: https://github.com/KumarRobotics/ublox.git
+    version: ros2
+  rtcm_msgs:
+    type: git
+    url: https://github.com/tilk/rtcm_msgs.git
+    version: master
+  nmea_msgs:
+    type: git
+    url: https://github.com/ros-drivers/nmea_msgs.git
+    version: ros2
+  velodyne:
+    type: git
+    url: https://github.com/ros-drivers/velodyne.git
+    version: jazzy-devel
+  ackermann_msgs:
+    type: git
+    url: https://github.com/ros-drivers/ackermann_msgs.git
+    version: ros2
+  nav2_msgs:
+    type: git
+    url: https://github.com/ros-navigation/navigation2.git
+    version: jazzy
+  point_cloud_transport:
+    type: git
+    url: https://github.com/ros-perception/point_cloud_transport.git
+    version: jazzy
+  proxsuite:
+    type: git
+    url: https://github.com/Simple-Robotics/proxsuite.git
+    version: devel
+  point_cloud_msg_wrapper:
+    type: git
+    url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper.git
+    version: rolling
+  behaviortree_cpp:
+    type: git
+    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+    version: v3.8
+# Cache-bust: 1775602888

--- a/docker/scripts/build_and_clean_rhel.sh
+++ b/docker/scripts/build_and_clean_rhel.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -eo pipefail
+
+function build_and_clean() {
+    local ccache_dir=$1
+    local install_base=$2
+    local colcon_build_args=$3
+    # Base paths for colcon package discovery (default: /autoware/src only)
+    local base_paths="${4:-/autoware/src}"
+
+    local taskset_cmd=""
+    local num_cores
+    num_cores=$(nproc)
+    if [ "$num_cores" -gt 1 ]; then
+        taskset_cmd="taskset --cpu-list 0-$((num_cores - 2))"
+    fi
+
+    # Runtime patches (best-effort, don't fail the build)
+    set +e
+
+    # M_PIf/M_PI_2f/M_PI_4f: C23 constants not available in GCC 11 (RHEL 9)
+    grep -rl 'M_PIf\b' /autoware/src/ --include='*.hpp' --include='*.cpp' 2>/dev/null | \
+        while read -r f; do
+            if ! grep -q 'ifndef M_PIf' "$f" 2>/dev/null; then
+                sed -i '1i #ifndef M_PIf\n#define M_PIf static_cast<float>(M_PI)\n#endif\n#ifndef M_PI_2f\n#define M_PI_2f static_cast<float>(M_PI_2)\n#endif\n#ifndef M_PI_4f\n#define M_PI_4f static_cast<float>(M_PI_4)\n#endif' "$f" 2>/dev/null
+            fi
+        done
+
+    # COLCON_IGNORE CUDA packages in bind-mounted source
+    for pkg in autoware_cuda_dependency_meta autoware_cuda_utils autoware_cuda_pointcloud_preprocessor \
+      autoware_tensorrt_common autoware_tensorrt_plugins autoware_tensorrt_yolox autoware_tensorrt_classifier \
+      autoware_tensorrt_bevdet autoware_tensorrt_bevformer autoware_tensorrt_vad \
+      autoware_lidar_centerpoint autoware_lidar_transfusion autoware_lidar_frnet \
+      autoware_lidar_apollo_instance_segmentation autoware_bevfusion autoware_bytetrack \
+      autoware_camera_streampetr autoware_ptv3 autoware_simpl_prediction \
+      autoware_image_projection_based_fusion autoware_traffic_light_classifier \
+      autoware_traffic_light_fine_detector autoware_ground_segmentation_cuda \
+      autoware_probabilistic_occupancy_grid_map autoware_calibration_status_classifier \
+      autoware_diffusion_planner autoware_shape_estimation \
+      bevdet_vendor trt_batched_nms cuda_blackboard; do
+        find /autoware/src -name "$pkg" -type d -exec touch {}/COLCON_IGNORE \; 2>/dev/null
+    done
+    # Duplicate autoware_agnocast_wrapper fix
+    touch /autoware/src/universe/autoware_universe/common/autoware_agnocast_wrapper/COLCON_IGNORE 2>/dev/null
+
+    # Suppress tl_expected deprecation warning (system tl/expected.hpp exists, but
+    # the #warning fires before the redirect and -Werror=cpp turns it into an error)
+    local tl_hdr="/opt/autoware/include/tl_expected/expected.hpp"
+    if [ -f "$tl_hdr" ] && grep -q '#warning' "$tl_hdr"; then
+        sed -i '/#warning/,/NOLINT/d; /#pragma message/,/NOLINT/d' "$tl_hdr" 2>/dev/null
+    fi
+
+    # Boost 1.75 compat: algorithms/correct.hpp and algorithms/is_valid.hpp
+    # don't include strategies/cartesian.hpp, causing missing strategy_converter
+    # and default_strategy errors for custom Point types (Eigen-based Point2d).
+    # Patch these headers to include the full cartesian strategy set.
+    for bhpp in \
+      /usr/include/boost/geometry/algorithms/correct.hpp \
+      /usr/include/boost/geometry/algorithms/is_valid.hpp \
+      /usr/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp; do
+        if [ -f "$bhpp" ] && ! grep -q 'strategies/cartesian.hpp' "$bhpp"; then
+            sed -i '1i #include <boost/geometry/strategies/cartesian.hpp>  // RHEL Boost 1.75 compat' "$bhpp" 2>/dev/null
+        fi
+    done
+
+    # Patch: boost::geometry::is_valid() fails on Boost < 1.77 with Eigen-based Point2d
+    # Replace with a simpler polygon size check on older Boost
+    for rcpf in \
+      /autoware/src/core/autoware_utils/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp \
+      /autoware/src/universe/autoware_universe/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp; do
+        if [ -f "$rcpf" ]; then
+            sed -i 's|!is_convex(poly) && boost::geometry::is_valid(poly) && poly.outer().size() != vertices|!is_convex(poly) \&\& poly.outer().size() > 3 \&\& poly.outer().size() != vertices /* Boost 1.75 compat: is_valid removed */|' "$rcpf" 2>/dev/null
+        fi
+    done
+
+    set -eo pipefail
+
+    # shellcheck disable=SC2086
+    du -sh "$ccache_dir" && ccache -s
+
+    # Multiple passes for dependency ordering
+    for pass in 1 2 3; do
+        # shellcheck disable=SC2086
+        $taskset_cmd colcon build --cmake-args \
+            " -Wno-dev" \
+            " --no-warn-unused-cli" \
+            " -DPython3_EXECUTABLE=/usr/bin/python3" \
+            " -DBUILD_TESTING=OFF" \
+            " -DBUILD_WITH_VECTORIZATION_SUPPORT=OFF" \
+            " -DCMAKE_CXX_FLAGS=-Wno-error=cpp" \
+            --base-paths $base_paths \
+            --merge-install \
+            --install-base "$install_base" \
+            --mixin release compile-commands ccache \
+            $colcon_build_args 2>&1 || true
+        local failed
+        # shellcheck disable=SC2086
+        failed=$(colcon list --base-paths $base_paths --packages-select-build-failed 2>/dev/null | wc -l)
+        echo "=== Pass $pass: $failed packages failed ==="
+        [ "$failed" -eq 0 ] && break
+        # Remove build dirs of failed packages so colcon retries them
+        # shellcheck disable=SC2086
+        colcon list --base-paths $base_paths --packages-select-build-failed --paths-only 2>/dev/null | while read -r p; do
+            rm -rf "/autoware/build/$(basename "$p")"
+        done
+    done
+
+    du -sh "$ccache_dir" && ccache -s
+    rm -rf /autoware/build /autoware/log
+}
+
+build_and_clean "$@"

--- a/docker/scripts/build_and_clean_rhel.sh
+++ b/docker/scripts/build_and_clean_rhel.sh
@@ -19,7 +19,7 @@ function build_and_clean() {
     set +e
 
     # M_PIf/M_PI_2f/M_PI_4f: C23 constants not available in GCC 11 (RHEL 9)
-    grep -rl 'M_PIf\b' /autoware/src/ --include='*.hpp' --include='*.cpp' 2>/dev/null | \
+    grep -rl 'M_PIf\b' /autoware/src/ --include='*.hpp' --include='*.cpp' 2>/dev/null |
         while read -r f; do
             if ! grep -q 'ifndef M_PIf' "$f" 2>/dev/null; then
                 sed -i '1i #ifndef M_PIf\n#define M_PIf static_cast<float>(M_PI)\n#endif\n#ifndef M_PI_2f\n#define M_PI_2f static_cast<float>(M_PI_2)\n#endif\n#ifndef M_PI_4f\n#define M_PI_4f static_cast<float>(M_PI_4)\n#endif' "$f" 2>/dev/null
@@ -28,16 +28,16 @@ function build_and_clean() {
 
     # COLCON_IGNORE CUDA packages in bind-mounted source
     for pkg in autoware_cuda_dependency_meta autoware_cuda_utils autoware_cuda_pointcloud_preprocessor \
-      autoware_tensorrt_common autoware_tensorrt_plugins autoware_tensorrt_yolox autoware_tensorrt_classifier \
-      autoware_tensorrt_bevdet autoware_tensorrt_bevformer autoware_tensorrt_vad \
-      autoware_lidar_centerpoint autoware_lidar_transfusion autoware_lidar_frnet \
-      autoware_lidar_apollo_instance_segmentation autoware_bevfusion autoware_bytetrack \
-      autoware_camera_streampetr autoware_ptv3 autoware_simpl_prediction \
-      autoware_image_projection_based_fusion autoware_traffic_light_classifier \
-      autoware_traffic_light_fine_detector autoware_ground_segmentation_cuda \
-      autoware_probabilistic_occupancy_grid_map autoware_calibration_status_classifier \
-      autoware_diffusion_planner autoware_shape_estimation \
-      bevdet_vendor trt_batched_nms cuda_blackboard; do
+        autoware_tensorrt_common autoware_tensorrt_plugins autoware_tensorrt_yolox autoware_tensorrt_classifier \
+        autoware_tensorrt_bevdet autoware_tensorrt_bevformer autoware_tensorrt_vad \
+        autoware_lidar_centerpoint autoware_lidar_transfusion autoware_lidar_frnet \
+        autoware_lidar_apollo_instance_segmentation autoware_bevfusion autoware_bytetrack \
+        autoware_camera_streampetr autoware_ptv3 autoware_simpl_prediction \
+        autoware_image_projection_based_fusion autoware_traffic_light_classifier \
+        autoware_traffic_light_fine_detector autoware_ground_segmentation_cuda \
+        autoware_probabilistic_occupancy_grid_map autoware_calibration_status_classifier \
+        autoware_diffusion_planner autoware_shape_estimation \
+        bevdet_vendor trt_batched_nms cuda_blackboard; do
         find /autoware/src -name "$pkg" -type d -exec touch {}/COLCON_IGNORE \; 2>/dev/null
     done
     # Duplicate autoware_agnocast_wrapper fix
@@ -55,9 +55,9 @@ function build_and_clean() {
     # and default_strategy errors for custom Point types (Eigen-based Point2d).
     # Patch these headers to include the full cartesian strategy set.
     for bhpp in \
-      /usr/include/boost/geometry/algorithms/correct.hpp \
-      /usr/include/boost/geometry/algorithms/is_valid.hpp \
-      /usr/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp; do
+        /usr/include/boost/geometry/algorithms/correct.hpp \
+        /usr/include/boost/geometry/algorithms/is_valid.hpp \
+        /usr/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp; do
         if [ -f "$bhpp" ] && ! grep -q 'strategies/cartesian.hpp' "$bhpp"; then
             sed -i '1i #include <boost/geometry/strategies/cartesian.hpp>  // RHEL Boost 1.75 compat' "$bhpp" 2>/dev/null
         fi
@@ -66,8 +66,8 @@ function build_and_clean() {
     # Patch: boost::geometry::is_valid() fails on Boost < 1.77 with Eigen-based Point2d
     # Replace with a simpler polygon size check on older Boost
     for rcpf in \
-      /autoware/src/core/autoware_utils/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp \
-      /autoware/src/universe/autoware_universe/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp; do
+        /autoware/src/core/autoware_utils/autoware_utils_geometry/src/geometry/random_concave_polygon.cpp \
+        /autoware/src/universe/autoware_universe/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp; do
         if [ -f "$rcpf" ]; then
             sed -i 's|!is_convex(poly) && boost::geometry::is_valid(poly) && poly.outer().size() != vertices|!is_convex(poly) \&\& poly.outer().size() > 3 \&\& poly.outer().size() != vertices /* Boost 1.75 compat: is_valid removed */|' "$rcpf" 2>/dev/null
         fi

--- a/docker/scripts/cleanup_dnf.sh
+++ b/docker/scripts/cleanup_dnf.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eo pipefail
+
+function cleanup_dnf() {
+    dnf clean all 2>/dev/null || true
+    rm -rf "$HOME"/.cache 2>/dev/null || true
+}
+
+cleanup_dnf "$@"

--- a/docker/scripts/resolve_rosdep_keys_rhel.sh
+++ b/docker/scripts/resolve_rosdep_keys_rhel.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eo pipefail
+
+function resolve_rosdep_keys() {
+    local src_path=$1
+    local ros_distro=$2
+    local rosdep_keys_args=$3
+
+    # shellcheck disable=SC2086
+    local keys
+    keys=$(rosdep keys $rosdep_keys_args --ignore-src --from-paths "$src_path" 2>/dev/null || true)
+
+    if [ -z "$keys" ]; then
+        return 0
+    fi
+
+    # Resolve with RHEL OS override, filter out ros-jazzy-* (built from source)
+    echo "$keys" |
+        xargs -r rosdep resolve --rosdistro "$ros_distro" --os=rhel:9 2>/dev/null |
+        grep -v '^#' |
+        sed 's/ \+/\n/g' |
+        grep -v '^ros-' |
+        grep -v '^$' |
+        sort -u || true
+}
+
+resolve_rosdep_keys "$@"


### PR DESCRIPTION
## Description

Add `Dockerfile.rhel` and supporting scripts to build Autoware on AlmaLinux 9 (RHEL 9 compatible) without CUDA.

The ROS 2 Jazzy [RHEL 9 binary](https://github.com/ros2/ros2/releases/download/release-jazzy-20260128/ros2-jazzy-20260128-linux-rhel9-amd64.tar.bz2) provides ros-base equivalent (371 packages). Missing ROS packages (diagnostic_updater, geographic_msgs, pcl_ros, lanelet2_core, grid_map, filters, etc.) are built from source via `rhel-extra-deps.repos`.

### Key changes

- **`docker/Dockerfile.rhel`**: Multi-stage Dockerfile (16 stages) with BuildKit parallel builds
- **`docker/scripts/build_and_clean_rhel.sh`**: 3-pass colcon build with RHEL-specific patches (M_PIf, Boost 1.75, CUDA COLCON_IGNORE)
- **`docker/scripts/resolve_rosdep_keys_rhel.sh`**: rosdep resolution with --os=rhel:9
- **`docker/rhel-extra-deps.repos`**: VCS manifest of 37 ROS packages not in RHEL binary
- **`docker/README-rhel.md`**: Build procedure documentation

### Image sizes

| Target | Size | Packages |
|--------|------|----------|
| universe-devel | ~13.7 GB | 431 built (0 failed) |
| universe (runtime) | ~7.1 GB | 746 recognized by ros2 pkg list |

## How was this PR tested?

- Built universe-devel target: 431 packages succeeded, 0 failed
- Built universe runtime target: 7.06 GB image
- Verified ros2 pkg list returns 746 packages (189 autoware_* packages)
- Verified ros2 topic list and ros2 node list work correctly
- Verified entrypoint with UID/GID remapping via gosu