### PR TITLE
feat: default data paths to ~/autoware_data/{ml_models,maps}

### DIFF
--- a/.github/workflows/health-check-ansible-artifacts.yaml
+++ b/.github/workflows/health-check-ansible-artifacts.yaml
@@ -62,11 +62,11 @@ jobs:
       - name: 📊 Report artifacts size and disk space
         run: |
           df -h
-          size_bytes=$(du -sb "$HOME/autoware_data" 2>/dev/null | awk '{print $1+0}')
+          size_bytes=$(du -sb "$HOME/autoware_data/ml_models" 2>/dev/null | awk '{print $1+0}')
           size_gb=$(awk -v b="${size_bytes:-0}" 'BEGIN { printf "%.2f", b/1e9 }')
           echo "📦 Artifacts directory size: ${size_gb} GB"
           {
             echo "## 📦 Artifacts download"
             echo ""
-            echo "Total size of \`$HOME/autoware_data\`: **${size_gb} GB**"
+            echo "Total size of \`$HOME/autoware_data/ml_models\`: **${size_gb} GB**"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.webauto-ci/main/autoware-setup/run.sh
+++ b/.webauto-ci/main/autoware-setup/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ansible_args=()
-ansible_args+=("--extra-vars" "data_dir=$HOME/autoware_data")
+ansible_args+=("--extra-vars" "data_dir=$HOME/autoware_data/ml_models")
 ansible_args+=("--extra-vars" "ros2_installation_type=ros-base")
 ansible_args+=("--extra-vars" "install_devel=false")
 

--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -4,7 +4,7 @@ The Autoware perception stack uses models for inference. These models are downlo
 
 The models are hosted by Web.Auto.
 
-Default `data_dir` location is `~/autoware_data`.
+Default `data_dir` location is `~/autoware_data/ml_models` (part of the asset-typed `~/autoware_data/` layout: `assets/`, `maps/`, `ml_models/`, `recordings/`, `scenarios/`).
 
 ## Download instructions
 
@@ -65,7 +65,25 @@ This step should be repeated when a new playbook is added.
 #### Run the playbook
 
 ```bash
-ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data" --ask-become-pass
+ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
 ```
 
 This will download and extract the artifacts to the specified directory and validate the checksums.
+
+### Migrating from the legacy layout
+
+Earlier versions of this role downloaded directly into `~/autoware_data/`. To match the new
+layout, move the existing model directories under `~/autoware_data/ml_models/` (and, if you
+were using `~/autoware_map/`, into `~/autoware_data/maps/`):
+
+```bash
+mkdir -p ~/autoware_data/ml_models
+shopt -s extglob
+mv ~/autoware_data/!(ml_models|maps|recordings|scenarios|assets) ~/autoware_data/ml_models/
+
+# only if you also have ~/autoware_map/
+[ -d ~/autoware_map ] && mv ~/autoware_map ~/autoware_data/maps
+```
+
+Re-running the playbook is also safe: it will populate the new `ml_models/` directory and you
+can delete the old top-level model folders afterwards.

--- a/ansible/roles/artifacts/defaults/main.yaml
+++ b/ansible/roles/artifacts/defaults/main.yaml
@@ -1,1 +1,1 @@
-data_dir: "{{ ansible_env.HOME }}/autoware_data" # noqa: var-naming[no-role-prefix]
+data_dir: "{{ ansible_env.HOME }}/autoware_data/ml_models" # noqa: var-naming[no-role-prefix]

--- a/ansible/roles/demo_artifacts/README.md
+++ b/ansible/roles/demo_artifacts/README.md
@@ -14,16 +14,14 @@ After running the role, the following layout is created under `demo_artifacts__a
 ```console
 ~/autoware_data
 ├── maps
-│   └── demos
-│       ├── sample-map-planning/
-│       ├── sample-map-planning.zip
-│       ├── sample-map-rosbag/
-│       └── sample-map-rosbag.zip
+│   ├── sample-map-planning/
+│   ├── sample-map-planning.zip
+│   ├── sample-map-rosbag/
+│   └── sample-map-rosbag.zip
 └── recordings
     └── bags
-        └── demos
-            ├── sample-rosbag/
-            └── sample-rosbag.zip
+        ├── sample-rosbag/
+        └── sample-rosbag.zip
 ```
 
 ## Run

--- a/ansible/roles/demo_artifacts/tasks/main.yaml
+++ b/ansible/roles/demo_artifacts/tasks/main.yaml
@@ -7,55 +7,55 @@
     cache_valid_time: 3600
 
 # sample-map-planning (planning-sim demo)
-- name: Create maps/demos directory inside {{ demo_artifacts__autoware_data_dir }}
+- name: Create maps directory inside {{ demo_artifacts__autoware_data_dir }}
   ansible.builtin.file:
-    path: "{{ demo_artifacts__autoware_data_dir }}/maps/demos"
+    path: "{{ demo_artifacts__autoware_data_dir }}/maps"
     mode: "755"
     state: directory
 
-- name: Download maps/demos/sample-map-planning.zip
+- name: Download maps/sample-map-planning.zip
   become: true
   ansible.builtin.get_url:
     url: https://autoware-files.s3.us-west-2.amazonaws.com/maps/demos/sample-map-planning.zip
-    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/demos/sample-map-planning.zip"
+    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/sample-map-planning.zip"
     mode: "644"
     checksum: sha256:5536fce7bb8db7688fdf94ec004118b898637ad0d5b6175108b10989dd6e93b9
 
-- name: Extract maps/demos/sample-map-planning.zip
+- name: Extract maps/sample-map-planning.zip
   ansible.builtin.unarchive:
-    src: "{{ demo_artifacts__autoware_data_dir }}/maps/demos/sample-map-planning.zip"
-    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/demos/"
+    src: "{{ demo_artifacts__autoware_data_dir }}/maps/sample-map-planning.zip"
+    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/"
 
 # sample-map-rosbag (rosbag-replay-simulation demo)
-- name: Download maps/demos/sample-map-rosbag.zip
+- name: Download maps/sample-map-rosbag.zip
   become: true
   ansible.builtin.get_url:
     url: https://autoware-files.s3.us-west-2.amazonaws.com/maps/demos/sample-map-rosbag.zip
-    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/demos/sample-map-rosbag.zip"
+    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/sample-map-rosbag.zip"
     mode: "644"
     checksum: sha256:07e2da0b0bf12e2324f7083c2ce5556fb8044c50cef1da6428ab9084c3903bc8
 
-- name: Extract maps/demos/sample-map-rosbag.zip
+- name: Extract maps/sample-map-rosbag.zip
   ansible.builtin.unarchive:
-    src: "{{ demo_artifacts__autoware_data_dir }}/maps/demos/sample-map-rosbag.zip"
-    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/demos/"
+    src: "{{ demo_artifacts__autoware_data_dir }}/maps/sample-map-rosbag.zip"
+    dest: "{{ demo_artifacts__autoware_data_dir }}/maps/"
 
 # sample-rosbag (rosbag-replay-simulation demo)
-- name: Create recordings/bags/demos directory inside {{ demo_artifacts__autoware_data_dir }}
+- name: Create recordings/bags directory inside {{ demo_artifacts__autoware_data_dir }}
   ansible.builtin.file:
-    path: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/demos"
+    path: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags"
     mode: "755"
     state: directory
 
-- name: Download recordings/bags/demos/sample-rosbag.zip
+- name: Download recordings/bags/sample-rosbag.zip
   become: true
   ansible.builtin.get_url:
     url: https://autoware-files.s3.us-west-2.amazonaws.com/recordings/bags/demos/sample-rosbag.zip
-    dest: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/demos/sample-rosbag.zip"
+    dest: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/sample-rosbag.zip"
     mode: "644"
     checksum: sha256:5f9d36353393b3d249212153c19049822b1298db56512aa045b4f7f6fc37cf88
 
-- name: Extract recordings/bags/demos/sample-rosbag.zip
+- name: Extract recordings/bags/sample-rosbag.zip
   ansible.builtin.unarchive:
-    src: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/demos/sample-rosbag.zip"
-    dest: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/demos/"
+    src: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/sample-rosbag.zip"
+    dest: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/"

--- a/docker/README.md
+++ b/docker/README.md
@@ -115,8 +115,8 @@ docker run --rm -it \
   -e HOST_GID=$(id -g) \
   -e QT_X11_NO_MITSHM=1 \
   -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-  -v $HOME/autoware_map:/home/aw/autoware_map \
-  -v $HOME/autoware_data:/home/aw/autoware_data \
+  -v $HOME/autoware_data/maps:/home/aw/autoware_data/maps \
+  -v $HOME/autoware_data/ml_models:/home/aw/autoware_data/ml_models \
   -v $HOME/autoware:/home/aw/autoware \
   -w /home/aw/autoware \
   --runtime=nvidia \
@@ -137,8 +137,8 @@ docker run --rm -it \
 | `-e HOST_UID/HOST_GID`              | Entrypoint remaps the `aw` user to match host UID/GID, avoiding permission issues on mounted volumes |
 | `-e QT_X11_NO_MITSHM`               | Disable MIT-SHM for Qt apps (shared memory doesn't work across container boundary)                   |
 | `-v /tmp/.X11-unix`                 | Mount X11 socket for GUI forwarding                                                                  |
-| `-v autoware_map`                   | Mount map data from host                                                                             |
-| `-v autoware_data`                  | Mount perception model data from host                                                                |
+| `-v autoware_data/maps`             | Mount maps from host (lanelet2 + pointcloud)                                                         |
+| `-v autoware_data/ml_models`        | Mount ML model artifacts from host                                                                   |
 | `-v autoware`                       | Mount source code for development                                                                    |
 | `-w /home/aw/autoware`              | Set working directory to the mounted source                                                          |
 | `--runtime=nvidia`                  | Use NVIDIA container runtime for GPU support                                                         |

--- a/docker/examples/basic/README.md
+++ b/docker/examples/basic/README.md
@@ -1,6 +1,6 @@
 # basic
 
-Three flavors of "drop me into a shell" container. All three use the `universe-devel-*` images (build tooling plus `/opt/autoware` built from source), mount `~/autoware_map` and `~/autoware_data`, forward `$DISPLAY`, and differ only in how the GPU is exposed.
+Three flavors of "drop me into a shell" container. All three use the `universe-devel-*` images (build tooling plus `/opt/autoware` built from source), mount `~/autoware_data/maps` and `~/autoware_data/ml_models`, forward `$DISPLAY`, and differ only in how the GPU is exposed.
 
 | Host GPU / driver            | Use          | How                                              |
 | ---------------------------- | ------------ | ------------------------------------------------ |

--- a/docker/examples/basic/dev-cpu.compose.yaml
+++ b/docker/examples/basic/dev-cpu.compose.yaml
@@ -12,6 +12,6 @@ services:
       - LIBGL_ALWAYS_SOFTWARE=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_map:/home/aw/autoware_map
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
+      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
     command: bash

--- a/docker/examples/basic/dev-dri.compose.yaml
+++ b/docker/examples/basic/dev-dri.compose.yaml
@@ -16,6 +16,6 @@ services:
       - render
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_map:/home/aw/autoware_map
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
+      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
     command: bash

--- a/docker/examples/basic/dev-nvidia.compose.yaml
+++ b/docker/examples/basic/dev-nvidia.compose.yaml
@@ -14,8 +14,8 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_map:/home/aw/autoware_map
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
+      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
     deploy:
       resources:
         reservations:

--- a/docker/examples/demos/awsim/README.md
+++ b/docker/examples/demos/awsim/README.md
@@ -5,8 +5,8 @@ Bridges autoware to the [AWSIM](https://tier4.github.io/AWSIM/) Unity simulator 
 ## Prerequisites
 
 - NVIDIA GPU with the NVIDIA Container Toolkit installed
-- Shinjuku map extracted to `~/autoware_map/Shinjuku-Map/map`
-- Perception model data under `~/autoware_data`
+- Shinjuku map extracted to `~/autoware_data/maps/Shinjuku-Map/map`
+- Perception model data under `~/autoware_data/ml_models`
 - AWSIM running on the host and reachable on the ROS 2 graph
 - Docker Compose v2
 
@@ -37,7 +37,7 @@ The image's entrypoint sources `/opt/autoware/setup.bash` (via `AUTOWARE_RUNTIME
 ros2 launch autoware_launch e2e_simulator.launch.xml \
   vehicle_model:=sample_vehicle \
   sensor_model:=awsim_sensor_kit \
-  map_path:=/home/aw/autoware_map/Shinjuku-Map/map
+  map_path:=/home/aw/autoware_data/maps/Shinjuku-Map/map
 ```
 
-`map_path` points inside the container; it maps to `~/autoware_map/Shinjuku-Map/map` on the host via the `volumes:` mount.
+`map_path` points inside the container; it maps to `~/autoware_data/maps/Shinjuku-Map/map` on the host via the `volumes:` mount.

--- a/docker/examples/demos/awsim/docker-compose.yaml
+++ b/docker/examples/demos/awsim/docker-compose.yaml
@@ -15,8 +15,8 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_map:/home/aw/autoware_map
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
+      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
     deploy:
       resources:
         reservations:
@@ -31,5 +31,5 @@ services:
         ros2 launch autoware_launch e2e_simulator.launch.xml \
           vehicle_model:=sample_vehicle \
           sensor_model:=awsim_sensor_kit \
-          map_path:=/home/aw/autoware_map/Shinjuku-Map/map
+          map_path:=/home/aw/autoware_data/maps/Shinjuku-Map/map
         exec bash

--- a/docker/examples/demos/planning-simulator/README.md
+++ b/docker/examples/demos/planning-simulator/README.md
@@ -6,11 +6,11 @@ Planning sim itself doesn't need a GPU — perception is dummy. The only reason 
 
 ## Prerequisites
 
-- Sample map extracted to `~/autoware_map/sample-map-planning`
-- Perception model data under `~/autoware_data` (mounted but not used by this demo)
+- Sample map extracted to `~/autoware_data/maps/sample-map-planning` (the layout produced by the `demo_artifacts` ansible role)
+- Perception model data under `~/autoware_data/ml_models` (mounted but not used by this demo)
 - Docker Compose v2
 
-[Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_map/sample-map-planning` before running.
+[Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_data/maps/sample-map-planning` before running, or run the `demo_artifacts` ansible role which places it there automatically.
 
 ## Run (no GPU, software rendering)
 
@@ -65,9 +65,9 @@ To enable ROS 2 discovery with other hosts on the network, add `network_mode: ho
 
 ```bash
 ros2 launch autoware_launch planning_simulator.launch.xml \
-  map_path:=/home/aw/autoware_map/sample-map-planning \
+  map_path:=/home/aw/autoware_data/maps/sample-map-planning \
   vehicle_model:=sample_vehicle \
   sensor_model:=sample_sensor_kit
 ```
 
-`map_path` points inside the container; it maps to `~/autoware_map/sample-map-planning` on the host via the `volumes:` mount.
+`map_path` points inside the container; it maps to `~/autoware_data/maps/sample-map-planning` on the host via the `volumes:` mount.

--- a/docker/examples/demos/planning-simulator/docker-compose.yaml
+++ b/docker/examples/demos/planning-simulator/docker-compose.yaml
@@ -11,14 +11,14 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_map:/home/aw/autoware_map
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
+      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
     command:
       - bash
       - -c
       - |
         ros2 launch autoware_launch planning_simulator.launch.xml \
-          map_path:=/home/aw/autoware_map/sample-map-planning \
+          map_path:=/home/aw/autoware_data/maps/sample-map-planning \
           vehicle_model:=sample_vehicle \
           sensor_model:=sample_sensor_kit
         exec bash

--- a/docker/examples/demos/scenario-simulator/README.md
+++ b/docker/examples/demos/scenario-simulator/README.md
@@ -10,10 +10,10 @@ Both services use `network_mode: host` and share a generated `cyclonedds.xml` (v
 ## Prerequisites
 
 - Docker Compose v2
-- Sample map extracted to `~/autoware_map/sample-map-planning`
+- Sample map extracted to `~/autoware_data/maps/sample-map-planning` (the layout produced by the `demo_artifacts` ansible role)
 - Sample scenarios cloned to `~/autoware_data/scenarios`
 
-[Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_map/sample-map-planning`.
+[Download the sample map](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map) and unpack it to `~/autoware_data/maps/sample-map-planning`, or run the `demo_artifacts` ansible role which places it there automatically.
 
 Clone the sample scenarios repository:
 
@@ -66,7 +66,7 @@ Edit the `command:` block in `docker-compose.yaml` to change launch arguments â€
 
 ```bash
 ros2 launch autoware_launch planning_simulator.launch.xml \
-  map_path:=/home/aw/autoware_map/sample-map-planning \
+  map_path:=/home/aw/autoware_data/maps/sample-map-planning \
   vehicle_model:=sample_vehicle \
   sensor_model:=sample_sensor_kit \
   scenario_simulation:=true

--- a/docker/examples/demos/scenario-simulator/docker-compose.yaml
+++ b/docker/examples/demos/scenario-simulator/docker-compose.yaml
@@ -12,7 +12,8 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_map:/home/aw/autoware_map
+      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
+      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
       - cyclonedds-config:/shared-config:rw
     healthcheck:
       test:
@@ -33,7 +34,7 @@ services:
         cp /home/aw/cyclonedds.xml /shared-config/cyclonedds.xml
         chmod 644 /shared-config/cyclonedds.xml
         ros2 launch autoware_launch planning_simulator.launch.xml \
-          map_path:=/home/aw/autoware_map/sample-map-planning \
+          map_path:=/home/aw/autoware_data/maps/sample-map-planning \
           vehicle_model:=sample_vehicle \
           sensor_model:=sample_sensor_kit \
           scenario_simulation:=true
@@ -52,8 +53,8 @@ services:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - CYCLONEDDS_URI=file:///shared-config/cyclonedds.xml
     volumes:
-      - ${HOME}/autoware_data:/home/aw/autoware_data:ro
-      - ${HOME}/autoware_map:/home/aw/autoware_map:ro
+      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps:ro
+      - ${HOME}/autoware_data/scenarios:/home/aw/autoware_data/scenarios:ro
       - cyclonedds-config:/shared-config:ro
     command:
       - bash

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -24,7 +24,7 @@ print_help() {
     echo "  --no-nvidia     Disable installation of the NVIDIA-related roles ('cuda' and 'tensorrt')"
     echo "  --no-cuda-drivers Disable installation of 'cuda-drivers' in the role 'cuda'"
     echo "  --runtime       Disable installation dev package of role 'cuda' and 'tensorrt'"
-    echo "  --data-dir      Set data directory (default: $HOME/autoware_data)"
+    echo "  --data-dir      Set data directory (default: $HOME/autoware_data/ml_models)"
     echo "  --download-artifacts"
     echo "                  Download artifacts"
     echo "  --module        Specify the module (default: all)"
@@ -36,7 +36,7 @@ SCRIPT_DIR=$(readlink -f "$(dirname "$0")")
 
 # Parse arguments
 args=()
-option_data_dir="$HOME/autoware_data"
+option_data_dir="$HOME/autoware_data/ml_models"
 
 while [ "$1" != "" ]; do
     case "$1" in


### PR DESCRIPTION
- **Parent Issue:** #7068
- Move the `artifacts` ansible role default `data_dir` to `~/autoware_data/ml_models`; update `setup-dev-env.sh`, `.webauto-ci/main/autoware-setup/run.sh`, and the artifacts health-check workflow to match.
- Add a migration section to `ansible/roles/artifacts/README.md` covering the move from a legacy `~/autoware_data/` (and `~/autoware_map/`) install.
- Migrate every docker compose example off the legacy `~/autoware_map/` host directory: drop both the `${HOME}/autoware_map:/home/aw/autoware_map` and the broad `${HOME}/autoware_data:/home/aw/autoware_data` mounts, replacing them with two narrow mounts that keep maps and ml_models cleanly separated:
  - `${HOME}/autoware_data/maps:/home/aw/autoware_data/maps`
  - `${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models`
  The `scenario-simulator` runner additionally mounts `${HOME}/autoware_data/scenarios:ro`. All in-container `map_path:=` defaults now point at `/home/aw/autoware_data/maps[/demos]/<map>`. Top-level `docker/README.md` and `docker/examples/basic/README.md` prose updated to match.

## Why

Final piece of the host-side restructure described in #7068: `~/autoware_data/` is now organized by asset type, with `ml_models/` for what the `artifacts` role downloads and `maps/` for what `demo_artifacts` (and end users) place. The launches in `autoware_launch` already default to the new layout (paired PR); this PR moves the data-producer side over and retires the legacy `~/autoware_map/` directory entirely so a fresh install of the playbook + a fresh docker demo run line up end-to-end.

Users on the legacy layout can pin the old paths (`data_path:=$HOME/autoware_data`, `map_path:=$HOME/autoware_map/<map>`) on the command line, but the documented defaults no longer reference them.

---

- Pairs with autowarefoundation/autoware_launch#1835 (the launch-arg defaults and `AutowareSample.system.yaml`). Both must merge together for the end-to-end flow (ansible playbook -> docker demo) to work on the new layout.
- Pairs with autowarefoundation/autoware_universe#12523 (per-package launch defaults and READMEs).
- Pairs with autowarefoundation/autoware_tools#417 (tools-repo README map_path examples).
- Pairs with autowarefoundation/autoware_system_designer#53 (`vehicle_x.system.yaml`).
- Builds on autowarefoundation/autoware_universe#12521 (already merged) which removed the hardcoded `$(env HOME)/autoware_data/...` strings from the universe param YAMLs.
- Builds on autowarefoundation/autoware_launch#1834 (already merged) which plumbed `data_path` through the planning chain.
- Builds on #7067 (already merged) which introduced the `demo_artifacts` role placing sample maps under `~/autoware_data/maps/demos/`.

## Test plan

- [ ] Ansible artifacts role resolves the new default in check mode:

  ```bash
  ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
  ansible-playbook autoware.dev_env.install_dev_env --tags artifacts --check -v 2>&1 | grep -m1 data_dir
  ```

  Expect `data_dir` to resolve to `$HOME/autoware_data/ml_models`.

- [ ] Setup script help text and parsed default match the new layout:

  ```bash
  bash setup-dev-env.sh --help | grep -- --data-dir
  ```

  Expect: `--data-dir      Set data directory (default: $HOME/autoware_data/ml_models)`.

- [ ] Docker demo composes resolve the new map and ml_models bindings:

  ```bash
  for f in docker/examples/demos/{awsim,planning-simulator,scenario-simulator}/docker-compose.yaml docker/examples/basic/dev-{cpu,dri,nvidia}.compose.yaml; do
    echo "=== $f ==="
    grep -E '/home/aw/autoware_(data|map)' "$f"
  done
  ```

  Expect every line to be either `${HOME}/autoware_data/maps:/home/aw/autoware_data/maps[:ro]`, `${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models[:ro]`, `${HOME}/autoware_data/scenarios:/home/aw/autoware_data/scenarios:ro`, or a `map_path:=/home/aw/autoware_data/maps[/demos]/<map>` launch arg. No `autoware_map` references.

- [ ] No leftover `${HOME}/autoware_map` mounts:

  ```bash
  grep -rn 'autoware_map' docker/ | grep -v 'autoware_map_msgs'
  ```

  Expect no output.

- [ ] Health-check workflow narrows its size measurement to the new default. Trigger by adding the `run:health-check` label on the PR; in the step summary look for `Total size of $HOME/autoware_data/ml_models: ...`.
