### PR TITLE
fix(docker): install iproute2 and surface entrypoint setup failures

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -28,6 +28,7 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
     sudo \
     pipx \
     bash-completion \
+    iproute2 \
     gosu
 
 # Remove default ubuntu user (present since 24.04, occupies UID 1000)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,14 +7,19 @@ if [ -n "${HOST_UID}" ] && [ -n "${HOST_GID}" ]; then
     groupmod -g "${HOST_GID}" "${USERNAME}" >/dev/null 2>&1 || true
 fi
 
+try_set() {
+    "$@" >/dev/null 2>&1 ||
+        echo "[entrypoint] WARN: failed: $* (need --privileged or --cap-add=NET_ADMIN)" >&2
+}
+
 # Enable multicast on loopback so DDS discovery works when pinned to lo
-ip link set lo multicast on >/dev/null 2>&1 || true
+try_set ip link set lo multicast on
 
 # Apply system-wide network tuning for DDS (needs --privileged or --cap-add=NET_ADMIN)
 # https://autowarefoundation.github.io/autoware-documentation/main/installation/additional-settings-for-developers/network-configuration/dds-settings/#tune-system-wide-network-settings
-sysctl -w net.core.rmem_max=2147483647 >/dev/null 2>&1 || true
-sysctl -w net.ipv4.ipfrag_time=3 >/dev/null 2>&1 || true
-sysctl -w net.ipv4.ipfrag_high_thresh=134217728 >/dev/null 2>&1 || true
+try_set sysctl -w net.core.rmem_max=2147483647
+try_set sysctl -w net.ipv4.ipfrag_time=3
+try_set sysctl -w net.ipv4.ipfrag_high_thresh=134217728
 
 # shellcheck source=/dev/null
 source "/opt/ros/${ROS_DISTRO}/setup.bash"


### PR DESCRIPTION
- Add `iproute2` to the base image so `ip link set lo multicast on` actually runs (the binary was missing, silently no-opping under `|| true`).
- Wrap entrypoint network setup in a `try_set` helper that stays silent on success and prints a `WARN` with the failing command on failure.

## Why
The entrypoint's DDS network tuning is best-effort, but the previous `>/dev/null 2>&1 || true` pattern hid two distinct failure modes: the `ip` binary wasn't installed in `ros:*-ros-base`, and when the container lacked the required capabilities users saw no indication that DDS discovery might misbehave.

---

## Test plan

- [x] `docker buildx bake -f docker/docker-bake.hcl base` succeeds.
- [x] `docker run --rm autoware:base-jazzy true` prints the expected `WARN` line and nothing else.
- [x] `docker run --rm --privileged autoware:base-jazzy true` prints no entrypoint output.