### PR TITLE
ci(health-check): skip scenario-test when docker-build is skipped

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -26,6 +26,8 @@ jobs:
     if: ${{ needs.label-check.outputs.result == 'true' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' }}
+    outputs:
+      main-build-ran: ${{ steps.build-status.outputs.ran }}
     strategy:
       fail-fast: false
       matrix:
@@ -135,12 +137,21 @@ jobs:
             AUTOWARE_BASE_CUDA_IMAGE=${{ steps.derive.outputs.autoware_base_cuda_image }}
             LIB_DIR=${{ matrix.lib-dir }}
 
+      - name: Set main build status
+        id: build-status
+        if: ${{ matrix.build-type == 'main' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch') }}
+        run: echo "ran=true" >> $GITHUB_OUTPUT
+
       - name: Show disk space
         if: always()
         run: |
           df -h
   scenario-test:
     needs: docker-build
+    if: ${{ needs.docker-build.outputs.main-build-ran == 'true' }}
     uses: ./.github/workflows/scenario-test-reusable.yaml
     with:
       autoware_container_image: autoware:health-check-${{ github.sha }}


### PR DESCRIPTION
## Description

Fix health-check CI failing when "Build Autoware" step is skipped. Previously, the scenario-test job would fail because the Docker image artifact was not generated when no relevant files changed.

Added an output `main-build-ran` from the `docker-build` job, set to `true` only when `build-type==main` actually runs the build. The `scenario-test` job now only runs when this output is `true`.

## Related links

None.

## How was this PR tested?

CI (automated on PR).

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

- Build runs (main) → scenario-test runs (same as before)
- Build skipped → scenario-test skipped (no more failure)