### PR TITLE
refactor(repositories/autoware.repos): move agnocast under core, switch to autowarefoundation upstream

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -1,5 +1,13 @@
 repositories:
   # core
+  # TODO(TIER IV): During the transition period of Agnocast introduction,
+  # the Agnocast ROS packages are provided as a source build.
+  # Once the transition stabilizes, use the packages released from the official ROS repository.
+  # Issue: https://github.com/autowarefoundation/autoware/issues/5968
+  core/agnocast:
+    type: git
+    url: https://github.com/autowarefoundation/agnocast.git
+    version: 2.3.3
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
@@ -41,6 +49,7 @@ repositories:
     type: git
     url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
     version: 1.4.0
+
   # universe
   universe/autoware_universe:
     type: git
@@ -99,11 +108,13 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/managed_transform_buffer.git
     version: 0.2.0
+
   # launcher
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
     version: 0.50.0
+
   # sensor_component
   sensor_component/external/sensor_component_description:
     type: git
@@ -127,12 +138,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan
     version: e39a814180b03f00a5692b6951a5d4e9f0463486
-  # middleware
-  # TODO(TIER IV): During the transition period of Agnocast introduction,
-  # the Agnocast ROS packages are provided as a source build.
-  # Once the transition stabilizes, use the packages released from the official ROS repository.
-  # Issue: https://github.com/autowarefoundation/autoware/issues/5968
-  middleware/external/agnocast:
-    type: git
-    url: https://github.com/tier4/agnocast.git
-    version: 2.3.3


### PR DESCRIPTION
- Moves `agnocast` from `middleware/external/agnocast` to `core/agnocast` and reorders it to the top of the `core` block.
- Switches the upstream URL from `tier4/agnocast` to `autowarefoundation/agnocast` (pinned version `2.3.3` unchanged).
- Adds blank-line separators between the `core`, `universe`, `launcher`, and `sensor_component` sections for readability.

## Why

Agnocast is consumed as a core dependency rather than an external middleware add-on, so its previous location under `middleware/external/` was misleading. It has also been transferred to the `autowarefoundation` org, so the `.repos` entry should track the canonical upstream. Grouping it with the other `core/*` entries keeps the related TIER IV transition TODO visible at the top of the file.

---

## Test plan

CI passes.