### PR TITLE
ci(ansible): split artifacts health check into its own workflow

### DIFF
--- a/.github/workflows/health-check-ansible-artifacts.yaml
+++ b/.github/workflows/health-check-ansible-artifacts.yaml
@@ -1,0 +1,72 @@
+name: health-check-ansible-artifacts
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        uses: step-security/changed-files@v47
+        with:
+          files: |
+            ansible/roles/artifacts/**
+            ansible/playbooks/install_dev_env.yaml
+            ansible/scripts/install-ansible.sh
+            ansible-galaxy-requirements.yaml
+            .github/workflows/health-check-ansible-artifacts.yaml
+
+  require-label:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
+    with:
+      label: run:health-check
+
+  install-artifacts:
+    needs: require-label
+    if: needs.require-label.outputs.result == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛒 Check out repository
+        uses: actions/checkout@v6
+
+      - name: 💾 Show disk space (before install)
+        run: df -h
+
+      - name: 🔧 Install ansible
+        run: bash ansible/scripts/install-ansible.sh
+
+      - name: 📦 Download artifacts via ansible
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+          ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -v
+
+      - name: 📊 Report artifacts size and disk space
+        run: |
+          df -h
+          size_bytes=$(du -sb "$HOME/autoware_data" 2>/dev/null | awk '{print $1+0}')
+          size_gb=$(awk -v b="${size_bytes:-0}" 'BEGIN { printf "%.2f", b/1e9 }')
+          echo "📦 Artifacts directory size: ${size_gb} GB"
+          {
+            echo "## 📦 Artifacts download"
+            echo ""
+            echo "Total size of \`$HOME/autoware_data\`: **${size_gb} GB**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -9,7 +9,7 @@ on:
       - labeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -29,6 +29,8 @@ jobs:
             ansible/**
             ansible-galaxy-requirements.yaml
             .github/workflows/health-check-ansible.yaml
+          files_ignore: |
+            ansible/roles/artifacts/**
 
   require-label:
     needs: changed-files
@@ -39,8 +41,8 @@ jobs:
 
   install-dev-env:
     needs: require-label
-    if: ${{ needs.require-label.outputs.result == 'true' }}
-    runs-on: [self-hosted, Linux, X64]
+    if: needs.require-label.outputs.result == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -50,15 +52,16 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-      - name: Check out repository
+      - name: 🛒 Check out repository
         uses: actions/checkout@v6
 
-      - name: Show disk space
-        if: always()
+      - name: 💾 Show disk space (before install)
+        id: disk-before
         run: |
           df -h
+          echo "used_bytes=$(df -B1 --output=used / | tail -1 | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
-      - name: Configure apt retries and mirror fallback
+      - name: 🌐 Configure apt and debconf
         run: |
           echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/99-retries
           echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/99-retries
@@ -69,27 +72,27 @@ jobs:
               sed -E -i 's|http://archive\.ubuntu\.com/ubuntu/?|mirror+file:///etc/apt/ubuntu-mirrors.list|g' "$f"
             fi
           done
+          echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y git sudo curl ca-certificates apt-utils
-
-      - name: Install tzdata non-interactively
-        run: |
-          DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
-
-      - name: Set git config
-        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install dev environment via ansible
+      - name: 🔧 Install dev environment via ansible
         run: |
           bash ansible/scripts/install-ansible.sh
           export PATH="$HOME/.local/bin:$PATH"
           ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
-          ansible-playbook autoware.dev_env.install_dev_env -v
+          ansible-playbook autoware.dev_env.install_dev_env --skip-tags artifacts -v
+
+      - name: 📊 Report installation disk footprint
+        run: |
+          df -h
+          used_bytes_after=$(df -B1 --output=used / | tail -1 | tr -d ' ')
+          delta=$(( used_bytes_after - ${{ steps.disk-before.outputs.used_bytes }} ))
+          delta_gb=$(awk -v b="${delta}" 'BEGIN { printf "%.2f", b/1e9 }')
+          echo "📦 Installation disk usage: ${delta_gb} GB"
+          {
+            echo "## 📦 Installation disk usage (\`${{ matrix.image }}\`)"
+            echo ""
+            echo "Root filesystem grew by **${delta_gb} GB** during the install."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   install-dev-env-required:
     needs: install-dev-env


### PR DESCRIPTION
- Split the artifacts role out of `health-check-ansible` into a new dedicated workflow `health-check-ansible-artifacts` so the large `$HOME/autoware_data` download runs on its own schedule (only when artifact-related paths change).
- Move `health-check-ansible` from self-hosted runners back to GitHub-hosted `ubuntu-latest` and drop the now-redundant apt/tzdata/git bootstrap steps (handled by [ansible/scripts/install-ansible.sh](https://github.com/autowarefoundation/autoware/blob/54adceaaecb84dfc4be26ebd49bdb947821e5167/ansible/scripts/install-ansible.sh)), skipping the `artifacts` tag.
- Report installation disk footprint in both workflows via `$GITHUB_STEP_SUMMARY` (delta for the install, total size for the artifacts download).

## Why
The artifacts download dominates disk and network in the health check, yet most ansible edits don't touch it. Isolating it gives us targeted triggers (via `files_ignore: ansible/roles/artifacts/**`), frees the main check to run on GitHub-hosted runners again, and makes disk usage visible per job.

---

## Test plan

- [x] https://github.com/autowarefoundation/autoware/actions/runs/24876935354/
- [x] https://github.com/autowarefoundation/autoware/actions/runs/24876935397/