### PR TITLE
ci(health-check-pr): skip docs and examples-only changes

### DIFF
--- a/.github/workflows/health-check-pr.yaml
+++ b/.github/workflows/health-check-pr.yaml
@@ -33,6 +33,9 @@ jobs:
             ansible-galaxy-requirements.yaml
             ansible/**
             docker/**
+          files_ignore: |
+            docker/examples/**
+            **/*.md
 
   require-label:
     needs: changed-files


### PR DESCRIPTION
- Adds `files_ignore` to the `changed-files` filter in [.github/workflows/health-check-pr.yaml](https://github.com/autowarefoundation/autoware/blob/d601635855987e302cfb89eeab49b4fb7fd1ec66/.github/workflows/health-check-pr.yaml), so PRs touching only markdown files or `docker/examples/**` no longer trigger the health-check matrix.

## Why

The compose examples under `docker/examples/**` are user-facing demos that don't affect the built images. Markdown changes don't affect builds either. Today every README tweak inside `docker/**` (the prior PR was a recent example) launches the full three-job matrix for no reason — wasting runner minutes.

---

## Test plan

This PR itself modifies `.github/workflows/health-check-pr.yaml`, which is in the `files:` include list, so the matrix will still fire on this PR — expected, and it exercises the filter end-to-end.

- [ ] On this PR: `changed-files` job's `should-run` is `true` and the three matrix jobs run.
- [ ] After merge, a docs-only PR (e.g. a README typo fix anywhere) shows `should-run=false` and the `health-check` matrix jobs are skipped.
- [ ] After merge, a `docker/examples/**`-only PR shows the same skip behaviour.
- [ ] After merge, a real `docker/**` change (e.g. editing `docker/base.Dockerfile`) still triggers the matrix.