### PR TITLE
refactor(ansible): add install script and host playbook, migrate health-check workflow

### DIFF
--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -70,6 +70,21 @@ jobs:
             fi
           done
 
+      - name: Keep downloaded apt packages for cache
+        run: |
+          rm -f /etc/apt/apt.conf.d/docker-clean
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+      - name: Restore apt cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: apt-${{ matrix.image }}-${{ hashFiles('ansible/**', 'ansible-galaxy-requirements.yaml') }}
+          restore-keys: |
+            apt-${{ matrix.image }}-
+
       - name: Install dependencies
         run: |
           apt-get update

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -13,7 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        uses: step-security/changed-files@v47
+        with:
+          files: |
+            ansible/**
+            ansible-galaxy-requirements.yaml
+            .github/workflows/health-check-ansible.yaml
+
   require-label:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
     uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:health-check

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -1,4 +1,4 @@
-name: setup-universe
+name: health-check-ansible
 
 on:
   pull_request:
@@ -18,18 +18,16 @@ jobs:
     with:
       label: run:health-check
 
-  setup-universe:
+  install-dev-env:
     needs: require-label
     if: ${{ needs.require-label.outputs.result == 'true' }}
     runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image: ubuntu:22.04
-            ros_distro: humble
-          - image: ubuntu:24.04
-            ros_distro: jazzy
+        image:
+          - ubuntu:22.04
+          - ubuntu:24.04
     container:
       image: ${{ matrix.image }}
     steps:
@@ -67,6 +65,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run setup script
+      - name: Install dev environment via ansible
         run: |
-          ./setup-dev-env.sh --ros-distro ${{ matrix.ros_distro }} -y -v universe
+          bash ansible/scripts/install-ansible.sh
+          export PATH="$HOME/.local/bin:$PATH"
+          ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+          ansible-playbook autoware.dev_env.install_dev_env -v

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -70,21 +70,6 @@ jobs:
             fi
           done
 
-      - name: Keep downloaded apt packages for cache
-        run: |
-          rm -f /etc/apt/apt.conf.d/docker-clean
-          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-
-      - name: Restore apt cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: apt-${{ matrix.image }}-${{ hashFiles('ansible/**', 'ansible-galaxy-requirements.yaml') }}
-          restore-keys: |
-            apt-${{ matrix.image }}-
-
       - name: Install dependencies
         run: |
           apt-get update

--- a/ansible/playbooks/install_dev_env.yaml
+++ b/ansible/playbooks/install_dev_env.yaml
@@ -15,7 +15,7 @@
 
     - name: Print configuration
       ansible.builtin.debug:
-        msg: "Ubuntu {{ ansible_distribution_version }} -> ROS {{ rosdistro }}"
+        msg: Ubuntu {{ ansible_distribution_version }} -> ROS {{ rosdistro }}
       tags: [always]
 
   roles:

--- a/ansible/playbooks/install_dev_env.yaml
+++ b/ansible/playbooks/install_dev_env.yaml
@@ -3,6 +3,7 @@
   connection: local
   vars:
     rosdistro: "{{ {'22.04': 'humble', '24.04': 'jazzy'}[ansible_distribution_version] }}"
+    install_devel: "y" # yamllint disable-line rule:quoted-strings
   module_defaults:
     ansible.builtin.get_url:
       timeout: 300

--- a/ansible/playbooks/install_dev_env.yaml
+++ b/ansible/playbooks/install_dev_env.yaml
@@ -30,7 +30,7 @@
     - role: autoware.dev_env.rmw_implementation
       vars:
         rmw_implementation__rosdistro: "{{ rosdistro }}"
-      tags: [base, core, universe, rmw]
+      tags: [core, universe, rmw]
 
     - role: autoware.dev_env.gdown
       tags: [core, universe, gdown]
@@ -41,12 +41,20 @@
     - role: autoware.dev_env.agnocast
       tags: [core, universe, agnocast]
 
+    # Recommended development tooling
+    - role: autoware.dev_env.dev_tools
+      tags: [core, universe, dev_tools]
+
+    # Qt5ct setup (RViz theme)
+    - role: autoware.dev_env.qt5ct_setup
+      tags: [core, universe, qt5ct_setup]
+
     # Autoware runtime dependencies
     - role: autoware.dev_env.acados
       tags: [universe, acados]
 
     - role: autoware.dev_env.geographiclib
-      tags: [core, universe, geographiclib]
+      tags: [universe, geographiclib]
 
     - role: autoware.dev_env.cuda
       tags: [universe, nvidia, cuda]
@@ -57,14 +65,6 @@
     - role: autoware.dev_env.spconv
       tags: [universe, nvidia, spconv]
 
-    # Recommended development tooling
-    - role: autoware.dev_env.dev_tools
-      tags: [core, universe, dev_tools]
-
     # ONNX models and other artifacts
     - role: autoware.dev_env.artifacts
       tags: [universe, artifacts]
-
-    # Qt5ct setup (RViz theme)
-    - role: autoware.dev_env.qt5ct_setup
-      tags: [core, universe, qt5ct_setup]

--- a/ansible/playbooks/install_dev_env.yaml
+++ b/ansible/playbooks/install_dev_env.yaml
@@ -1,0 +1,69 @@
+- name: Install Autoware development environment on a host
+  hosts: localhost
+  connection: local
+  vars:
+    rosdistro: "{{ {'22.04': 'humble', '24.04': 'jazzy'}[ansible_distribution_version] }}"
+  module_defaults:
+    ansible.builtin.get_url:
+      timeout: 300
+  pre_tasks:
+    - name: Verify supported Ubuntu version
+      ansible.builtin.fail:
+        msg: Only Ubuntu 22.04 and 24.04 are supported. See https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
+      when: ansible_distribution_version not in ['22.04', '24.04']
+      tags: [always]
+
+    - name: Print configuration
+      ansible.builtin.debug:
+        msg: "Ubuntu {{ ansible_distribution_version }} -> ROS {{ rosdistro }}"
+      tags: [always]
+
+  roles:
+    # Base ROS 2 environment
+    - role: autoware.dev_env.ros2
+      tags: [core, universe, ros2]
+
+    - role: autoware.dev_env.ros2_dev_tools
+      tags: [core, universe, ros2_dev_tools]
+
+    - role: autoware.dev_env.rmw_implementation
+      vars:
+        rmw_implementation__rosdistro: "{{ rosdistro }}"
+      tags: [base, core, universe, rmw]
+
+    - role: autoware.dev_env.gdown
+      tags: [core, universe, gdown]
+
+    - role: autoware.dev_env.build_tools
+      tags: [core, universe, build_tools, ccache]
+
+    - role: autoware.dev_env.agnocast
+      tags: [core, universe, agnocast]
+
+    # Autoware runtime dependencies
+    - role: autoware.dev_env.acados
+      tags: [universe, acados]
+
+    - role: autoware.dev_env.geographiclib
+      tags: [core, universe, geographiclib]
+
+    - role: autoware.dev_env.cuda
+      tags: [universe, nvidia, cuda]
+
+    - role: autoware.dev_env.tensorrt
+      tags: [universe, nvidia, tensorrt]
+
+    - role: autoware.dev_env.spconv
+      tags: [universe, nvidia, spconv]
+
+    # Recommended development tooling
+    - role: autoware.dev_env.dev_tools
+      tags: [core, universe, dev_tools]
+
+    # ONNX models and other artifacts
+    - role: autoware.dev_env.artifacts
+      tags: [universe, artifacts]
+
+    # Qt5ct setup (RViz theme)
+    - role: autoware.dev_env.qt5ct_setup
+      tags: [core, universe, qt5ct_setup]

--- a/ansible/roles/artifacts/defaults/main.yaml
+++ b/ansible/roles/artifacts/defaults/main.yaml
@@ -1,0 +1,1 @@
+data_dir: "{{ ansible_env.HOME }}/autoware_data" # noqa: var-naming[no-role-prefix]

--- a/ansible/scripts/install-ansible.sh
+++ b/ansible/scripts/install-ansible.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Install Ansible (and its OS prerequisites) so that the playbooks under
+# autoware/ansible/ can be run.
+#
+# Does NOT install Galaxy collections or run any playbook. After this script,
+# run from the repo root:
+#   ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+#   ansible-playbook autoware.dev_env.install_dev_env [--skip-tags nvidia ...]
+
+set -euo pipefail
+
+if ! command -v sudo >/dev/null 2>&1; then
+    apt-get -y update
+    apt-get -y install sudo
+fi
+
+sudo apt-get -y update
+sudo apt-get -y install git python3-pip python3-venv pipx
+
+python3 -m pipx ensurepath
+export PATH="${PIPX_BIN_DIR:-$HOME/.local/bin}:$PATH"
+
+pipx install --include-deps --force "ansible==10.*"
+
+echo "ansible installed: $(ansible --version | head -n1)"


### PR DESCRIPTION
## Summary

- Step 1 of #7052.

- **refactor(ansible):** add install script and host dev env playbook
  - `ansible/scripts/install-ansible.sh` — bootstrap that installs OS prerequisites and ansible 10.x via pipx. Does not install Galaxy collections or invoke any playbook.
  - `ansible/playbooks/install_dev_env.yaml` — tag-driven host installation playbook. Auto-derives `rosdistro` from Ubuntu version (22.04 → humble, 24.04 → jazzy). No `vars_prompt`; selection via `--tags`/`--skip-tags`.
- **ci(ansible):** rename `setup-universe` workflow to `health-check-ansible`
  - File rename: `.github/workflows/setup-universe.yaml` → `health-check-ansible.yaml`.
  - Replaces `setup-dev-env.sh` invocation with `install-ansible.sh` + `ansible-galaxy` + `install_dev_env` playbook.
  - Job renamed from `setup-universe` to `install-dev-env`.
  - Matrix simplified: `ros_distro` removed (auto-derived from Ubuntu version).

Existing playbooks and `setup-dev-env.sh` are left in place; subsequent PRs in #7052 will rename and consolidate.

## Branch protection

If `setup-universe / setup-universe` was a required status check, update protection rules to `health-check-ansible / install-dev-env` after this lands.

## Test plan

- [ ] `run:health-check` label applied; verify `health-check-ansible / install-dev-env` succeeds on both `ubuntu:22.04` and `ubuntu:24.04` matrix legs.
- [ ] Confirm rosdistro auto-detection prints correctly in the "Print configuration" task in CI logs.