### PR TITLE
ci(docker-new): split base-cuda layer and restructure CI pipelines

### DIFF
--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -40,8 +40,10 @@ runs:
             max-parallelism = ${{ inputs.max-parallelism }}
         install: true
 
+    # TODO: temporarily disabled via `if: false`. Re-enable once cache saving is needed again.
     - name: Cache ccache
       uses: actions/cache@v4
+      if: false
       with:
         path: |
           root-ccache
@@ -49,8 +51,10 @@ runs:
         restore-keys: |
           ccache-tools-${{ inputs.platform }}-
 
+    # TODO: temporarily disabled via `if: false`. Re-enable once cache saving is needed again.
     - name: Cache apt-get
       uses: actions/cache@v4
+      if: false
       with:
         path: |
           var-cache-apt

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -49,9 +49,10 @@ runs:
         vcs import --shallow --force src < ${{ inputs.additional-repos }}
       shell: bash
 
+    # TODO: temporarily disabled via `&& false`. Re-enable once cache saving is needed again.
     - name: Cache ccache
       uses: actions/cache@v4
-      if: ${{ github.ref == 'refs/heads/main'}}
+      if: ${{ github.ref == 'refs/heads/main' && false }}
       id: cache-ccache
       with:
         path: |
@@ -61,9 +62,10 @@ runs:
           ccache-${{ inputs.platform }}-${{ inputs.cache-tag-suffix }}-
           ccache-${{ inputs.platform }}-
 
+    # TODO: temporarily disabled via `&& false`. Re-enable once cache saving is needed again.
     - name: Cache apt-get
       uses: actions/cache@v4
-      if: ${{ github.ref == 'refs/heads/main'}}
+      if: ${{ github.ref == 'refs/heads/main' && false }}
       id: cache-apt-get
       with:
         path: |

--- a/.github/workflows/docker-build-and-push-new.yaml
+++ b/.github/workflows/docker-build-and-push-new.yaml
@@ -51,17 +51,48 @@ jobs:
             .github/workflows/docker-build-new.yaml
             .github/workflows/docker-build-pipeline-new.yaml
             .github/workflows/docker-build-and-push-new.yaml
+            .github/workflows/docker-manifest-new.yaml
 
-  humble:
+  humble-amd64:
     needs: changed-files
     if: needs.changed-files.outputs.should-build == 'true'
     uses: ./.github/workflows/docker-build-pipeline-new.yaml
     with:
       ros-distro: humble
+      platform: amd64
 
-  jazzy:
+  humble-arm64:
     needs: changed-files
     if: needs.changed-files.outputs.should-build == 'true'
     uses: ./.github/workflows/docker-build-pipeline-new.yaml
+    with:
+      ros-distro: humble
+      platform: arm64
+
+  humble-manifest:
+    needs: [humble-amd64, humble-arm64]
+    uses: ./.github/workflows/docker-manifest-new.yaml
+    with:
+      ros-distro: humble
+
+  jazzy-amd64:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-build == 'true'
+    uses: ./.github/workflows/docker-build-pipeline-new.yaml
+    with:
+      ros-distro: jazzy
+      platform: amd64
+
+  jazzy-arm64:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-build == 'true'
+    uses: ./.github/workflows/docker-build-pipeline-new.yaml
+    with:
+      ros-distro: jazzy
+      platform: arm64
+
+  jazzy-manifest:
+    needs: [jazzy-amd64, jazzy-arm64]
+    uses: ./.github/workflows/docker-manifest-new.yaml
     with:
       ros-distro: jazzy

--- a/.github/workflows/docker-build-new.yaml
+++ b/.github/workflows/docker-build-new.yaml
@@ -1,3 +1,25 @@
+# Reusable workflow that builds and pushes one docker-new bake group via
+# `docker buildx bake`, for one ROS distro, on ONE platform. Callers run
+# this twice (amd64 + arm64) to produce per-arch tags, then stitch them
+# with the separate `docker-manifest-new.yaml` workflow.
+#
+# Two independent caches cooperate:
+#
+#   - GHA mount cache (actions/cache). Caches the BuildKit RUN mounts
+#     (apt, ccache, pip, pipx) as a tarball keyed per
+#     bake-group/distro/platform/sha. Only main pushes write; other refs
+#     are read-only. An inline prune step runs at the end of the build
+#     job: it deletes every entry in the lineage except the current SHA
+#     key (which post-save is about to write) and also deletes anything
+#     above `max-cache-size-gb`. Net effect: the lineage stays at most
+#     one tarball, and an oversized save gets evicted on the next run.
+#
+#   - GHCR registry layer cache (`cache-to=type=registry`). Caches the
+#     BuildKit image layers on ghcr.io, one tag per bake-group. Every ref
+#     writes; reads fall back branch → main. `mode=max` means each tag's
+#     manifest is a superset of its stages, so a group only needs to read
+#     its own tag.
+
 name: docker-build-new-reusable
 
 on:
@@ -5,6 +27,10 @@ on:
     inputs:
       bake-group:
         description: HCL group to build (e.g. ci-base, ci-core)
+        type: string
+        required: true
+      platform:
+        description: Target platform (amd64 or arm64)
         type: string
         required: true
       runner-amd64:
@@ -19,10 +45,6 @@ on:
         description: ROS distribution
         type: string
         default: jazzy
-      cache-key-prefix:
-        description: Extra prefix for cache key separation
-        type: string
-        default: ""
       target-image:
         description: Registry image name
         type: string
@@ -35,20 +57,21 @@ on:
         description: Whether to free disk space before building
         type: boolean
         default: true
+      max-cache-size-gb:
+        description: Max allowed size (GB) for restored BuildKit cache mounts; cache is dropped and purged if exceeded
+        type: number
+        default: 6
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [amd64, arm64]
-        include:
-          - platform: amd64
-            arch-platform: linux/amd64
-          - platform: arm64
-            arch-platform: linux/arm64
-    runs-on: ${{ matrix.platform == 'amd64' && inputs.runner-amd64 || inputs.runner-arm64 }}
-    outputs:
-      target-tags: ${{ steps.compute-tags.outputs.tags }}
+    name: ${{ inputs.bake-group }}
+    runs-on: ${{ inputs.platform == 'amd64' && inputs.runner-amd64 || inputs.runner-arm64 }}
+    permissions:
+      contents: read
+      packages: write
+      actions: write
+    env:
+      CACHE_KEY_PREFIX: buildkit-mounts-${{ inputs.bake-group }}-${{ inputs.ros-distro }}-${{ inputs.platform }}-
+      IS_MAIN_PUSH: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     steps:
       - name: 💻 Runner specs
         run: |
@@ -68,18 +91,6 @@ jobs:
       - name: 📥 Check out repository
         uses: actions/checkout@v6
 
-      - name: 🏷️ Compute manifest tags from HCL
-        id: compute-tags
-        run: |
-          targets=$(docker buildx bake -f docker-new/docker-bake.hcl --print ${{ inputs.bake-group }} 2>/dev/null \
-            | jq -r '.group."${{ inputs.bake-group }}".targets[]')
-          tags=""
-          for t in $targets; do
-            tags="${tags:+$tags }${t}-${{ inputs.ros-distro }}"
-          done
-          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
-          echo "::notice::Manifest tags: ${tags}"
-
       - name: 🧹 Free disk space
         if: inputs.free-disk-space && runner.environment == 'github-hosted'
         uses: ./.github/actions/free-disk-space
@@ -98,6 +109,84 @@ jobs:
             [worker.oci]
               max-parallelism = 2
 
