### PR TITLE
chore: update Autoware Core version to 1.8.0

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -39,7 +39,7 @@ repositories:
   core/autoware_rviz_plugins:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
-    version: 0.4.0
+    version: 0.5.0
   core/autoware_system_designer:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -31,7 +31,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.12.0
+    version: 1.1.0
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -35,7 +35,7 @@ repositories:
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
-    version: 1.7.2
+    version: 1.8.0
   core/autoware_rviz_plugins:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -113,7 +113,7 @@ repositories:
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
-    version: 0.50.0
+    version: 0.51.0
 
   # sensor_component
   sensor_component/external/sensor_component_description:

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -54,7 +54,7 @@ repositories:
   universe/autoware_universe:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git
-    version: 0.50.2
+    version: 0.51.0
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git

--- a/repositories/tools.repos
+++ b/repositories/tools.repos
@@ -2,4 +2,4 @@ repositories:
   tools:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
-    version: 0.6.0
+    version: 0.7.0


### PR DESCRIPTION
## Description
Update autoware.repos files for Autoware Core 1.8.0.
https://github.com/autowarefoundation/autoware/issues/7047

## How was this PR tested?

### Humble
- [x] source build
  - [x] planning simulation
  - [x] rosbag simulation
  - [x] AWSIM simulation
- [x] docker build
  - [x] planning simulation
  - [x] AWSIM simulation
  - [x] scenario simulation

### Jazzy
- [x] source build
  - [x] planning simulation
  - [x] rosbag simulation
  - [x] AWSIM simulation
- [x] docker build
  - [x] planning simulation
  - [x] AWSIM simulation
  - [x] scenario simulation
