### PR TITLE
feat: add scenario simulation demo

### DIFF
--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -12,3 +12,4 @@ Pre-configured scenarios that launch autoware on container start.
 
 - [planning-simulator/README.md](demos/planning-simulator/README.md)
 - [awsim/README.md](demos/awsim/README.md)
+- [scenario-simulator/README.md](demos/scenario-simulator/README.md)

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -58,7 +58,7 @@ Each `command:` block ends with `exec bash`, so when `ros2 launch` exits the con
 
 ## Customizing
 
-Edit the `command:` block in `docker-compose.yaml` to change launch arguments — for example, point `scenario:=` at a different YAML under `~/sample_scenario/`, or flip `launch_rviz:=true` on the scenario-simulator side to watch the run.
+Edit the `command:` block in `docker-compose.yaml` to change launch arguments — for example, point `scenario:=` at a different YAML under `~/autoware_data/scenarios`, or flip `launch_rviz:=true` on the scenario-simulator side to watch the run.
 
 ## Launch command reference
 
@@ -86,5 +86,4 @@ ros2 launch scenario_test_runner scenario_test_runner.launch.py \
 
 Paths above are container paths. They map back to the host via the `volumes:` block:
 
-- `~/sample_scenario` → `/sample_scenario` (autoware) and `/home/aw/sample_scenario` (scenario-simulator)
 - The shared `cyclonedds-config` volume is populated by the `autoware` service on startup and mounted read-only into the scenario-simulator at `/home/aw/cyclonedds.xml`, which is what `CYCLONEDDS_URI` points at.

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -78,7 +78,7 @@ ros2 launch autoware_launch planning_simulator.launch.xml \
 ros2 launch scenario_test_runner scenario_test_runner.launch.py \
   architecture_type:=awf/universe/20250130 \
   record:=false \
