### PR TITLE
docs(docker-new): add compose examples (basic + awsim + planning-sim)

### DIFF
--- a/docker-new/examples/README.md
+++ b/docker-new/examples/README.md
@@ -1,0 +1,14 @@
+# Examples
+
+Docker Compose examples for running Autoware with the `docker-new` images.
+
+## Basic
+
+Minimal dev shells — `dev-cpu`, `dev-dri`, `dev-nvidia`. Pick the one matching your GPU. See [basic/README.md](basic/README.md).
+
+## Demos
+
+Pre-configured scenarios that launch autoware on container start.
+
+- [planning-simulator/README.md](demos/planning-simulator/README.md)
+- [awsim/README.md](demos/awsim/README.md)

--- a/docker-new/examples/basic/README.md
+++ b/docker-new/examples/basic/README.md
@@ -1,0 +1,66 @@
+# basic
+
+Three flavors of "drop me into a shell" container. All three use the `universe-devel-*` images (build tooling plus `/opt/autoware` built from source), mount `~/autoware_map` and `~/autoware_data`, forward `$DISPLAY`, and differ only in how the GPU is exposed.
+
+| Host GPU / driver            | Use          | How                                              |
+| ---------------------------- | ------------ | ------------------------------------------------ |
+| NVIDIA + proprietary driver  | `dev-nvidia` | `runtime: nvidia` injects proprietary GLX / CUDA |
+| NVIDIA + Nouveau open driver | `dev-dri`    | `/dev/dri` passthrough with Mesa nouveau         |
+| Intel / AMD                  | `dev-dri`    | `/dev/dri` passthrough with Mesa iris / radeonsi |
+| No GPU / headless CI         | `dev-cpu`    | forces Mesa `llvmpipe` software rendering        |
+
+`dev-nvidia` uses `universe-devel-cuda-jazzy`; the other two use `universe-devel-jazzy`.
+
+On NVIDIA hosts running the proprietary driver, `dev-dri` silently falls back to `llvmpipe` (no `nvidia-drm` loader in Mesa) — use `dev-nvidia` instead. Software rendering is fine for text-heavy rviz but laggy on dense point clouds.
+
+Verify you actually got hardware acceleration inside the container:
+
+```bash
+glxinfo -B | grep -E "OpenGL (vendor|renderer)"
+```
+
+You want to see your GPU (`NVIDIA Corporation` / `AMD Radeon...` / `Mesa Intel...`), not `llvmpipe`.
+
+## Run
+
+```bash
+# Allow the container to connect to the host X server
+xhost +local:docker
+
+# Pick one
+COMPOSE=docker-new/examples/basic/dev-cpu.compose.yaml
+COMPOSE=docker-new/examples/basic/dev-dri.compose.yaml
+COMPOSE=docker-new/examples/basic/dev-nvidia.compose.yaml
+
+HOST_UID=$(id -u) HOST_GID=$(id -g) \
+  docker compose -f "$COMPOSE" run --rm autoware
+```
+
+`HOST_UID` / `HOST_GID` are forwarded so the entrypoint can remap the in-container `aw` user to match your host UID/GID; without them, files created in mounted volumes would be owned by the wrong user. The compose files default both to `1000` — you can drop the prefix if your host UID/GID are 1000.
+
+Inside the container, `/opt/autoware` holds the prebuilt install space. The devel images don't source it automatically — you do that yourself before running ROS 2 commands:
+
+```bash
+source /opt/autoware/setup.bash
+ros2 doctor   # quick smoke test: RMW, topics, node discovery
+```
+
+See `demos/` for pre-configured launches (planning-simulator, awsim).
+
+## Attaching a second terminal
+
+`docker compose run` creates a one-off container that disappears when you exit. To open more shells in the same container, start it detached with `up` instead:
+
+```bash
+# Terminal 1 — start the container in the background
+HOST_UID=$(id -u) HOST_GID=$(id -g) \
+  docker compose -f "$COMPOSE" up -d
+
+# Terminal 2, 3, ... — attach a new bash shell
+docker compose -f "$COMPOSE" exec autoware /docker-entrypoint.sh bash
+
+# Any terminal — tear it down when you're done
+docker compose -f "$COMPOSE" down
+```
+
+Running `bash` through `/docker-entrypoint.sh` is what `docker compose up` does for you on the first shell. It drops to the `aw` user and sources `/opt/ros/$ROS_DISTRO/setup.bash` before handing you the prompt. Without it, `docker exec` lands you as `root` with no ROS environment.

