### PR TITLE
ci(health-check): lift matrix to callers and add run-condition gate

### DIFF
--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -90,3 +90,17 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
           ansible-playbook autoware.dev_env.install_dev_env -v
+
+  install-dev-env-required:
+    needs: install-dev-env
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify install-dev-env outcome
+        run: |
+          result="${{ needs.install-dev-env.result }}"
+          echo "install-dev-env: $result"
+          case "$result" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac

--- a/.github/workflows/health-check-pr.yaml
+++ b/.github/workflows/health-check-pr.yaml
@@ -42,6 +42,26 @@ jobs:
       label: run:health-check
 
   health-check:
-    needs: require-label
+    if: ${{ always() }}
+    needs: [changed-files, require-label]
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [main, nightly, main-arm64]
+        include:
+          - build-type: main
+            platform: amd64
+            runner: "['ubuntu-24.04']"
+          - build-type: nightly
+            platform: amd64
+            runner: "['ubuntu-24.04']"
+          - build-type: main-arm64
+            platform: arm64
+            runner: "['ubuntu-24.04-arm']"
     uses: ./.github/workflows/health-check-reusable.yaml
+    with:
+      build-type: ${{ matrix.build-type }}
+      platform: ${{ matrix.platform }}
+      runner: ${{ matrix.runner }}
+      run-condition: ${{ needs.changed-files.outputs.should-run == 'true' && needs.require-label.outputs.result == 'true' }}
     secrets: inherit

--- a/.github/workflows/health-check-reusable.yaml
+++ b/.github/workflows/health-check-reusable.yaml
@@ -24,6 +24,18 @@ name: health-check-reusable
 on:
   workflow_call:
     inputs:
+      build-type:
+        description: Build-type label (e.g. main, nightly, main-arm64); drives caching lineage and conditional steps
+        type: string
+        required: true
+      platform:
+        description: Target platform (amd64 or arm64)
+        type: string
+        required: true
+      runner:
+        description: JSON array string for runs-on, e.g. "['ubuntu-24.04']"
+        type: string
+        required: true
       ros-distro:
         description: ROS distribution
         type: string
@@ -32,31 +44,22 @@ on:
         description: Max allowed size (GB) for restored BuildKit cache mounts; cache is dropped and purged if exceeded
         type: number
         default: 6
+      run-condition:
+        description: When false the job is skipped; callers always fire the matrix so required status checks report
+        type: boolean
+        default: true
 
 jobs:
   docker-build:
-    strategy:
-      fail-fast: false
-      matrix:
-        build-type: [main, nightly, main-arm64]
-        include:
-          - build-type: main
-            platform: amd64
-            runner: "['ubuntu-24.04']"
-          - build-type: nightly
-            platform: amd64
-            runner: "['ubuntu-24.04']"
-          - build-type: main-arm64
-            platform: arm64
-            runner: "['ubuntu-24.04-arm']"
-    runs-on: ${{ fromJson(matrix.runner) }}
+    if: ${{ inputs.run-condition }}
+    runs-on: ${{ fromJson(inputs.runner) }}
     permissions:
       contents: read
       packages: write
       actions: write
     env:
-      CACHE_KEY_PREFIX: buildkit-mounts-health-check-${{ matrix.build-type }}-${{ inputs.ros-distro }}-${{ matrix.platform }}-
-      CACHE_REF_PREFIX: ghcr.io/${{ github.repository }}-buildcache:health-check-${{ matrix.build-type }}-${{ inputs.ros-distro }}-${{ matrix.platform }}
+      CACHE_KEY_PREFIX: buildkit-mounts-health-check-${{ inputs.build-type }}-${{ inputs.ros-distro }}-${{ inputs.platform }}-
+      CACHE_REF_PREFIX: ghcr.io/${{ github.repository }}-buildcache:health-check-${{ inputs.build-type }}-${{ inputs.ros-distro }}-${{ inputs.platform }}
       IS_MAIN_PUSH: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     steps:
       - name: 🔧 Change permission of workspace
@@ -84,11 +87,11 @@ jobs:
           echo "::endgroup::"
 
       - name: 🧹 Free disk space
-        if: matrix.build-type != 'main'
+        if: inputs.build-type != 'main'
         uses: ./.github/actions/free-disk-space
 
       - name: 💾 Create additional swap
