### PR TITLE
refactor(ansible): mark legacy entrypoints for removal

### DIFF
--- a/ansible/playbooks/download_artifacts.yaml
+++ b/ansible/playbooks/download_artifacts.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: replace with `ansible-playbook autoware.dev_env.install_dev_env --tags artifacts`.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Download Autoware artifacts
   hosts: localhost
   module_defaults:

--- a/ansible/playbooks/install_rviz_theme.yaml
+++ b/ansible/playbooks/install_rviz_theme.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: replace with `ansible-playbook autoware.dev_env.install_dev_env --tags qt5ct_setup`.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Install RViz theme
   hosts: localhost
   roles:

--- a/ansible/playbooks/install_spconv.yaml
+++ b/ansible/playbooks/install_spconv.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: replace with `ansible-playbook autoware.dev_env.install_dev_env --tags spconv`.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Download and install the cumm and spconv packages
   hosts: localhost
   roles:

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: superseded by install_dev_env.yaml.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Set up source development environments for Autoware Universe
   hosts: localhost
   connection: local

--- a/ansible/playbooks/role_rmw_implementation.yaml
+++ b/ansible/playbooks/role_rmw_implementation.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: duplicate of install_rmw.yaml (was rmw.yaml).
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Install RMW implementation
   hosts: localhost
   roles:

--- a/ansible/playbooks/setup_acados.yaml
+++ b/ansible/playbooks/setup_acados.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: replace with `ansible-playbook autoware.dev_env.install_dev_env --tags acados`.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Setup acados
   hosts: localhost
   connection: local

--- a/ansible/playbooks/telegraf.yaml
+++ b/ansible/playbooks/telegraf.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: no known callers; scheduled for removal.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Set up Telegraf and InfluxDB v2
   hosts: localhost
   roles:

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -1,3 +1,6 @@
+# DEPRECATED: superseded by install_dev_env.yaml.
+# Scheduled for removal on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+
 - name: Set up source development environments for Autoware Universe
   hosts: localhost
   connection: local

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
+# DEPRECATED: superseded by ansible/scripts/install-ansible.sh +
+# `ansible-playbook autoware.dev_env.install_dev_env`. Scheduled for removal
+# on 2026-05-24. See https://github.com/autowarefoundation/autoware/issues/7052.
+#
 # Set up development environment for Autoware Core/Universe.
 # Usage: setup-dev-env.sh <ros2_installation_type('core' or 'universe')> [-y] [-v] [--no-nvidia]
 # Note: -y option is only for CI.
 
 set -e
+
+echo -e "\e[33m[DEPRECATED] setup-dev-env.sh will be removed on 2026-05-24.\e[m" >&2
+echo -e "\e[33mMigrate to: bash ansible/scripts/install-ansible.sh && ansible-playbook autoware.dev_env.install_dev_env [--tags ...]\e[m" >&2
+echo -e "\e[33mSee https://github.com/autowarefoundation/autoware/issues/7052\e[m" >&2
 
 # Function to print help message
 print_help() {


### PR DESCRIPTION
- **Parent Issue:** #7052
- Adds `DEPRECATED` header comments to 8 legacy ansible playbooks and `setup-dev-env.sh`, pointing at replacements and a 2026-05-24 removal date.
- `setup-dev-env.sh` also prints a yellow deprecation banner to stderr on every invocation.
- No functional changes.

## Why

Phase 1 of the ansible entrypoint consolidation in #7052: give callers a migration window before Phase 2 deletes these files together.

---

## Test plan

- [x] Banner fires: `bash setup-dev-env.sh --help 2>&1 >/dev/null | head -3` shows 3 yellow `[DEPRECATED]` lines.
   <img width="949" height="81" alt="image" src="https://github.com/user-attachments/assets/127468e4-6ec0-4496-ac25-94d60c702b9b" />
- [x] Marked playbook still parses: `ansible-playbook --syntax-check ansible/playbooks/universe.yaml`.