-  scenario:=/home/aw/sample_scenario/sample-scenario.yaml \
+  scenario:=/home/aw/autoware_data/scenarios/autoware_sample_scenarios/sample-scenario.yaml \
   use_custom_centerline:=true \
   launch_rviz:=false \
   launch_autoware:=false

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -11,14 +11,16 @@ Both services use `network_mode: host` and share a generated `cyclonedds.xml` (v
 
 - Docker Compose v2
 - Sample map extracted to `~/autoware_map/sample-map-planning`
-- Sample scenarios cloned to `~/autoware_scenario/`
+- Sample scenarios cloned to `~/autoware_data/scenarios`
 
 [Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_map/sample-map-planning`.
 
 Clone the sample scenarios repository to `~/autoware_scenario/`:
 
 ```bash
-git clone https://github.com/autowarefoundation/autoware_sample_scenarios.git ~/autoware_scenario
+mkdir -p ~/autoware_data/scenarios/
+cd ~/autoware_data/scenarios/
+git clone https://github.com/autowarefoundation/autoware_sample_scenarios.git
 ```
 
 ## Run

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -15,7 +15,7 @@ Both services use `network_mode: host` and share a generated `cyclonedds.xml` (v
 
 [Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_map/sample-map-planning`.
 
-Clone the sample scenarios repository to `~/autoware_scenario/`:
+Clone the sample scenarios repository:
 
 ```bash
 mkdir -p ~/autoware_data/scenarios/

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -66,7 +66,7 @@ Edit the `command:` block in `docker-compose.yaml` to change launch arguments â€
 
 ```bash
 ros2 launch autoware_launch planning_simulator.launch.xml \
-  map_path:=/sample_scenario/sample-map-planning \
+  map_path:=/home/aw/autoware_map/sample-map-planning \
   vehicle_model:=sample_vehicle \
   sensor_model:=sample_sensor_kit \
   scenario_simulation:=true

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -1,0 +1,88 @@
+# scenario-simulator
+
+Runs a `scenario_simulator_v2` scenario against a live Autoware planning stack. Two services are defined in `docker-compose.yaml`:
+
+- `autoware` — the `ghcr.io/autowarefoundation/autoware:universe-humble` image launching `planning_simulator.launch.xml` with `scenario_simulation:=true` so it pairs with an external scenario runner.
+- `scenario-simulator` — the `scenario_test_runner` from `ghcr.io/tier4/scenario_simulator_v2:humble-25.0.17-runtime`, with `launch_autoware:=false` so it only drives the simulator engine.
+
+Both services use `network_mode: host` and share a generated `cyclonedds.xml` (via the `cyclonedds-config` named volume) so ROS 2 discovery works between them. The `scenario-simulator` service waits for the `autoware` service's healthcheck (`/api/operation_mode/state` topic) to pass before launching.
+
+## Prerequisites
+
+- Docker Compose v2
+- Sample map extracted to `~/autoware_map/sample-map-planning`
+- Sample scenarios cloned to `~/autoware_scenario/`
+
+[Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_map/sample-map-planning`.
+
+Clone the sample scenarios repository to `~/autoware_scenario/`:
+
+```bash
+git clone https://github.com/autowarefoundation/autoware_sample_scenarios.git ~/autoware_scenario
+```
+
+## Run
+
+```bash
+xhost +local:docker
+cd docker/examples/demos/scenario-simulator
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up
+```
+
+`docker compose up` starts both services; the `scenario-simulator` service blocks on the `autoware` healthcheck and then launches the scenario. Logs are interleaved.
+
+To run them in separate terminals (each gets its own stdout/stdin):
+
+```bash
+xhost +local:docker
+
+# terminal 1 — Autoware planning stack (rviz needs X11)
+cd docker/examples/demos/scenario-simulator
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose run --rm autoware
+
+# terminal 2 — scenario runner
+# --no-deps stops compose from starting a second `autoware` container
+# (scenario-simulator declares depends_on: autoware); wait until the
+# container in terminal 1 is healthy before running this.
+cd docker/examples/demos/scenario-simulator
+docker compose run --rm --no-deps scenario-simulator
+```
+
+`HOST_UID`/`HOST_GID` default to `1000`; drop the prefix if your host UID/GID are 1000.
+
+## After the launch exits
+
+Each `command:` block ends with `exec bash`, so when `ros2 launch` exits the container drops into an interactive shell instead of disappearing. `Ctrl+D` exits and removes the container (`--rm`).
+
+## Customizing
+
+Edit the `command:` block in `docker-compose.yaml` to change launch arguments — for example, point `scenario:=` at a different YAML under `~/sample_scenario/`, or flip `launch_rviz:=true` on the scenario-simulator side to watch the run.
+
+## Launch command reference
+
+`autoware`:
+
+```bash
+ros2 launch autoware_launch planning_simulator.launch.xml \
+  map_path:=/sample_scenario/sample-map-planning \
+  vehicle_model:=sample_vehicle \
+  sensor_model:=sample_sensor_kit \
+  scenario_simulation:=true
+```
+
+`scenario-simulator`:
+
+```bash
+ros2 launch scenario_test_runner scenario_test_runner.launch.py \
+  architecture_type:=awf/universe/20250130 \
+  record:=false \
+  scenario:=/home/aw/sample_scenario/sample-scenario.yaml \
+  use_custom_centerline:=true \
+  launch_rviz:=false \
+  launch_autoware:=false
+```
+
+Paths above are container paths. They map back to the host via the `volumes:` block:
+
+- `~/sample_scenario` → `/sample_scenario` (autoware) and `/home/aw/sample_scenario` (scenario-simulator)
+- The shared `cyclonedds-config` volume is populated by the `autoware` service on startup and mounted read-only into the scenario-simulator at `/home/aw/cyclonedds.xml`, which is what `CYCLONEDDS_URI` points at.

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -84,6 +84,4 @@ ros2 launch scenario_test_runner scenario_test_runner.launch.py \
   launch_autoware:=false
 ```
 
-Paths above are container paths. They map back to the host via the `volumes:` block:
-
-- The shared `cyclonedds-config` volume is populated by the `autoware` service on startup and mounted read-only into the scenario-simulator at `/home/aw/cyclonedds.xml`, which is what `CYCLONEDDS_URI` points at.
+The `cyclonedds-config` named volume is populated by the `autoware` service on startup (a copy of `/home/aw/cyclonedds.xml`) and mounted into the scenario-simulator at `/shared-config`, which `CYCLONEDDS_URI` points at.

--- a/docker/examples/demos/scenario-simulator/docker-compose.yaml
+++ b/docker/examples/demos/scenario-simulator/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - CYCLONEDDS_URI=file:///shared-config/cyclonedds.xml
     volumes:
-      - ${HOME}/autoware_scenario:/home/aw/autoware_scenario:ro
+      - ${HOME}/autoware_data:/home/aw/autoware_data:ro
       - ${HOME}/autoware_map:/home/aw/autoware_map:ro
       - cyclonedds-config:/shared-config:ro
     command:
@@ -62,7 +62,7 @@ services:
         ros2 launch scenario_test_runner scenario_test_runner.launch.py \
           architecture_type:=awf/universe/20250130 \
           record:=false \
-          scenario:=/home/aw/autoware_scenario/sample-scenario.yaml \
+          scenario:=/home/aw/autoware_data/scenarios/autoware_sample_scenarios/sample-scenario.yaml \
           use_custom_centerline:=true \
           launch_rviz:=false \
           launch_autoware:=false

--- a/docker/examples/demos/scenario-simulator/docker-compose.yaml
+++ b/docker/examples/demos/scenario-simulator/docker-compose.yaml
@@ -1,0 +1,72 @@
+services:
+  autoware:
+    image: ghcr.io/autowarefoundation/autoware:universe-humble
+    network_mode: host
+    privileged: true
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+      - QT_X11_NO_MITSHM=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${HOME}/autoware_map:/home/aw/autoware_map
+      - cyclonedds-config:/shared-config:rw
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          bash -c 'source /opt/ros/humble/setup.bash &&
+          source /opt/autoware/setup.bash &&
+          ros2 topic list 2>/dev/null | grep -q /api/operation_mode/state'
+      interval: 10s
+      timeout: 10s
+      retries: 60
+      start_period: 30s
+    command:
+      - bash
+      - -c
+      - |
+        sudo chown $(id -u):$(id -g) /shared-config
+        cp /home/aw/cyclonedds.xml /shared-config/cyclonedds.xml
+        chmod 644 /shared-config/cyclonedds.xml
+        ros2 launch autoware_launch planning_simulator.launch.xml \
+          map_path:=/home/aw/autoware_map/sample-map-planning \
+          vehicle_model:=sample_vehicle \
+          sensor_model:=sample_sensor_kit \
+          scenario_simulation:=true
+        exec bash
+
+  # TODO: use jazzy image when it becomes available
+  scenario-simulator:
+    image: ghcr.io/tier4/scenario_simulator_v2:humble-25.0.17-runtime
+    network_mode: host
+    stdin_open: true
+    tty: true
+    depends_on:
+      autoware:
+        condition: service_healthy
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - CYCLONEDDS_URI=file:///shared-config/cyclonedds.xml
+    volumes:
+      - ${HOME}/autoware_scenario:/home/aw/autoware_scenario:ro
+      - ${HOME}/autoware_map:/home/aw/autoware_map:ro
+      - cyclonedds-config:/shared-config:ro
+    command:
+      - bash
+      - -c
+      - |
+        ros2 launch scenario_test_runner scenario_test_runner.launch.py \
+          architecture_type:=awf/universe/20250130 \
+          record:=false \
+          scenario:=/home/aw/autoware_scenario/sample-scenario.yaml \
+          use_custom_centerline:=true \
+          launch_rviz:=false \
+          launch_autoware:=false
+        exec bash
+
+volumes:
+  cyclonedds-config:


### PR DESCRIPTION
## Description

### Related Issue
https://github.com/autowarefoundation/autoware/issues/7031

### Summary

- Adds a new Docker Compose demo under `docker/examples/demos/scenario-simulator/` that pairs the `scenario_test_runner` from `scenario_simulator_v2` with the Autoware planning stack (`planning_simulator.launch.xml` with `scenario_simulation:=true`).
- Both services run with `network_mode: host` and share a generated `cyclonedds.xml` via a named volume so ROS 2 discovery works between containers.
- The `scenario-simulator` service waits for the `autoware` service to become healthy (probed by checking for the `/api/operation_mode/state` topic) before launching the scenario.

### Files changed

- `docker/examples/demos/scenario-simulator/docker-compose.yaml` — two-service compose stack (`autoware` + `scenario-simulator`) with healthcheck-gated startup.
- `docker/examples/demos/scenario-simulator/README.md` — prerequisites, run instructions (split-terminal and `compose up`), and a launch-command reference.

### Notes / follow-ups

- The `scenario-simulator` image is pinned to `ghcr.io/tier4/scenario_simulator_v2:humble-25.0.17-runtime`; there's a `TODO` in the compose file to switch to a jazzy image once it's published.


## How was this PR tested?

- [x]  docker compose up from the demo directory brings both services up and the scenario runs to completion against rviz.
- [x]  Split-terminal flow (docker compose run --rm autoware + docker compose run --rm scenario-simulator) works as documented.