--- a/docker-new/examples/basic/dev-cpu.compose.yaml
+++ b/docker-new/examples/basic/dev-cpu.compose.yaml
@@ -1,0 +1,17 @@
+services:
+  autoware:
+    image: ghcr.io/autowarefoundation/autoware-new:universe-devel-jazzy
+    privileged: true
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+      - QT_X11_NO_MITSHM=1
+      - LIBGL_ALWAYS_SOFTWARE=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${HOME}/autoware_map:/home/aw/autoware_map
+      - ${HOME}/autoware_data:/home/aw/autoware_data
+    command: bash

--- a/docker-new/examples/basic/dev-dri.compose.yaml
+++ b/docker-new/examples/basic/dev-dri.compose.yaml
@@ -1,0 +1,21 @@
+services:
+  autoware:
+    image: ghcr.io/autowarefoundation/autoware-new:universe-devel-jazzy
+    privileged: true
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+      - QT_X11_NO_MITSHM=1
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+      - render
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${HOME}/autoware_map:/home/aw/autoware_map
+      - ${HOME}/autoware_data:/home/aw/autoware_data
+    command: bash

--- a/docker-new/examples/basic/dev-nvidia.compose.yaml
+++ b/docker-new/examples/basic/dev-nvidia.compose.yaml
@@ -1,0 +1,26 @@
+services:
+  autoware:
+    image: ghcr.io/autowarefoundation/autoware-new:universe-devel-cuda-jazzy
+    privileged: true
+    runtime: nvidia
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - NVIDIA_VISIBLE_DEVICES=all
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+      - QT_X11_NO_MITSHM=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${HOME}/autoware_map:/home/aw/autoware_map
+      - ${HOME}/autoware_data:/home/aw/autoware_data
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    command: bash