-        if: matrix.platform == 'arm64'
+        if: inputs.platform == 'arm64'
         run: |
           sudo fallocate -l 8G /mnt/swapfile
           sudo chmod 600 /mnt/swapfile
@@ -103,7 +106,7 @@ jobs:
           vcs import --shallow src < repositories/autoware.repos
 
       - name: 📦 Overlay nightly repos
-        if: matrix.build-type == 'nightly'
+        if: inputs.build-type == 'nightly'
         run: |
           vcs import --shallow --force src < repositories/autoware-nightly.repos
 

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -14,5 +14,23 @@ concurrency:
 
 jobs:
   health-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [main, nightly, main-arm64]
+        include:
+          - build-type: main
+            platform: amd64
+            runner: "['ubuntu-24.04']"
+          - build-type: nightly
+            platform: amd64
+            runner: "['ubuntu-24.04']"
+          - build-type: main-arm64
+            platform: arm64
+            runner: "['ubuntu-24.04-arm']"
     uses: ./.github/workflows/health-check-reusable.yaml
+    with:
+      build-type: ${{ matrix.build-type }}
+      platform: ${{ matrix.platform }}
+      runner: ${{ matrix.runner }}
     secrets: inherit


### PR DESCRIPTION
- Move the `build-type`/`platform`/`runner` matrix out of [health-check-reusable.yaml](https://github.com/autowarefoundation/autoware/blob/54adceaaecb84dfc4be26ebd49bdb947821e5167/.github/workflows/health-check-reusable.yaml) and into each caller ([health-check.yaml](https://github.com/autowarefoundation/autoware/blob/54adceaaecb84dfc4be26ebd49bdb947821e5167/.github/workflows/health-check.yaml), [health-check-pr.yaml](https://github.com/autowarefoundation/autoware/blob/54adceaaecb84dfc4be26ebd49bdb947821e5167/.github/workflows/health-check-pr.yaml)); the reusable now takes `build-type`, `platform`, and `runner` as inputs so callers can tailor the matrix independently.
- Add a `run-condition` input (default `true`) and gate the reusable's `docker-build` job with `if: inputs.run-condition`; `health-check-pr` always fires the matrix and derives `run-condition` from its `changed-files` + `require-label` gates.

## Why

**Before & After**
<img width="2123" height="429" alt="image" src="https://github.com/user-attachments/assets/bc098b5b-8098-4e60-b2ac-0239caec9869" />

Branch protection requires the health-check matrix jobs to report, but `health-check-pr` was skipping the whole job when a PR touched none of the watched paths, leaving required checks stuck on `Expected — Waiting for status to be reported`. Always-firing the matrix with an internal `run-condition` gate lets the inner job skip cleanly while still reporting a completed status, matching the pattern already used by [autoware_universe's build-and-test-packages-above-differential](https://github.com/autowarefoundation/autoware_universe/blob/main/.github/workflows/build-and-test-packages-above-differential.yaml). Lifting the matrix to callers is a natural follow-on so each trigger (main push / schedule / PR) can choose its own matrix shape.

---

**⚠️ Branch protection update required before merging.** This renames the required status check from `health-check / docker-build (main)` to `health-check (main) / docker-build` (the matrix axis now appears on the outer caller job). The `main` branch protection rule must be updated to require the new name; otherwise merges will block on the old, never-reported check.

## Test plan

- [ ] Open this PR **without** the `run:health-check` label; confirm `health-check (main) / docker-build`, `health-check (nightly) / docker-build`, and `health-check (main-arm64) / docker-build` all report **success** (matrix fires, inner job skips on `run-condition: false`).
- [ ] Add the `run:health-check` label; confirm the same three jobs re-run and actually execute the build steps (non-trivial runtime, BuildKit cache restore visible in logs).
- [ ] On a follow-up PR that touches no watched paths (e.g. a docs-only change), confirm the three matrix checks still report **success** (skipped path) and do not stay on `Expected`.
- [ ] After merge, verify the scheduled/cron run of `health-check.yaml` on `main` still executes all three matrix legs end-to-end (no `run-condition` default changes its behavior).
- [ ] Confirm branch-protection on `main` has been updated to require `health-check (main) / docker-build` (and any other legs that were previously required) before merging this PR.