### PR TITLE
feat(ansible): add install_docker.yaml and deprecate docker.yaml

### DIFF
--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: superseded by install_docker.yaml.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Set up Docker development environments for Autoware
   hosts: localhost
   connection: local

--- a/ansible/playbooks/install_docker.yaml
+++ b/ansible/playbooks/install_docker.yaml
@@ -1,0 +1,15 @@
+- name: Install Docker engine and NVIDIA container toolkit for Autoware
+  hosts: localhost
+  connection: local
+  pre_tasks:
+    - name: Print configuration
+      ansible.builtin.debug:
+        msg: Installing Docker engine. Use --skip-tags nvidia to skip the NVIDIA container toolkit.
+      tags: [always]
+
+  roles:
+    - role: autoware.dev_env.docker_engine
+      tags: [docker, docker_engine]
+
+    - role: autoware.dev_env.nvidia_container_toolkit
+      tags: [nvidia, nvidia_container_toolkit]


### PR DESCRIPTION
- **Parent Issue:** #7052
- Adds [`ansible/playbooks/install_docker.yaml`](https://github.com/autowarefoundation/autoware/blob/2440d27eda88d0f38a966c9b4c674ef0d8f63a73/ansible/playbooks/install_docker.yaml): tag-driven playbook installing `docker_engine` + `nvidia_container_toolkit`. No host-side CUDA since CUDA userspace libs belong inside the container.
- Marks [`ansible/playbooks/docker.yaml`](https://github.com/autowarefoundation/autoware/blob/2440d27eda88d0f38a966c9b4c674ef0d8f63a73/ansible/playbooks/docker.yaml) with a deprecation banner pointing to the replacement and a removal date of **2026-05-24**. File is untouched otherwise and remains fully functional.

## Why

Phase 1 (additive only) of the ansible-entrypoint consolidation tracked in #7052. External consumers reference `docker.yaml` (TIER IV internal scripts, `autowarefoundation/openadkit`), so it cannot be renamed or deleted in this PR. Landing the replacement + deprecation marker now gives consumers a ~1 month migration window before Phase 2 deletes the old file.

New playbook follows the tag-driven convention already used by `autoware_requirements.yaml` and `install_dev_env.yaml`: no `vars_prompt`, all opt-in/opt-out via `--tags`/`--skip-tags`.

---

## Test plan

- [ ] Lint passes:

  ~~~bash
  pre-commit run --files ansible/playbooks/install_docker.yaml ansible/playbooks/docker.yaml
  ~~~

- [ ] New playbook installs Docker + NVIDIA container toolkit on a clean Ubuntu 24.04 host:

  ~~~bash
  ansible-playbook ansible/playbooks/install_docker.yaml
  docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu24.04 nvidia-smi
  ~~~

- [ ] \`--skip-tags nvidia\` installs Docker only, no NVIDIA toolkit:

  ~~~bash
  ansible-playbook ansible/playbooks/install_docker.yaml --skip-tags nvidia
  docker run --rm hello-world
  ~~~

- [ ] Old \`docker.yaml\` still runs end-to-end (backwards compatibility during the deprecation window):

  ~~~bash
  ansible-playbook ansible/playbooks/docker.yaml
  ~~~

- [ ] Deprecation banner visible at the top of \`ansible/playbooks/docker.yaml\` on the PR diff view.