### PR TITLE
docs(ansible): migrate role READMEs to install_dev_env + --tags

### DIFF
--- a/ansible/roles/acados/README.md
+++ b/ansible/roles/acados/README.md
@@ -24,7 +24,7 @@ ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
 This step should be repeated when the ansible directory is updated.
 
 ```bash
-ansible-playbook autoware.dev_env.setup_acados --ask-become-pass
+ansible-playbook autoware.dev_env.install_dev_env --tags acados --ask-become-pass
 ```
 
 ## Directory layout

--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -1,6 +1,6 @@
 # Autoware artifacts
 
-The Autoware perception stack uses models for inference. These models are automatically downloaded as part of the `setup-dev-env.sh` script.
+The Autoware perception stack uses models for inference. These models are downloaded by running `ansible-playbook autoware.dev_env.install_dev_env --tags artifacts`.
 
 The models are hosted by Web.Auto.
 

--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -65,7 +65,7 @@ This step should be repeated when a new playbook is added.
 #### Run the playbook
 
 ```bash
-ansible-playbook autoware.dev_env.download_artifacts -e "data_dir=$HOME/autoware_data" --ask-become-pass
+ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data" --ask-become-pass
 ```
 
 This will download and extract the artifacts to the specified directory and validate the checksums.

--- a/ansible/roles/qt5ct_setup/README.md
+++ b/ansible/roles/qt5ct_setup/README.md
@@ -14,7 +14,7 @@ Follow the instructions below to **install** or **update** the custom theme for 
 ```bash
 cd ~/autoware # The root directory of the cloned repository
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
-ansible-playbook autoware.dev_env.install_rviz_theme  --ask-become-pass
+ansible-playbook autoware.dev_env.install_dev_env --tags qt5ct_setup --ask-become-pass
 ```
 
 ## How to use the custom theme in RViz2

--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -29,7 +29,7 @@ The `ros2_installation_type` variable can also be found in:
 [./defaults/main.yaml](./defaults/main.yaml)
 
 For Universe, the `rosdistro` variable can also be found in:
-[../../playbooks/universe.yaml](../../playbooks/universe.yaml)
+[../../playbooks/install_dev_env.yaml](../../playbooks/install_dev_env.yaml)
 
 ```bash
 # Choose your ROS distribution

--- a/ansible/roles/spconv/README.md
+++ b/ansible/roles/spconv/README.md
@@ -25,7 +25,7 @@ The following command will install a particular version of the packages using an
 ```bash
 export SPCONV_CUMM_VERSION=0.5.3
 export SPCONV_VERSION=2.3.8
-ansible-playbook autoware.dev_env.install_spconv.yaml -e spconv_cumm_version=${SPCONV_CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} --ask-become-pass
+ansible-playbook autoware.dev_env.install_dev_env --tags spconv -e spconv_cumm_version=${SPCONV_CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} --ask-become-pass
 ```
 
 ### Installation for NVIDIA Jetson platforms
@@ -33,5 +33,5 @@ ansible-playbook autoware.dev_env.install_spconv.yaml -e spconv_cumm_version=${S
 ```bash
 export SPCONV_CUMM_VERSION=0.5.3
 export SPCONV_VERSION=2.3.8
-ansible-playbook autoware.dev_env.install_spconv.yaml -e spconv_cumm_version=${SPCONV_CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} -e spconv_is_jetson=true --ask-become-pass
+ansible-playbook autoware.dev_env.install_dev_env --tags spconv -e spconv_cumm_version=${SPCONV_CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} -e spconv_is_jetson=true --ask-become-pass
 ```


### PR DESCRIPTION
- **Parent Issue:** #7052 (Phase 1, step 5)
- Updates the role READMEs for `acados`, `artifacts`, `qt5ct_setup`, `spconv`, and `ros2` to use `ansible-playbook autoware.dev_env.install_dev_env --tags <role>` instead of the soon-to-be-removed per-role playbooks and `setup-dev-env.sh`.
- [ansible/roles/artifacts/README.md](https://github.com/autowarefoundation/autoware/blob/ffd90345eb2c1c061bf6282951119ed237e882e3/ansible/roles/artifacts/README.md) also drops the lingering mention of `setup-dev-env.sh` in the intro paragraph.
- [ansible/roles/ros2/README.md](https://github.com/autowarefoundation/autoware/blob/ffd90345eb2c1c061bf6282951119ed237e882e3/ansible/roles/ros2/README.md) points the `rosdistro` source link at `install_dev_env.yaml` instead of `universe.yaml`.

## Why

Phase 1 migration step from #7052: now that `install_dev_env.yaml` exists and the per-role playbooks are marked for removal on 2026-05-24, the role READMEs need to point at the supported command so users don't copy-paste deprecated invocations.

---

## Test plan

Docs-only change, so verification is limited to checking the new commands resolve and the rendered docs look right.

- [x] Each new command parses and runs syntax-check:
  ```bash
  for tag in acados artifacts qt5ct_setup spconv; do ansible-playbook --syntax-check ansible/playbooks/install_dev_env.yaml --tags "$tag"; done
  ```
  Expected: `playbook: ansible/playbooks/install_dev_env.yaml` for all four, no errors.

- [x] No lingering references to the deprecated commands remain in the touched READMEs:
  ```bash
  grep -nE "setup-dev-env\.sh|setup_acados|download_artifacts|install_rviz_theme|install_spconv|universe\.yaml" ansible/roles/{acados,artifacts,qt5ct_setup,spconv,ros2}/README.md
  ```
  Expected: no matches.

- [x] Render each updated README on GitHub after push and confirm code blocks render cleanly.