### PR TITLE
ci(health-check-pr): always run, gate work via changed-files

### DIFF
--- a/.github/workflows/health-check-pr.yaml
+++ b/.github/workflows/health-check-pr.yaml
@@ -7,21 +7,36 @@ on:
       - synchronize
       - reopened
       - labeled
-    paths:
-      - repositories/*.repos
-      - .github/workflows/health-check.yaml
-      - .github/workflows/health-check-pr.yaml
-      - .github/workflows/health-check-reusable.yaml
-      - ansible-galaxy-requirements.yaml
-      - ansible/**
-      - docker-new/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        uses: step-security/changed-files@v47
+        with:
+          files: |
+            repositories/*.repos
+            .github/workflows/health-check.yaml
+            .github/workflows/health-check-pr.yaml
+            .github/workflows/health-check-reusable.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker-new/**
+
   require-label:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
     uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:health-check


### PR DESCRIPTION
- Drop the `pull_request.paths:` filter so the workflow triggers on every PR
- Add a `changed-files` job using `step-security/changed-files@v47` to detect whether any health-check-relevant path changed
- Gate `require-label` on the detection output; `health-check` cascades via `needs:`

## Why

When a workflow used as a required status check has a trigger-level `paths:` filter, GitHub does not trigger it on PRs that don't touch those paths. The required check then never appears, and branch protection blocks the PR forever. Skipped jobs satisfy required checks; missing workflows do not, so the workflow now always runs and skips internally instead.

- Noticed on #7034, which only touches `.github/workflows/cleanup-actions-caches.yaml` and never triggered `health-check-pr`, leaving the required check missing
- Regression introduced by #7030, which moved the `changed-files` gate from a per-step check up to a trigger-level `paths:` filter

---

## Test plan

- [ ] Open a PR that touches no relevant paths (e.g. only edits a markdown file)
  - [ ] `health-check-pr / changed-files` runs and succeeds
  - [ ] `health-check-pr / require-label` shows as **Skipped**
  - [ ] `health-check-pr / health-check` shows as **Skipped**
  - [ ] Branch protection treats the required check as satisfied (PR is mergeable)
- [ ] Open a PR that touches `docker-new/**`, `ansible/**`, or `repositories/*.repos`
  - [ ] `changed-files` reports `any_changed=true`
  - [ ] Without the `run:health-check` label: `require-label` fails, `health-check` skips
  - [ ] With the `run:health-check` label: `require-label` passes, `health-check` runs the reusable workflow
- [ ] Verify branch protection rules list job-level checks (e.g. `health-check-pr / health-check`), not the workflow file itself — only per-job skipped checks count as success