### PR TITLE
refactor(webauto-ci): migrate autoware-setup to install_dev_env

### DIFF
--- a/.webauto-ci/main/autoware-setup/run.sh
+++ b/.webauto-ci/main/autoware-setup/run.sh
@@ -11,4 +11,4 @@ ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
 ansible-playbook autoware.dev_env.install_dev_env \
     "${ansible_args[@]}" \
     -e WORKSPACE_ROOT="$(pwd)" \
-    --skip-tags vcs,dev_tools
+    --skip-tags dev_tools

--- a/.webauto-ci/main/autoware-setup/run.sh
+++ b/.webauto-ci/main/autoware-setup/run.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 
 ansible_args=()
-ansible_args+=("--extra-vars" "prompt_install_nvidia=y")
-ansible_args+=("--extra-vars" "prompt_download_artifacts=y")
 ansible_args+=("--extra-vars" "data_dir=$HOME/autoware_data")
 ansible_args+=("--extra-vars" "ros2_installation_type=ros-base")
 ansible_args+=("--extra-vars" "install_devel=false")
@@ -10,7 +8,7 @@ ansible_args+=("--extra-vars" "install_devel=false")
 ansible_args+=("--extra-vars" "rosdistro=humble")
 
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
-ansible-playbook "ansible/playbooks/universe.yaml" \
+ansible-playbook autoware.dev_env.install_dev_env \
     "${ansible_args[@]}" \
     -e WORKSPACE_ROOT="$(pwd)" \
-    --skip-tags vcs
+    --skip-tags vcs,dev_tools


### PR DESCRIPTION
- **Parent Issue:** #7052
- Switches [`.webauto-ci/main/autoware-setup/run.sh`](https://github.com/autowarefoundation/autoware/blob/c3622964a36687b211a314a277b3a00af48fbca8/.webauto-ci/main/autoware-setup/run.sh) from the soon-to-be-removed `ansible/playbooks/universe.yaml` to the tag-driven `autoware.dev_env.install_dev_env`.
- Preserves the `install_devel=false` semantics by replacing the old top-level `when: install_devel == 'y'` gate with `--skip-tags dev_tools` (the new playbook expresses optional roles via tags, not `vars_prompt`).
- Drops `--skip-tags vcs` — no role or task in the ansible collection ever defined a `vcs` tag, so the flag was a no-op in the old invocation too.
- Also drops `prompt_install_nvidia=y` and `prompt_download_artifacts=y` extra-vars: the new playbook has no `vars_prompt`, and both the NVIDIA and artifacts role sets run by default (no `--skip-tags` for them here).

## Why

Step 6 of the Phase 1 migration tracked in #7052. `universe.yaml` is scheduled for removal on 2026-05-24; this moves the last caller in the `autoware` repo so the deletion in Phase 2 is uncontested.

---

## Behavioral equivalence

For the exact extra-vars this script passes (`install_devel=false`, `rosdistro=humble`, NVIDIA + artifacts enabled, `dev_tools` skipped), role-by-role tracing confirms the two playbooks install the same 13 roles in the same mode.

### Roles installed

| Role | Old (`universe.yaml`) | New (`install_dev_env.yaml` + `--skip-tags dev_tools`) | Same? |
|---|---|---|---|
| `ros2` | installed | installed | ✓ |
| `ros2_dev_tools` | installed | installed | ✓ |
| `rmw_implementation` | installed (`rosdistro=humble`) | installed (`rosdistro=humble`) | ✓ |
| `gdown` | installed | installed | ✓ |
| `build_tools` | installed | installed | ✓ |
| `agnocast` | installed (gated `when: rosdistro == 'humble'`) | installed (no gate; tag-only) | ✓ for humble; differs on jazzy |
| `acados` | installed | installed | ✓ |
| `geographiclib` | installed | installed | ✓ |
| `cuda` | installed, **runtime-only** (`install_devel='false'` inside role) | installed, **runtime-only** (same var) | ✓ |
| `tensorrt` | installed, **runtime-only** (same gate) | installed, **runtime-only** (same gate) | ✓ |
| `spconv` | installed (gated `when: prompt_install_nvidia == 'y'`) | installed (no gate; tag-only) | ✓ (same input); differs if someone set `prompt_install_nvidia=n` |
| `dev_tools` | **skipped** (gated `when: install_devel == 'y'`) | **skipped** (via `--skip-tags dev_tools`) | ✓ |
| `artifacts` | installed (gated `when: prompt_download_artifacts == 'y'`, `data_dir=$HOME/autoware_data`) | installed (no gate; same `data_dir`) | ✓ |
| `qt5ct_setup` | installed | installed | ✓ |

### Why each old gate maps to the same result under the new mechanism

| Old gate | New mechanism | Why equivalent for this invocation |
|---|---|---|
| `when: prompt_install_nvidia == 'y'` → CUDA/TensorRT/spconv | no gate; always runs unless `--skip-tags nvidia` | old passed `prompt_install_nvidia=y` anyway, so both install them |
| `when: prompt_download_artifacts == 'y'` → artifacts | no gate; always runs unless `--skip-tags artifacts` | old passed `prompt_download_artifacts=y` anyway |
| `when: install_devel == 'y'` → dev_tools top-level | `--skip-tags dev_tools` | old set `install_devel=false`, so dev_tools was already skipped |
| `when: rosdistro == 'humble'` → agnocast | no gate; tag-only | old passed `rosdistro=humble` anyway |

### Vars still consumed unchanged

| Var | Who consumes it | Effect |
|---|---|---|
| `rosdistro=humble` | `rmw_implementation`, agnocast (indirectly) | same |
| `install_devel=false` | `cuda` / `tensorrt` tasks (`when: install_devel == 'y'`) → devel packages skipped | same |
| `ros2_installation_type=ros-base` | `ros2` role | same |
| `data_dir=$HOME/autoware_data` | `artifacts` role | same |
| `WORKSPACE_ROOT=$(pwd)` | not consumed by any role in the chain | no effect either way (same story with `universe.yaml`) |

---

## Test plan

- [ ] https://evaluation.ci.tier4.jp/evaluation/reports/e31005b5-1c36-5aa4-88fd-e6a2b7c77920?project_id=awf