+      - name: 🏷️ Compute target tags from HCL
+        id: compute-tags
+        run: |
+          targets=$(docker buildx bake -f docker-new/docker-bake.hcl --print ${{ inputs.bake-group }} 2>/dev/null \
+            | jq -r '.group."${{ inputs.bake-group }}".targets[]')
+          tags=""
+          for t in $targets; do
+            tags="${tags:+$tags }${t}-${{ inputs.ros-distro }}"
+          done
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Target tags: ${tags}"
+
+      # cache-restore always runs so cache-matched-key is exposed for the
+      # summary (the combined actions/cache@v5 action only outputs cache-hit).
+      # cache-save is gated on main-push and uses lookup-only: true — it
+      # downloads nothing, it exists only so its post-step can save the
+      # tarball after buildkit-cache-dance's post-extract. Non-main runs
+      # skip it entirely, so cancelled PR runs can't write half-populated
+      # tarballs under a key that future main runs would restore from.
+      - name: 💾 Restore BuildKit cache mounts
+        id: cache-restore
+        uses: actions/cache/restore@v5
+        with:
+          path: cache-mounts
+          key: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          restore-keys: |
+            ${{ env.CACHE_KEY_PREFIX }}
+
+      - name: 💾 Arm post-step save of BuildKit cache mounts (main)
+        if: env.IS_MAIN_PUSH == 'true'
+        id: cache-save
+        uses: actions/cache@v5
+        with:
+          path: cache-mounts
+          key: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          lookup-only: true
+
+      - name: 💉 Inject BuildKit cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          # apt-cache (/var/cache/apt = downloaded .debs) is cached for
+          # every group except ci-base-cuda*. CUDA/cuDNN/TensorRT .debs
+          # alone exceed a reasonable tarball size; rebuilding those
+          # layers is rare enough that redownloading from the NVIDIA CDN
+          # beats paying the cache quota. For non-CUDA groups the
+          # post-build purge evicts any lineage that still outgrows the
+          # size guard.
+          cache-map: |
+            {
+              ${{ !startsWith(inputs.bake-group, 'ci-base-cuda') && format('"cache-mounts/apt-cache": {{
+                "id": "apt-cache-{0}",
+                "target": "/var/cache/apt"
+              }},', inputs.ros-distro) || '' }}
+              "cache-mounts/apt-lists": {
+                "id": "apt-lists-${{ inputs.ros-distro }}",
+                "target": "/var/lib/apt/lists"
+              },
+              "cache-mounts/ccache": {
+                "id": "ccache-${{ inputs.ros-distro }}",
+                "target": "/home/aw/.ccache",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pip": {
+                "id": "pip-cache",
+                "target": "/home/aw/.cache/pip",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pipx": {
+                "id": "pipx-cache",
+                "target": "/home/aw/.cache/pipx",
+                "uid": "1000",
+                "gid": "1000"
+              }
+            }
+          skip-extraction: ${{ steps.cache-restore.outputs.cache-hit }}
+
       - name: 🔑 Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -111,6 +200,8 @@ jobs:
           ref_name="${GITHUB_REF_NAME//\//-}"
           echo "ref_name=${ref_name}" >> "$GITHUB_OUTPUT"
           echo "date=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
+          echo "build_start=$(date +%s)" >> "$GITHUB_OUTPUT"
+          echo "disk_before_kb=$(df --output=avail / | tail -1 | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
@@ -123,17 +214,18 @@ jobs:
           echo "::group::Build info"
           echo "  Group:    ${{ inputs.bake-group }}"
           echo "  Distro:   ${{ inputs.ros-distro }}"
-          echo "  Platform: ${{ matrix.platform }}"
+          echo "  Platform: ${{ inputs.platform }}"
           echo "  Ref:      ${GITHUB_REF_NAME}"
           echo "  Event:    ${{ github.event_name }}"
           echo "::endgroup::"
 
-      - name: 🔨 Build and push [${{ inputs.bake-group }}] (${{ matrix.platform }})
+      - name: 🔨 Build and push [${{ inputs.bake-group }}] (${{ inputs.platform }})
+        id: bake
         uses: docker/bake-action@v7
         env:
           ROS_DISTRO: ${{ inputs.ros-distro }}
           REGISTRY: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
-          PLATFORM: ${{ matrix.platform }}
+          PLATFORM: ${{ inputs.platform }}
           TAG_DATE: ${{ steps.meta.outputs.date }}
           TAG_VERSION: ${{ steps.meta.outputs.version }}
           TAG_REF: ${{ steps.meta.outputs.ref }}
@@ -145,76 +237,112 @@ jobs:
           files: docker-new/docker-bake.hcl
           provenance: false
           set: |
-            *.platform=${{ matrix.arch-platform }}
+            *.platform=linux/${{ inputs.platform }}
             *.args.ROS_DISTRO=${{ inputs.ros-distro }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ inputs.ros-distro }}-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.ros-distro }}-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ inputs.ros-distro }}-${{ matrix.platform }}-main
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.ros-distro }}-${{ matrix.platform }}-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ inputs.ros-distro }}-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }},mode=max,ignore-error=true
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.bake-group }}-${{ inputs.ros-distro }}-${{ inputs.platform }}-${{ steps.meta.outputs.ref_name }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.bake-group }}-${{ inputs.ros-distro }}-${{ inputs.platform }}-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.bake-group }}-${{ inputs.ros-distro }}-${{ inputs.platform }}-${{ steps.meta.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: 📊 Build summary
         if: always()
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
+          BUILDCACHE_REF: ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.bake-group }}-${{ inputs.ros-distro }}-${{ inputs.platform }}-${{ steps.meta.outputs.ref_name }}
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
+          CACHE_MATCHED_KEY: ${{ steps.cache-restore.outputs.cache-matched-key }}
+          CACHE_EXACT_HIT: ${{ steps.cache-restore.outputs.cache-hit }}
+          BUILD_START: ${{ steps.meta.outputs.build_start }}
+          DISK_BEFORE_KB: ${{ steps.meta.outputs.disk_before_kb }}
         run: |