--- a/docker-new/examples/demos/awsim/README.md
+++ b/docker-new/examples/demos/awsim/README.md
@@ -1,0 +1,43 @@
+# awsim
+
+Bridges autoware to the [AWSIM](https://tier4.github.io/AWSIM/) Unity simulator over `network_mode: host` and launches `e2e_simulator.launch.xml`. AWSIM itself runs on the host (or elsewhere on the LAN); this container is the autoware side of the bridge.
+
+## Prerequisites
+
+- NVIDIA GPU with the NVIDIA Container Toolkit installed
+- Shinjuku map extracted to `~/autoware_map/Shinjuku-Map/map`
+- Perception model data under `~/autoware_data`
+- AWSIM running on the host and reachable on the ROS 2 graph
+- Docker Compose v2
+
+## Run
+
+```bash
+xhost +local:docker
+
+cd docker-new/examples/demos/awsim
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose run --rm awsim
+```
+
+When the launch exits the container drops into `bash` (from `exec bash` at the end of `command`) so you can inspect state. `Ctrl+D` exits and removes the container (`--rm`).
+
+The compose file defaults `HOST_UID`/`HOST_GID` to `1000`; drop the prefix if your host UID/GID are 1000.
+
+## Customizing
+
+Edit the `command:` block in `docker-compose.yaml` to change launch arguments (vehicle model, sensor kit, map path). The service uses `universe-cuda-jazzy`; swap the `image:` tag to target a different ROS distro (e.g. `universe-cuda-humble`) or point at a locally built image.
+
+`network_mode: host` is required so AWSIM's DDS traffic reaches the container; removing it will break the connection.
+
+## Launch command reference
+
+The image's entrypoint sources `/opt/autoware/setup.bash` (via `AUTOWARE_RUNTIME=1`), then the service launches:
+
+```bash
+ros2 launch autoware_launch e2e_simulator.launch.xml \
+  vehicle_model:=sample_vehicle \
+  sensor_model:=awsim_sensor_kit \
+  map_path:=/home/aw/autoware_map/Shinjuku-Map/map
+```
+
+`map_path` points inside the container; it maps to `~/autoware_map/Shinjuku-Map/map` on the host via the `volumes:` mount.

--- a/docker-new/examples/demos/awsim/docker-compose.yaml
+++ b/docker-new/examples/demos/awsim/docker-compose.yaml
@@ -1,0 +1,35 @@
+services:
+  awsim:
+    image: ghcr.io/autowarefoundation/autoware-new:universe-cuda-jazzy
+    privileged: true
+    runtime: nvidia
+    network_mode: host
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - NVIDIA_VISIBLE_DEVICES=all
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+      - QT_X11_NO_MITSHM=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${HOME}/autoware_map:/home/aw/autoware_map
+      - ${HOME}/autoware_data:/home/aw/autoware_data
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    command:
+      - bash
+      - -c
+      - |
+        ros2 launch autoware_launch e2e_simulator.launch.xml \
+          vehicle_model:=sample_vehicle \
+          sensor_model:=awsim_sensor_kit \
+          map_path:=/home/aw/autoware_map/Shinjuku-Map/map
+        exec bash

--- a/docker-new/examples/demos/planning-simulator/README.md
+++ b/docker-new/examples/demos/planning-simulator/README.md
@@ -1,0 +1,73 @@
+# planning-simulator
+
+Launches the planning simulator with the sample map, vehicle, and sensor kit using the `universe-jazzy` image. The `docker-compose.yaml` here runs the full launch command automatically on container start, then drops to `bash` so you can inspect state after the sim exits.
+
+Planning sim itself doesn't need a GPU — perception is dummy. The only reason to use GPU passthrough here is to get hardware-accelerated rviz rendering. See the NVIDIA section below.
+
+## Prerequisites
+
+- Sample map extracted to `~/autoware_map/sample-map-planning`
+- Perception model data under `~/autoware_data` (mounted but not used by this demo)
+- Docker Compose v2
+
+[Download the sample map](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/README.md) and unpack it to `~/autoware_map/sample-map-planning` before running.
+
+## Run (no GPU, software rendering)
+
+Works on any host. rviz will use Mesa's `llvmpipe` software rasterizer — fine for light views, laggy on dense point clouds.
+
+```bash
+xhost +local:docker
+
+cd docker-new/examples/demos/planning-simulator
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose run --rm planning-simulator
+```
+
+## Run (Intel / AMD hosts, hardware accel)
+
+Merge the `docker-compose.dri.yaml` overlay to pass `/dev/dri` into the container. Works with Mesa's open drivers (iris, radeonsi, nouveau). Silently falls back to `llvmpipe` on NVIDIA + proprietary driver, so use the NVIDIA overlay there instead.
+
+```bash
+xhost +local:docker
+
+cd docker-new/examples/demos/planning-simulator
+HOST_UID=$(id -u) HOST_GID=$(id -g) \
+  docker compose -f docker-compose.yaml -f docker-compose.dri.yaml \
+  run --rm planning-simulator
+```
+
+## Run (NVIDIA hosts, hardware accel)
+
+Merge the `docker-compose.nvidia.yaml` overlay to add `runtime: nvidia`, NVIDIA env, and the `deploy.devices` block. Requires the NVIDIA proprietary driver and `nvidia-container-toolkit`.
+
+```bash
+xhost +local:docker
+
+cd docker-new/examples/demos/planning-simulator
+HOST_UID=$(id -u) HOST_GID=$(id -g) \
+  docker compose -f docker-compose.yaml -f docker-compose.nvidia.yaml \
+  run --rm planning-simulator
+```
+
+## After the launch exits
+
+The `command:` block ends with `exec bash`, so when `ros2 launch` exits the container drops into an interactive shell instead of disappearing. `Ctrl+D` exits and removes the container (`--rm`).
+
+The compose file defaults `HOST_UID`/`HOST_GID` to `1000`; drop the prefix if your host UID/GID are 1000.
+
+## Customizing
+
+Edit the `command:` block in `docker-compose.yaml` to change launch arguments (different map, vehicle, sensor kit). Swap the `image:` tag to target a different ROS distro (e.g. `universe-humble`).
+
+To enable ROS 2 discovery with other hosts on the network, add `network_mode: host` to the service.
+
+## Launch command reference
+
+```bash
+ros2 launch autoware_launch planning_simulator.launch.xml \
+  map_path:=/home/aw/autoware_map/sample-map-planning \
+  vehicle_model:=sample_vehicle \
+  sensor_model:=sample_sensor_kit
+```
+
+`map_path` points inside the container; it maps to `~/autoware_map/sample-map-planning` on the host via the `volumes:` mount.

--- a/docker-new/examples/demos/planning-simulator/README.md
+++ b/docker-new/examples/demos/planning-simulator/README.md
@@ -10,7 +10,7 @@ Planning sim itself doesn't need a GPU — perception is dummy. The only reason 
 - Perception model data under `~/autoware_data` (mounted but not used by this demo)
 - Docker Compose v2
 
-[Download the sample map](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/README.md) and unpack it to `~/autoware_map/sample-map-planning` before running.
+[Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_map/sample-map-planning` before running.
 
 ## Run (no GPU, software rendering)
 

--- a/docker-new/examples/demos/planning-simulator/docker-compose.dri.yaml
+++ b/docker-new/examples/demos/planning-simulator/docker-compose.dri.yaml
@@ -1,0 +1,7 @@
+services:
+  planning-simulator:
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+      - render

--- a/docker-new/examples/demos/planning-simulator/docker-compose.nvidia.yaml
+++ b/docker-new/examples/demos/planning-simulator/docker-compose.nvidia.yaml
@@ -1,0 +1,13 @@
+services:
+  planning-simulator:
+    runtime: nvidia
+    environment:
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-new/examples/demos/planning-simulator/docker-compose.yaml
+++ b/docker-new/examples/demos/planning-simulator/docker-compose.yaml
@@ -1,0 +1,24 @@
+services:
+  planning-simulator:
+    image: ghcr.io/autowarefoundation/autoware-new:universe-jazzy
+    privileged: true
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+      - QT_X11_NO_MITSHM=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${HOME}/autoware_map:/home/aw/autoware_map
+      - ${HOME}/autoware_data:/home/aw/autoware_data
+    command:
+      - bash
+      - -c
+      - |
+        ros2 launch autoware_launch planning_simulator.launch.xml \
+          map_path:=/home/aw/autoware_map/sample-map-planning \
+          vehicle_model:=sample_vehicle \
+          sensor_model:=sample_sensor_kit
+        exec bash


### PR DESCRIPTION
- **Parent Issue:** #6852
- **basic/** — three dev-shell compose files picking the right `universe-devel-*` image for the host GPU story: [`dev-cpu.compose.yaml`](https://github.com/autowarefoundation/autoware/blob/e0baba82457bee4a7f08b12a93a7477670bb3e49/docker-new/examples/basic/dev-cpu.compose.yaml) (`LIBGL_ALWAYS_SOFTWARE=1`, no GPU), [`dev-dri.compose.yaml`](https://github.com/autowarefoundation/autoware/blob/e0baba82457bee4a7f08b12a93a7477670bb3e49/docker-new/examples/basic/dev-dri.compose.yaml) (`/dev/dri` passthrough for Mesa iris/radeonsi/nouveau), [`dev-nvidia.compose.yaml`](https://github.com/autowarefoundation/autoware/blob/e0baba82457bee4a7f08b12a93a7477670bb3e49/docker-new/examples/basic/dev-nvidia.compose.yaml) (`runtime: nvidia` + `universe-devel-cuda-jazzy`). All three forward `$DISPLAY`, mount `~/autoware_map` / `~/autoware_data`, and remap the in-container `aw` user to the host UID/GID.
- **demos/planning-simulator/** — auto-launches `planning_simulator.launch.xml` with the sample map on `universe-jazzy`. Base [`docker-compose.yaml`](https://github.com/autowarefoundation/autoware/blob/e0baba82457bee4a7f08b12a93a7477670bb3e49/docker-new/examples/demos/planning-simulator/docker-compose.yaml) ships software rendering; [`docker-compose.dri.yaml`](https://github.com/autowarefoundation/autoware/blob/e0baba82457bee4a7f08b12a93a7477670bb3e49/docker-new/examples/demos/planning-simulator/docker-compose.dri.yaml) and [`docker-compose.nvidia.yaml`](https://github.com/autowarefoundation/autoware/blob/e0baba82457bee4a7f08b12a93a7477670bb3e49/docker-new/examples/demos/planning-simulator/docker-compose.nvidia.yaml) are overlays merged via `-f base -f overlay` for Intel/AMD or NVIDIA hardware acceleration.
- **demos/awsim/** — bridges to the [AWSIM](https://tier4.github.io/AWSIM/) Unity simulator via `network_mode: host` and launches `e2e_simulator.launch.xml` on `universe-cuda-jazzy`. See [`docker-compose.yaml`](https://github.com/autowarefoundation/autoware/blob/e0baba82457bee4a7f08b12a93a7477670bb3e49/docker-new/examples/demos/awsim/docker-compose.yaml).
- **Entrypoint convention.** Demo `command:` blocks end with `exec bash` so the container drops to an interactive shell after the launch exits, instead of disappearing.

## Why

The `docker-new` images landed without any user-facing launch examples — contributors had to reverse-engineer which tag to use, how to forward X11, when to add `runtime: nvidia` vs `/dev/dri`, and how the `HOST_UID`/`HOST_GID` entrypoint remap works. These compose files are the canonical "which knob for which host" reference and pair the three GPU passthrough strategies with the three image flavors (`universe-devel`, `universe`, `universe-cuda`) we actually ship.

---

- 6 of 6 PRs splitting #7025. Final PR in the stack.
- Depends on #7033 (merged).

## Test plan

- [ ] Basic dev-shell on an NVIDIA host — expect `glxinfo -B` to report `NVIDIA Corporation`:
  ```bash
  xhost +local:docker && HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f docker-new/examples/basic/dev-nvidia.compose.yaml run --rm autoware bash -c "glxinfo -B | grep -E 'OpenGL (vendor|renderer)'"
  ```
- [ ] Basic dev-shell on an Intel/AMD host — expect `Mesa Intel...` or `AMD Radeon...`, not `llvmpipe`:
  ```bash
  xhost +local:docker && HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f docker-new/examples/basic/dev-dri.compose.yaml run --rm autoware bash -c "glxinfo -B | grep -E 'OpenGL (vendor|renderer)'"
  ```
- [ ] Basic dev-shell CPU fallback — expect `llvmpipe`:
  ```bash
  xhost +local:docker && HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f docker-new/examples/basic/dev-cpu.compose.yaml run --rm autoware bash -c "glxinfo -B | grep -E 'OpenGL (vendor|renderer)'"
  ```
- [ ] Planning simulator launches on base compose (software rendering). With `~/autoware_map/sample-map-planning` present, expect rviz to render the vector map:
  ```bash
  xhost +local:docker && HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f docker-new/examples/demos/planning-simulator/docker-compose.yaml run --rm planning-simulator
  ```
- [ ] Planning simulator NVIDIA overlay merges cleanly — expect `runtime: nvidia` in the resolved config:
  ```bash
  docker compose -f docker-new/examples/demos/planning-simulator/docker-compose.yaml -f docker-new/examples/demos/planning-simulator/docker-compose.nvidia.yaml config | grep -E "runtime|NVIDIA_"
  ```
- [ ] Planning simulator DRI overlay merges cleanly — expect `/dev/dri` in `devices:`:
  ```bash
  docker compose -f docker-new/examples/demos/planning-simulator/docker-compose.yaml -f docker-new/examples/demos/planning-simulator/docker-compose.dri.yaml config | grep -E "devices|/dev/dri"
  ```
- [ ] AWSIM demo config resolves with `network_mode: host` and `runtime: nvidia`:
  ```bash
  docker compose -f docker-new/examples/demos/awsim/docker-compose.yaml config | grep -E "network_mode|runtime"
  ```
- [ ] UID/GID remap works — inside any of the dev shells, expect the `aw` user's UID/GID to match the host:
  ```bash
  HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f docker-new/examples/basic/dev-cpu.compose.yaml run --rm autoware bash -c "id -u && id -g"
  ```