+          duration="n/a"
+          if [ -n "${BUILD_START}" ]; then
+            duration="$(( $(date +%s) - BUILD_START )) s"
+          fi
+
+          disk_after_kb=$(df --output=avail / | tail -1 | tr -d ' ')
+          kb_to_gb() { awk "BEGIN { printf \"%.1f\", $1/1024/1024 }"; }
+          disk_before_gb=$(kb_to_gb "${DISK_BEFORE_KB:-0}")
+          disk_after_gb=$(kb_to_gb "${disk_after_kb}")
+          disk_delta_gb=$(awk "BEGIN { printf \"%+.1f\", (${disk_after_kb} - ${DISK_BEFORE_KB:-0})/1024/1024 }")
+
+          if [ -z "${CACHE_MATCHED_KEY}" ]; then
+            cache_status="miss"
+          elif [ "${CACHE_EXACT_HIT}" = "true" ]; then
+            cache_status="exact hit \`${CACHE_MATCHED_KEY}\`"
+          else
+            cache_status="partial hit \`${CACHE_MATCHED_KEY}\`"
+          fi
+
+          image_rows=""
+          if [ -n "${BAKE_METADATA}" ] && [ "${BAKE_METADATA}" != "null" ]; then
+            while IFS=$'\t' read -r target digest; do
+              [ -z "$digest" ] && continue
+              size_bytes=$(docker buildx imagetools inspect --raw "${IMAGE}@${digest}" 2>/dev/null \
+                | jq '(.config.size // 0) + ([.layers[]?.size] | add // 0)' 2>/dev/null)
+              if [ -n "$size_bytes" ] && [ "$size_bytes" != "null" ] && [ "$size_bytes" -gt 0 ] 2>/dev/null; then
+                size_col="$(( size_bytes / 1000000 )) MB"
+              else
+                size_col="?"
+              fi
+              image_rows+="| \`${target}\` | \`${digest:0:19}…\` | ${size_col} |"$'\n'
+            done < <(
+              echo "${BAKE_METADATA}" | jq -r '
+                to_entries
+                | map(select(.value."containerimage.digest"?))
+                | .[]
+                | [.key, .value."containerimage.digest"]
+                | @tsv
+              ' 2>/dev/null
+            )
+          fi
+
           {
-            echo "### 🐳 Docker Build: \`${{ inputs.bake-group }}\` (${{ matrix.platform }})"
+            echo "### 🐳 Docker Build: \`${{ inputs.bake-group }}\` (${{ inputs.platform }})"
             echo ""
             echo "| Key | Value |"
             echo "|-----|-------|"
-            echo "| **ROS Distro** | \`${{ inputs.ros-distro }}\` |"
-            echo "| **Platform** | \`${{ matrix.arch-platform }}\` |"
-            echo "| **Registry** | \`${IMAGE}\` |"
-            echo "| **Tags** | \`${{ steps.compute-tags.outputs.tags }}\` |"
+            echo "| 🤖 **ROS Distro** | \`${{ inputs.ros-distro }}\` |"
+            echo "| 🧱 **Platform** | \`linux/${{ inputs.platform }}\` |"
+            echo "| 🏃 **Runner** | \`${RUNNER_NAME}\` (${RUNNER_OS}/${RUNNER_ARCH}, ${RUNNER_ENVIRONMENT}) |"
+            echo "| ⏱️ **Duration** | ${duration} |"
+            echo "| 🌐 **Registry** | [\`${IMAGE}\`](https://github.com/${{ github.repository }}/pkgs/container/${{ inputs.target-image }}) |"
+            echo "| 🏷️ **Tags** | \`${{ steps.compute-tags.outputs.tags }}\` |"
+            echo "| 💾 **GHA cache** | ${cache_status} |"
+            echo "| 📥 **Registry cache (from)** | \`${BUILDCACHE_REF}\` + main fallback |"
             echo ""
-            echo "#### 💾 Disk space"
-            echo "\`\`\`"
-            df -h / | head -2
-            echo "\`\`\`"
+
+            if [ -n "${image_rows}" ]; then
+              echo "#### 📦 Pushed images"
+              echo ""
+              echo "| Target | Digest | Size |"
+              echo "|--------|--------|------|"
+              echo "${image_rows}"
+              echo ""
+            fi
+
+            echo "#### 💾 Disk"
+            echo ""
+            echo "| | Free |"
+            echo "|-|------|"
+            echo "| 🟢 Pre-build (after cleanup) | ${disk_before_gb} GB |"
+            echo "| 🔴 Post-build | ${disk_after_gb} GB |"
+            echo "| 📊 Δ | ${disk_delta_gb} GB |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  manifest:
-    needs: build
-    if: needs.build.result == 'success'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: 🔑 Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
-
-      - name: 🔗 Create multi-arch manifests
+      - name: 🧹 Prune cache lineage
+        if: env.IS_MAIN_PUSH == 'true' && steps.bake.outcome == 'success'
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
-          REF_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' && format('-{0}', github.ref_name) || '' }}
+          GH_TOKEN: ${{ github.token }}
+          KEEP_KEY: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          MAX_GB: ${{ inputs.max-cache-size-gb }}
         run: |
-          ref_suffix="${REF_SUFFIX//\//-}"
-          for tag in ${{ needs.build.outputs.target-tags }}; do
-            manifest_tag="${tag}${ref_suffix}"
-            echo "::group::📦 ${manifest_tag}"
-            docker manifest create "${IMAGE}:${manifest_tag}" \
-              "${IMAGE}:${manifest_tag}-amd64" \
-              "${IMAGE}:${manifest_tag}-arm64"
-            docker manifest push "${IMAGE}:${manifest_tag}"
-            echo "::endgroup::"
-          done
-
-      - name: 📊 Manifest summary
-        env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
-          REF_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' && format('-{0}', github.ref_name) || '' }}
-        run: |
-          ref_suffix="${REF_SUFFIX//\//-}"
-          {
-            echo "### 🔗 Multi-arch Manifests"
-            echo ""
-            echo "| Image | Platforms |"
-            echo "|-------|-----------|"
-            for tag in ${{ needs.build.outputs.target-tags }}; do
-              manifest_tag="${tag}${ref_suffix}"
-              echo "| \`${IMAGE}:${manifest_tag}\` | amd64, arm64 |"
-            done
-          } >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          max_bytes=$((MAX_GB * 1000 * 1000 * 1000))
+          echo "keep: ${KEEP_KEY} (written in post phase)"
+          gh cache list --repo "$GITHUB_REPOSITORY" --key "$CACHE_KEY_PREFIX" --json key,sizeInBytes \
+            | jq -r --arg keep "$KEEP_KEY" --argjson max "$max_bytes" \
+                '.[] | select(.key != $keep or .sizeInBytes > $max) | .key' \
+            | while read -r key; do
+                echo "delete: $key"
+                gh cache delete "$key" --repo "$GITHUB_REPOSITORY" || true
+              done

--- a/.github/workflows/docker-build-pipeline-new.yaml
+++ b/.github/workflows/docker-build-pipeline-new.yaml
@@ -7,6 +7,10 @@ on:
         description: ROS distribution
         type: string
         required: true
+      platform:
+        description: Target platform (amd64 or arm64)
+        type: string
+        required: true
       target-image:
         description: Registry image name
         type: string
@@ -17,6 +21,7 @@ jobs:
     uses: ./.github/workflows/docker-build-new.yaml
     with:
       bake-group: ci-base
+      platform: ${{ inputs.platform }}
       ros-distro: ${{ inputs.ros-distro }}
       target-image: ${{ inputs.target-image }}
       free-disk-space: false
@@ -26,6 +31,7 @@ jobs:
     uses: ./.github/workflows/docker-build-new.yaml
     with:
       bake-group: ci-core
+      platform: ${{ inputs.platform }}
       ros-distro: ${{ inputs.ros-distro }}
       target-image: ${{ inputs.target-image }}
       needs-source: true
@@ -36,16 +42,27 @@ jobs:
     uses: ./.github/workflows/docker-build-new.yaml
     with:
       bake-group: ci-universe
+      platform: ${{ inputs.platform }}
       ros-distro: ${{ inputs.ros-distro }}
       target-image: ${{ inputs.target-image }}
       needs-source: true
 
+  build-base-cuda:
+    needs: build-base
+    uses: ./.github/workflows/docker-build-new.yaml
+    with:
+      bake-group: ci-base-cuda
+      platform: ${{ inputs.platform }}
+      ros-distro: ${{ inputs.ros-distro }}
+      target-image: ${{ inputs.target-image }}
+      free-disk-space: true
+
   build-universe-cuda:
-    needs: build-core
+    needs: [build-core, build-base-cuda]
     uses: ./.github/workflows/docker-build-new.yaml
     with:
       bake-group: ci-universe-cuda
+      platform: ${{ inputs.platform }}
       ros-distro: ${{ inputs.ros-distro }}
       target-image: ${{ inputs.target-image }}
       needs-source: true
-      cache-key-prefix: cuda-

--- a/.github/workflows/docker-manifest-new.yaml
+++ b/.github/workflows/docker-manifest-new.yaml
@@ -1,0 +1,134 @@
+# Stitches the per-arch tags pushed by docker-build-new.yaml into
+# multi-arch manifests. Runs once per ROS distro after both the amd64
+# and arm64 pipelines have finished. The set of targets is derived from
+# the `default` group in docker-new/docker-bake.hcl, and the suffix set
+# mirrors the `tags()` function there so every per-arch variant the
+# build side pushed (plain, dated, versioned, ref-named) gets stitched.
+
+name: docker-manifest-new
+
+on:
+  workflow_call:
+    inputs:
+      ros-distro:
+        description: ROS distribution
+        type: string
+        required: true
+      target-image:
+        description: Registry image name
+        type: string
+        default: autoware-new
+
+jobs:
+  manifest:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
+      ROS_DISTRO: ${{ inputs.ros-distro }}
+      VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+    steps:
+      - name: 📥 Check out repository
+        uses: actions/checkout@v6
+
+      - name: 🐳 Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: 🔑 Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: 🧭 Discover manifest targets
+        id: targets
+        run: |
+          set -euo pipefail
+          targets=$(docker buildx bake -f docker-new/docker-bake.hcl --print default \
+            | jq -r '.group.default.targets[]')
+          if [ -z "$targets" ]; then
+            echo "::error::No targets found in default group of docker-new/docker-bake.hcl"
+            exit 1
+          fi
+          echo "Found $(echo "$targets" | wc -l) target(s)"
+          {
+            echo "list<<EOF"
+            echo "$targets"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 🏷️ Build manifest tag list
+        id: tags
+        env:
+          TARGETS: ${{ steps.targets.outputs.list }}
+        run: |
+          set -euo pipefail
+
+          date=$(date +'%Y%m%d')
+          ref=""
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref_name }}" != "main" ]]; then
+            ref="${GITHUB_REF_NAME//\//-}"
+          fi
+
+          # Mirror tags() in docker-new/docker-bake.hcl so every per-arch
+          # variant the build pushed gets a multi-arch counterpart:
+          #   - TAG_REF empty → plain + (dated if TAG_DATE)
+          #   - TAG_REF set   → only the ref variant (plain is not pushed)
+          #   - TAG_VERSION set (tag push) → add versioned variant
+          suffixes=()
+          if [ -z "$ref" ]; then
+            suffixes+=("")
+            [ -n "$date" ] && suffixes+=("-$date")
+          else
+            suffixes+=("-$ref")
+          fi
+          [ -n "$VERSION" ] && suffixes+=("-$VERSION")
+
+          tags=""
+          while IFS= read -r t; do
+            [ -z "$t" ] && continue
+            for suffix in "${suffixes[@]}"; do
+              tags+="${t}-${ROS_DISTRO}${suffix}"$'\n'
+            done
+          done <<< "$TARGETS"
+
+          echo "Built $(printf '%s' "$tags" | grep -c .) manifest tag(s) across ${#suffixes[@]} variant(s)"
+          {
+            echo "list<<EOF"
+            printf '%s' "$tags"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 🔗 Create multi-arch manifests
+        env:
+          TAGS: ${{ steps.tags.outputs.list }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "::group::📦 ${tag}"
+            docker manifest create "${IMAGE}:${tag}" \
+              "${IMAGE}:${tag}-amd64" \
+              "${IMAGE}:${tag}-arm64"
+            docker manifest push "${IMAGE}:${tag}"
+            echo "::endgroup::"
+          done <<< "$TAGS"
+
+      - name: 📊 Manifest summary
+        if: always()
+        env:
+          TAGS: ${{ steps.tags.outputs.list }}
+        run: |
+          {
+            echo "### 🔗 Multi-arch Manifests (${ROS_DISTRO})"
+            echo ""
+            echo "| Image | Platforms |"
+            echo "|-------|-----------|"
+            while IFS= read -r tag; do
+              [ -z "$tag" ] && continue
+              echo "| \`${IMAGE}:${tag}\` | amd64, arm64 |"
+            done <<< "$TAGS"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ansible/playbooks/autoware_requirements.yaml
+++ b/ansible/playbooks/autoware_requirements.yaml
@@ -23,14 +23,14 @@
     - role: autoware.dev_env.ros2_dev_tools
       tags: [core, universe, ros2_dev_tools]
 
-    - role: autoware.dev_env.acados
-      tags: [universe, acados]
+    - role: autoware.dev_env.qt5ct_setup
+      tags: [core, universe, qt5ct_setup]
 
     - role: autoware.dev_env.geographiclib
-      tags: [universe, geographiclib]
+      tags: [core, universe, geographiclib]
 
-    - role: autoware.dev_env.qt5ct_setup
-      tags: [universe, qt5ct_setup]
+    - role: autoware.dev_env.acados
+      tags: [universe, acados]
 
     - role: autoware.dev_env.cuda
       tags: [universe, nvidia, cuda]

--- a/ansible/playbooks/nvidia.yaml
+++ b/ansible/playbooks/nvidia.yaml
@@ -1,0 +1,10 @@
+- name: Install NVIDIA CUDA stack
+  hosts: localhost
+  connection: local
+  vars:
+    install_devel: N
+    cuda_install_drivers: false
+  roles:
+    - role: autoware.dev_env.cuda
+    - role: autoware.dev_env.tensorrt
+    - role: autoware.dev_env.spconv

--- a/ansible/playbooks/rmw.yaml
+++ b/ansible/playbooks/rmw.yaml
@@ -1,0 +1,7 @@
+- name: Install RMW implementation
+  hosts: localhost
+  connection: local
+  vars:
+    rosdistro:
+  roles:
+    - role: autoware.dev_env.rmw_implementation

--- a/docker-new/README.md
+++ b/docker-new/README.md
@@ -3,46 +3,45 @@
 ## Image Graph
 
 ```mermaid
-graph TD
-    base(["base"])
-    base --> core-dependencies(["core-dependencies"])
+graph TB
+    base(["base"]) --> core-dependencies(["core-dependencies"]) & core(["core"]) & base-cuda-runtime(["base-cuda-runtime"])
     core-dependencies --> core-devel(["core-devel"])
     core-devel --> universe-dependencies(["universe-dependencies"])
-    universe-dependencies --> universe-dependencies-cuda(["universe-dependencies-cuda"])
     universe-dependencies --> universe-devel(["universe-devel"])
-    universe-dependencies-cuda --> universe-devel-cuda(["universe-devel-cuda"])
-    base --> core(["core"])
+    universe-dependencies-cuda(["universe-dependencies-cuda"]) --> universe-devel-cuda(["universe-devel-cuda"])
     core-devel -- " COPY /opt/autoware " --> core
-    core --> universe-runtime-dependencies(["universe-runtime-dependencies"])
-    universe-runtime-dependencies --> universe(["universe"])
-    universe-runtime-dependencies --> universe-cuda(["universe-cuda"])
+    core --> universe(["universe"])
     universe-devel -- " COPY /opt/autoware " --> universe
-    universe-devel-cuda -- " COPY /opt/autoware " --> universe-cuda
+    universe-devel-cuda -- " COPY /opt/autoware " --> universe-cuda(["universe-cuda"])
+    core-devel -- " COPY /opt/autoware " --> universe-dependencies-cuda
+    base-cuda-devel(["base-cuda-devel"]) --> universe-dependencies-cuda
+    base-cuda-runtime --> universe-cuda & base-cuda-devel
     classDef base fill: #e8e8e8, color: #333
     classDef devel fill: #bbdefb, color: #333
     classDef runtime fill: #c8e6c9, color: #333
     classDef cuda fill: #e1bee7, color: #333
-    class base base
+    class base,base-cuda-runtime,base-cuda-devel base
     class core-dependencies,core-devel,universe-dependencies,universe-devel devel
-    class core,universe-runtime-dependencies,universe runtime
+    class core,universe runtime
     class universe-dependencies-cuda,universe-devel-cuda,universe-cuda cuda
 ```
 
 ## Images
 
-| Image                           | Description                                                                          | Use case                                                   |
-| ------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| `base`                          | ROS base, sudo, pipx, ansible, RMW, user `aw`                                        | Foundation for all other images                            |
-| `core-dependencies`             | Build deps + compiled core packages (except autoware_core and autoware_rviz_plugins) | CI for autoware_core                                       |
-| `core-devel`                    | Adds autoware_core build on top of core-dependencies                                 | Development and CI for packages depending on autoware_core |
-| `core`                          | Runtime-only: rosdep exec deps + compiled core from core-devel                       | Lightweight core runtime                                   |
-| `universe-dependencies`         | Ansible universe roles + rosdep build deps for all of autoware                       | CI for autoware_universe                                   |
-| `universe-dependencies-cuda`    | Adds CUDA, TensorRT, spconv dev libs                                                 | CI for CUDA-dependent packages                             |
-| `universe-devel`                | Builds all universe sources (no CUDA)                                                | Development without GPU                                    |
-| `universe-devel-cuda`           | Builds all universe sources with CUDA                                                | Development with GPU                                       |
-| `universe-runtime-dependencies` | Runtime ansible roles + rosdep exec deps                                             | Foundation for final runtime images                        |
-| `universe`                      | Runtime image with compiled autoware (no CUDA)                                       | Deployment without GPU                                     |
-| `universe-cuda`                 | Runtime image with compiled autoware + CUDA runtime libs                             | Deployment with GPU                                        |
+| Image                        | Description                                                                           | Use case                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `base`                       | ROS base, sudo, pipx, ansible, RMW, user `aw`                                         | Foundation for all other images                            |
+| `core-dependencies`          | Build deps + compiled core packages (except autoware_core and autoware_rviz_plugins)  | CI for autoware_core                                       |
+| `core-devel`                 | Adds autoware_core build on top of core-dependencies                                  | Development and CI for packages depending on autoware_core |
+| `core`                       | Runtime-only: rosdep exec deps + compiled core from core-devel                        | Lightweight core runtime                                   |
+| `base-cuda-runtime`          | `base` + CUDA/cuDNN/TensorRT runtime libs (no `-dev` packages)                        | Runtime foundation for `universe-cuda`                     |
+| `base-cuda-devel`            | `base-cuda-runtime` + CUDA/cuDNN/TensorRT dev headers                                 | Build foundation for CUDA universe packages                |
+| `universe-dependencies`      | Acados + rosdep build deps for all of autoware (non-CUDA path)                        | CI for autoware_universe                                   |
+| `universe-dependencies-cuda` | Core ansible roles + acados + rosdep build deps, inherits CUDA from `base-cuda-devel` | CI for CUDA-dependent packages                             |
+| `universe-devel`             | Builds all universe sources (no CUDA)                                                 | Development without GPU                                    |
+| `universe-devel-cuda`        | Builds all universe sources with CUDA                                                 | Development with GPU                                       |
+| `universe`                   | Runtime image with compiled autoware (no CUDA)                                        | Deployment without GPU                                     |
+| `universe-cuda`              | Runtime image with compiled autoware, inherits CUDA runtime from `base-cuda-runtime`  | Deployment with GPU                                        |
 
 ## Pull from GHCR
 
@@ -64,19 +63,20 @@ Tag pattern: `<stage>-<ros_distro>[-<date>|-<version>]`
 
 Available images (replace `jazzy` with `humble` for other distros):
 
-| Tag                                   | Description                                       |
-| ------------------------------------- | ------------------------------------------------- |
-| `base-jazzy`                          | ROS base + ansible + user aw                      |
-| `core-dependencies-jazzy`             | Build deps + core packages (except autoware_core) |
-| `core-devel-jazzy`                    | Full core development image                       |
-| `core-jazzy`                          | Lightweight core runtime                          |
-| `universe-dependencies-jazzy`         | Universe build dependencies                       |
-| `universe-dependencies-cuda-jazzy`    | Universe + CUDA dev libs                          |
-| `universe-devel-jazzy`                | Full universe development (no CUDA)               |
-| `universe-devel-cuda-jazzy`           | Full universe development with CUDA               |
-| `universe-runtime-dependencies-jazzy` | Universe runtime dependencies                     |
-| `universe-jazzy`                      | Runtime without GPU                               |
-| `universe-cuda-jazzy`                 | Runtime with GPU                                  |
+| Tag                                | Description                                       |
+| ---------------------------------- | ------------------------------------------------- |
+| `base-jazzy`                       | ROS base + ansible + user aw                      |
+| `core-dependencies-jazzy`          | Build deps + core packages (except autoware_core) |
+| `core-devel-jazzy`                 | Full core development image                       |
+| `core-jazzy`                       | Lightweight core runtime                          |
+| `base-cuda-runtime-jazzy`          | base + CUDA/cuDNN/TensorRT runtime                |
+| `base-cuda-devel-jazzy`            | base-cuda-runtime + CUDA/cuDNN/TensorRT dev       |
+| `universe-dependencies-jazzy`      | Universe build dependencies (no CUDA)             |
+| `universe-dependencies-cuda-jazzy` | Universe build deps on base-cuda-devel            |
+| `universe-devel-jazzy`             | Full universe development (no CUDA)               |
+| `universe-devel-cuda-jazzy`        | Full universe development with CUDA               |
+| `universe-jazzy`                   | Runtime without GPU                               |
+| `universe-cuda-jazzy`              | Runtime with GPU                                  |
 
 ## Build locally
 

--- a/docker-new/base-cuda.Dockerfile
+++ b/docker-new/base-cuda.Dockerfile
@@ -1,0 +1,52 @@
+# check=skip=InvalidDefaultArgInFrom
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE} AS base-cuda-runtime
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+
+USER ${USERNAME}
+# hadolint ignore=DL3003
+RUN --mount=type=bind,source=ansible-galaxy-requirements.yaml,target=/tmp/ansible/ansible-galaxy-requirements.yaml \
+    --mount=type=bind,source=ansible/galaxy.yml,target=/tmp/ansible/ansible/galaxy.yml \
+    --mount=type=bind,source=ansible/roles/cuda,target=/tmp/ansible/ansible/roles/cuda \
+    --mount=type=bind,source=ansible/roles/tensorrt,target=/tmp/ansible/ansible/roles/tensorrt \
+    --mount=type=bind,source=ansible/roles/spconv,target=/tmp/ansible/ansible/roles/spconv \
+    --mount=type=bind,source=ansible/playbooks/nvidia.yaml,target=/tmp/ansible/ansible/playbooks/nvidia.yaml \
+    --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=pipx-cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    cd /tmp/ansible && \
+    ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml && \
+    ansible-playbook autoware.dev_env.nvidia \
+      -e install_devel=N \
+      -e cuda_install_drivers=false && \
+    pipx uninstall ansible
+USER root
+
+ENV PATH="/usr/local/cuda/bin${PATH:+:$PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+FROM base-cuda-runtime AS base-cuda-devel
+ARG ROS_DISTRO
+
+USER ${USERNAME}
+# hadolint ignore=DL3003
+RUN --mount=type=bind,source=ansible-galaxy-requirements.yaml,target=/tmp/ansible/ansible-galaxy-requirements.yaml \
+    --mount=type=bind,source=ansible/galaxy.yml,target=/tmp/ansible/ansible/galaxy.yml \
+    --mount=type=bind,source=ansible/roles/cuda,target=/tmp/ansible/ansible/roles/cuda \
+    --mount=type=bind,source=ansible/roles/tensorrt,target=/tmp/ansible/ansible/roles/tensorrt \
+    --mount=type=bind,source=ansible/roles/spconv,target=/tmp/ansible/ansible/roles/spconv \
+    --mount=type=bind,source=ansible/playbooks/nvidia.yaml,target=/tmp/ansible/ansible/playbooks/nvidia.yaml \
+    --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=pipx-cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    cd /tmp/ansible && \
+    ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml && \
+    ansible-playbook autoware.dev_env.nvidia \
+      -e install_devel=y \
+      -e cuda_install_drivers=false && \
+    pipx uninstall ansible
+USER root

--- a/docker-new/base.Dockerfile
+++ b/docker-new/base.Dockerfile
@@ -20,8 +20,9 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
         sed -E -i 's|http://archive\.ubuntu\.com/ubuntu/?|mirror+file:///etc/apt/ubuntu-mirrors.list|g' "$f"; \
       fi; \
     done
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+
+RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     sudo \
@@ -46,20 +47,22 @@ ENV ANSIBLE_COLLECTIONS_PATH="/home/${USERNAME}/.ansible/collections"
 
 # hadolint ignore=DL3003
 RUN --mount=type=bind,source=ansible-galaxy-requirements.yaml,target=/tmp/ansible/ansible-galaxy-requirements.yaml \
-    --mount=type=bind,source=ansible,target=/tmp/ansible/ansible \
-    --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    --mount=type=bind,source=ansible/galaxy.yml,target=/tmp/ansible/ansible/galaxy.yml \
+    --mount=type=bind,source=ansible/roles/rmw_implementation,target=/tmp/ansible/ansible/roles/rmw_implementation \
+    --mount=type=bind,source=ansible/playbooks/rmw.yaml,target=/tmp/ansible/ansible/playbooks/rmw.yaml \
+    --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=pipx-cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
     pipx install --include-deps "ansible==10.*" && \
     cd /tmp/ansible && \
     ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml && \
-    ansible-playbook autoware.dev_env.autoware_requirements \
-      --tags rmw \
+    ansible-playbook autoware.dev_env.rmw \
       -e rosdistro=${ROS_DISTRO} && \
     pipx uninstall ansible
 
 COPY docker-new/files/cyclonedds.xml /home/${USERNAME}/cyclonedds.xml
 ENV CYCLONEDDS_URI=file:///home/${USERNAME}/cyclonedds.xml
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 # Entrypoint runs as root so it can adjust UID/GID, then drops to user
 USER root

--- a/docker-new/docker-bake.hcl
+++ b/docker-new/docker-bake.hcl
@@ -49,8 +49,8 @@ function "ctx" {
 group "default" {
   targets = ["base",
              "core-dependencies", "core-devel", "core",
-             "universe-dependencies", "universe-devel",
-             "universe-runtime-dependencies", "universe",
+             "base-cuda-runtime", "base-cuda-devel",
+             "universe-dependencies", "universe-devel", "universe",
              "universe-dependencies-cuda", "universe-devel-cuda", "universe-cuda"]
 }
 
@@ -62,9 +62,12 @@ group "ci-core" {
   targets = ["core-dependencies", "core-devel", "core"]
 }
 
+group "ci-base-cuda" {
+  targets = ["base-cuda-runtime", "base-cuda-devel"]
+}
+
 group "ci-universe" {
-  targets = ["universe-dependencies", "universe-devel",
-             "universe-runtime-dependencies", "universe"]
+  targets = ["universe-dependencies", "universe-devel", "universe"]
 }
 
 group "ci-universe-cuda" {
@@ -89,6 +92,7 @@ target "core-dependencies" {
   }
   args = {
     BASE_IMAGE = "autoware-base"
+    ROS_DISTRO = ROS_DISTRO
   }
 }
 
@@ -101,6 +105,7 @@ target "core-devel" {
   }
   args = {
     BASE_IMAGE = "autoware-base"
+    ROS_DISTRO = ROS_DISTRO
   }
 }
 
@@ -113,6 +118,33 @@ target "core" {
   }
   args = {
     BASE_IMAGE = "autoware-base"
+    ROS_DISTRO = ROS_DISTRO
+  }
+}
+
+target "base-cuda-runtime" {
+  dockerfile = "docker-new/base-cuda.Dockerfile"
+  target     = "base-cuda-runtime"
+  tags       = tags("base-cuda-runtime")
+  contexts = {
+    autoware-base = ctx("base")
+  }
+  args = {
+    BASE_IMAGE = "autoware-base"
+    ROS_DISTRO = ROS_DISTRO
+  }
+}
+
+target "base-cuda-devel" {
+  dockerfile = "docker-new/base-cuda.Dockerfile"
+  target     = "base-cuda-devel"
+  tags       = tags("base-cuda-devel")
+  contexts = {
+    autoware-base = ctx("base")
+  }
+  args = {
+    BASE_IMAGE = "autoware-base"
+    ROS_DISTRO = ROS_DISTRO
   }
 }
 
@@ -125,6 +157,7 @@ target "_universe-base" {
   args = {
     CORE_DEVEL_IMAGE = "autoware-core-devel"
     CORE_IMAGE       = "autoware-core"
+    ROS_DISTRO       = ROS_DISTRO
   }
 }
 
@@ -134,28 +167,10 @@ target "universe-dependencies" {
   tags     = tags("universe-dependencies")
 }
 
-target "universe-dependencies-cuda" {
-  inherits = ["_universe-base"]
-  target   = "universe-dependencies-cuda"
-  tags     = tags("universe-dependencies-cuda")
-}
-
-target "universe-devel-cuda" {
-  inherits = ["_universe-base"]
-  target   = "universe-devel-cuda"
-  tags     = tags("universe-devel-cuda")
-}
-
 target "universe-devel" {
   inherits = ["_universe-base"]
   target   = "universe-devel"
   tags     = tags("universe-devel")
-}
-
-target "universe-runtime-dependencies" {
-  inherits = ["_universe-base"]
-  target   = "universe-runtime-dependencies"
-  tags     = tags("universe-runtime-dependencies")
 }
 
 target "universe" {
@@ -164,8 +179,34 @@ target "universe" {
   tags     = tags("universe")
 }
 
+target "_universe-cuda-base" {
+  dockerfile = "docker-new/universe-cuda.Dockerfile"
+  contexts = {
+    autoware-base-cuda-runtime = ctx("base-cuda-runtime")
+    autoware-base-cuda-devel   = ctx("base-cuda-devel")
+    autoware-core-devel        = ctx("core-devel")
+  }
+  args = {
+    BASE_CUDA_RUNTIME_IMAGE = "autoware-base-cuda-runtime"
+    BASE_CUDA_DEVEL_IMAGE   = "autoware-base-cuda-devel"
+    ROS_DISTRO              = ROS_DISTRO
+  }
+}
+
+target "universe-dependencies-cuda" {
+  inherits = ["_universe-cuda-base"]
+  target   = "universe-dependencies-cuda"
+  tags     = tags("universe-dependencies-cuda")
+}
+
+target "universe-devel-cuda" {
+  inherits = ["_universe-cuda-base"]
+  target   = "universe-devel-cuda"
+  tags     = tags("universe-devel-cuda")
+}
+
 target "universe-cuda" {
-  inherits = ["_universe-base"]
+  inherits = ["_universe-cuda-base"]
   target   = "universe-cuda"
   tags     = tags("universe-cuda")
 }

--- a/docker-new/universe-cuda.Dockerfile
+++ b/docker-new/universe-cuda.Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1
-# check=skip=InvalidDefaultArgInFrom
-ARG BASE_IMAGE
+# check=skip=InvalidDefaultArgInFrom,UndefinedVar
+ARG BASE_CUDA_RUNTIME_IMAGE
+ARG BASE_CUDA_DEVEL_IMAGE
 
-FROM ${BASE_IMAGE} AS core-dependencies
+FROM ${BASE_CUDA_DEVEL_IMAGE} AS universe-dependencies-cuda
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
@@ -18,78 +19,54 @@ RUN --mount=type=bind,source=ansible-galaxy-requirements.yaml,target=/tmp/ansibl
     cd /tmp/ansible && \
     ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml && \
     ansible-playbook autoware.dev_env.autoware_requirements \
-      --tags core \
-      --skip-tags base \
+      --tags core,acados \
+      --skip-tags base,nvidia \
       -e "rosdistro=${ROS_DISTRO}" && \
+    sudo rm -rf /opt/acados/.git /opt/acados/examples /opt/acados/docs /opt/acados/test && \
     pipx uninstall ansible
 USER root
 
 ENV CC="/usr/lib/ccache/gcc"
 ENV CXX="/usr/lib/ccache/g++"
 ENV CCACHE_DIR="/home/aw/.ccache"
+ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+ENV ACADOS_SOURCE_DIR="/opt/acados"
+ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-COPY --parents --chown=${USERNAME}:${USERNAME} src/core/**/package.xml /tmp/autoware/
-RUN rm -rf /tmp/autoware/src/core/autoware_core /tmp/autoware/src/core/autoware_rviz_plugins
+# hadolint ignore=DL3022
+COPY --from=autoware-core-devel /opt/autoware /opt/autoware
+
+COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/autoware/
 
 RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
     apt-get update && \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
-    rosdep install -y --from-paths /tmp/autoware/src/core \
+    . /opt/autoware/setup.sh && \
+    rosdep install -y --from-paths /tmp/autoware/src \
       --ignore-src \
       --rosdistro "${ROS_DISTRO}" \
       --dependency-types=build \
       --dependency-types=build_export \
       --dependency-types=buildtool \
       --dependency-types=buildtool_export \
-      --dependency-types=test
+      --dependency-types=test && \
+    rm -rf /tmp/autoware
 
-RUN --mount=type=bind,source=src/core,target=/tmp/autoware/src/core,rw \
-    --mount=type=cache,id=ccache-${ROS_DISTRO},target=/home/aw/.ccache,uid=1000,gid=1000 \
-    rm -rf /tmp/autoware/src/core/autoware_core \
-           /tmp/autoware/src/core/autoware_rviz_plugins && \
-    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
-    colcon build \
-      --base-paths /tmp/autoware/src/core \
-      --install-base /opt/autoware \
-      --cmake-args -DCMAKE_BUILD_TYPE=Release && \
-    rm -rf build log
-
-FROM core-dependencies AS core-devel
+FROM universe-dependencies-cuda AS universe-devel-cuda
 ARG ROS_DISTRO
 
-COPY --parents --chown=${USERNAME}:${USERNAME} \
-    src/core/autoware_core/**/package.xml \
-    src/core/autoware_rviz_plugins/**/package.xml \
-    /tmp/autoware/
-
-RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && \
-    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
-    . /opt/autoware/setup.sh && \
-    rosdep install -y --from-paths /tmp/autoware/src/core \
-      --ignore-src \
-      --rosdistro "${ROS_DISTRO}" \
-      --dependency-types=build \
-      --dependency-types=build_export \
-      --dependency-types=buildtool \
-      --dependency-types=buildtool_export \
-      --dependency-types=test
-
-RUN --mount=type=bind,source=src/core/autoware_core,target=/tmp/autoware/src/core/autoware_core \
-    --mount=type=bind,source=src/core/autoware_rviz_plugins,target=/tmp/autoware/src/core/autoware_rviz_plugins \
-    --mount=type=cache,id=ccache-${ROS_DISTRO},target=/home/aw/.ccache,uid=1000,gid=1000 \
+RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
+    --mount=type=cache,id=ccache-${ROS_DISTRO},target=/home/aw/.ccache,uid=1000,gid=1000,sharing=shared \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
     . /opt/autoware/setup.sh && \
     colcon build \
-      --base-paths /tmp/autoware/src/core/autoware_core \
-                   /tmp/autoware/src/core/autoware_rviz_plugins \
+      --base-paths /tmp/autoware/src \
       --install-base /opt/autoware \
       --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     rm -rf build log
 
-FROM ${BASE_IMAGE} AS core
+FROM ${BASE_CUDA_RUNTIME_IMAGE} AS universe-cuda
 ARG ROS_DISTRO
 ENV AUTOWARE_RUNTIME=1
 
@@ -111,18 +88,23 @@ RUN --mount=type=bind,source=ansible-galaxy-requirements.yaml,target=/tmp/ansibl
     pipx uninstall ansible
 USER root
 
-COPY --from=core-devel /opt/autoware /opt/autoware
-RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +
-
-COPY --parents src/core/**/package.xml /tmp/
+COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/
 
 RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
     apt-get update && \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
-    sudo apt-get install -y "ros-${ROS_DISTRO}-topic-tools" && \
-    rosdep install -y --from-paths /tmp/src/core \
+    sudo apt-get install -y --no-install-recommends "ros-${ROS_DISTRO}-topic-tools" && \
+    rosdep install -y --from-paths /tmp/src \
       --dependency-types=exec \
       --ignore-src \
       --rosdistro "${ROS_DISTRO}" && \
     rm -rf /tmp/src
+
+COPY --from=universe-devel-cuda /opt/acados /opt/acados
+COPY --from=universe-devel-cuda /opt/autoware /opt/autoware
+RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +
+
+ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+ENV ACADOS_SOURCE_DIR="/opt/acados"
+ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"

--- a/docker-new/universe.Dockerfile
+++ b/docker-new/universe.Dockerfile
@@ -5,18 +5,16 @@ ARG CORE_IMAGE
 
 FROM ${CORE_DEVEL_IMAGE} AS universe-dependencies
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
 
-# Install universe ansible roles (repeated in universe-runtime-dependencies below
-# because that stage starts from a different base image and cannot share layers)
 USER ${USERNAME}
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/home/aw/.cache/pip,uid=1000,gid=1000 \
-    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=pip-cache,target=/home/aw/.cache/pip,uid=1000,gid=1000 \
+    --mount=type=cache,id=pipx-cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
     pipx install --include-deps "ansible==10.*" && \
     ansible-playbook autoware.dev_env.autoware_requirements \
-      --tags universe \
-      --skip-tags core,nvidia,artifacts \
+      --tags acados \
       -e "rosdistro=${ROS_DISTRO}" && \
     sudo rm -rf /opt/acados/.git /opt/acados/examples /opt/acados/docs /opt/acados/test && \
     pipx uninstall ansible
@@ -28,8 +26,8 @@ ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/autoware/
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
     apt-get update && \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
     . /opt/autoware/setup.sh && \
@@ -40,42 +38,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       --dependency-types=build_export \
       --dependency-types=buildtool \
       --dependency-types=buildtool_export \
-      --dependency-types=test
-
-FROM universe-dependencies AS universe-dependencies-cuda
-
-USER ${USERNAME}
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
-    pipx install --include-deps "ansible==10.*" && \
-    ansible-playbook autoware.dev_env.autoware_requirements \
-      --tags nvidia \
-      -e "rosdistro=${ROS_DISTRO}" \
-      -e install_devel=y \
-      -e cuda_install_drivers=false && \
-    pipx uninstall ansible
-USER root
-
-ENV PATH="/usr/local/cuda/bin${PATH:+:$PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-
-FROM universe-dependencies-cuda AS universe-devel-cuda
-
-RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
-    --mount=type=cache,target=/home/aw/.ccache,uid=1000,gid=1000,sharing=shared \
-    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
-    . /opt/autoware/setup.sh && \
-    colcon build \
-      --base-paths /tmp/autoware/src \
-      --install-base /opt/autoware \
-      --cmake-args -DCMAKE_BUILD_TYPE=Release && \
-    rm -rf build log
+      --dependency-types=test && \
+    rm -rf /tmp/autoware
 
 FROM universe-dependencies AS universe-devel
+ARG ROS_DISTRO
 
 RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
-    --mount=type=cache,target=/home/aw/.ccache,uid=1000,gid=1000,sharing=shared \
+    --mount=type=cache,id=ccache-${ROS_DISTRO},target=/home/aw/.ccache,uid=1000,gid=1000,sharing=shared \
     CCACHE_READONLY=1 \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
     . /opt/autoware/setup.sh && \
@@ -85,31 +55,14 @@ RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
       --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     rm -rf build log
 
-FROM ${CORE_IMAGE} AS universe-runtime-dependencies
+FROM ${CORE_IMAGE} AS universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-USER ${USERNAME}
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/home/aw/.cache/pip,uid=1000,gid=1000 \
-    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
-    pipx install --include-deps "ansible==10.*" && \
-    ansible-playbook autoware.dev_env.autoware_requirements \
-      --tags universe \
-      --skip-tags core,nvidia,artifacts \
-      -e "rosdistro=${ROS_DISTRO}" && \
-    sudo rm -rf /opt/acados/.git /opt/acados/examples /opt/acados/docs /opt/acados/test && \
-    pipx uninstall ansible
-USER root
-
-ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
-ENV ACADOS_SOURCE_DIR="/opt/acados"
-ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+ARG ROS_DISTRO
 
 COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
     apt-get update && \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
     . /opt/autoware/setup.sh && \
@@ -119,28 +72,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       --rosdistro "${ROS_DISTRO}" && \
     rm -rf /tmp/src
 
-FROM universe-runtime-dependencies AS universe
-
+COPY --from=universe-devel /opt/acados /opt/acados
 COPY --from=universe-devel /opt/autoware /opt/autoware
 RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +
 
-FROM universe-runtime-dependencies AS universe-cuda
-
-USER ${USERNAME}
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
-    pipx install --include-deps "ansible==10.*" && \
-    ansible-playbook autoware.dev_env.autoware_requirements \
-      --tags nvidia \
-      -e "rosdistro=${ROS_DISTRO}" \
-      -e install_devel=N \
-      -e cuda_install_drivers=false && \
-    pipx uninstall ansible
-USER root
-
-ENV PATH="/usr/local/cuda/bin${PATH:+:$PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-
-COPY --from=universe-devel-cuda /opt/autoware /opt/autoware
-RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +
+ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+ENV ACADOS_SOURCE_DIR="/opt/acados"
+ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"


### PR DESCRIPTION
- **Parent Issue:** #6852
- **Image graph.** Add `base-cuda-runtime` / `base-cuda-devel` stages in [`docker-new/base-cuda.Dockerfile`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/docker-new/base.Dockerfile) and rebase `universe-cuda` off them (was stacked on `universe`). Drop `universe-runtime-dependencies` — `universe` copies directly from `universe-devel`. New bake group `ci-base-cuda`.
- **Ansible split.** New [`ansible/playbooks/rmw.yaml`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/ansible/playbooks/autoware_requirements.yaml) and `nvidia.yaml`; Dockerfiles bind-mount only the role + playbook files they actually invoke (`ansible/roles/rmw_implementation`, `ansible/roles/nvidia_*`). Shrinks the bind-mount tree and the cache-invalidation surface.
- **Named BuildKit mounts.** Every `RUN --mount=type=cache,...` now carries an explicit `id=` (`apt-cache-${ROS_DISTRO}`, `apt-lists-${ROS_DISTRO}`, `ccache-${ROS_DISTRO}`, `pip-cache`, `pipx-cache`). Required for `buildkit-cache-dance` to round-trip mount state between runs.
- **Per-arch CI.** [`docker-build-pipeline-new.yaml`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/.github/workflows/docker-build-pipeline-new.yaml) takes a `platform` input; [`docker-build-and-push-new.yaml`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/.github/workflows/docker-build-and-push-new.yaml) fans out to `humble-amd64` / `humble-arm64` / `jazzy-amd64` / `jazzy-arm64`. Multi-arch manifest stitching extracted to a dedicated [`docker-manifest-new.yaml`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/.github/workflows/docker-build-new.yaml) run after both arches succeed.
- **Mount-cache persistence.** [`docker-build-new.yaml`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/.github/workflows/docker-build-new.yaml) saves/restores BuildKit mount tarballs via `actions/cache` + `buildkit-cache-dance`, with a size guard and lineage pruning (largest-per-lineage kept on main pushes; stale entries discarded). This is the SAVE side that #7032 reads from.
- **Entrypoint.** Bake `ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` into `base` so every downstream stage inherits it without relying on runtime-env override.

## Why

Previously `universe-cuda` stacked on `universe-dependencies`, so a change to either branch forced the other to rebuild and both branches shared one apt cache key — meaning the huge CUDA / cuDNN / TensorRT payload poisoned non-CUDA tarballs. Splitting CUDA into its own base plus per-arch CI jobs lets each branch cache independently, enables parallel amd64/arm64 builds, and matches the docker-new "Ansible-first" convention (version pins live in role `defaults/main.yaml`). Persisting BuildKit mount caches across runs turns cold builds into near-hot ones and is what lets health-check (#7032) reuse apt/ccache/pip/pipx state without spending compute.

---

- 5 of 6 PRs splitting #7025. Builds on #7032 (merged).
- Last PR in the stack (`docker-new/examples/`) follows this one.

## Test plan

- [ ] Dispatched `docker-build-and-push-new` against this branch: https://github.com/autowarefoundation/autoware/actions/runs/24580553216 — expect all four per-arch pipelines and both manifest jobs to succeed.
- [x] Inspect the rewired bake graph:
  ```bash
  docker buildx bake -f docker-new/docker-bake.hcl --print default | jq '{groups: .group | keys, targets: .target | keys}'
  ```
  Expect groups `default`, `ci-base`, `ci-core`, `ci-base-cuda`, `ci-universe`, `ci-universe-cuda`. Expect new targets `base-cuda-runtime`, `base-cuda-devel`. Expect `universe-runtime-dependencies` absent.
- [x] Verify the CI matrix on this PR: four per-arch pipeline runs (`humble-amd64`, `humble-arm64`, `jazzy-amd64`, `jazzy-arm64`) each executing `build-base` → `build-core` → `build-universe` plus `build-base-cuda` → `build-universe-cuda`; then `humble-manifest` / `jazzy-manifest` stitching the multi-arch tags after both arches succeed.
- [ ] Build the new CUDA base locally end-to-end:
  ```bash
  ROS_DISTRO=jazzy REGISTRY=autoware PLATFORM=amd64 TAG_DATE=$(date +%Y%m%d) TAG_VERSION= TAG_REF= docker buildx bake -f docker-new/docker-bake.hcl ci-base-cuda
  ```
  Expect `autoware:base-cuda-runtime-jazzy-amd64-<date>` and `autoware:base-cuda-devel-jazzy-amd64-<date>` visible in `docker images`.
- [ ] After this lands on `main`, confirm the persisted mount cache: the next `ci-universe` run's `Restore BuildKit cache mounts` step reports `Cache restored from key: buildkit-mounts-ci-universe-<distro>-<platform>-<sha>`, and the prune step logs `keep: buildkit-mounts-...` for exactly one entry per lineage.
- [ ] On a subsequent `health-check` run (#7032's pipeline), confirm its read-only mount restore now hits instead of missing, via the `Cache restored from key: buildkit-mounts-ci-universe-humble-<platform>-...` log line.
- [ ] Review the rewritten [`docker-new/README.md`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/docker-new/README.md) against the new graph in [`docker-new/docker-bake.hcl`](https://github.com/autowarefoundation/autoware/blob/2dbc3fabcceb8513f08488d2cbd5ead148d9fc57/docker-new/docker-bake.hcl).
