### PR TITLE
ci(health-check): always invoke require-label, gate via run-condition

### DIFF
--- a/.github/workflows/health-check-ansible-artifacts.yaml
+++ b/.github/workflows/health-check-ansible-artifacts.yaml
@@ -34,10 +34,11 @@ jobs:
 
   require-label:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: ${{ always() }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:health-check
+      run-condition: ${{ needs.changed-files.outputs.should-run == 'true' }}
 
   install-artifacts:
     needs: require-label

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -34,10 +34,11 @@ jobs:
 
   require-label:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: ${{ always() }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:health-check
+      run-condition: ${{ needs.changed-files.outputs.should-run == 'true' }}
 
   install-dev-env:
     needs: require-label

--- a/.github/workflows/health-check-pr.yaml
+++ b/.github/workflows/health-check-pr.yaml
@@ -39,10 +39,11 @@ jobs:
 
   require-label:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: ${{ always() }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:health-check
+      run-condition: ${{ needs.changed-files.outputs.should-run == 'true' }}
 
   health-check:
     if: ${{ always() }}


### PR DESCRIPTION
- Lift the path-filter `if` off the calling `require-label` job in all three health-check workflows so the reusable workflow is always invoked.
- Push the path-filter result through the reusable workflow's `run-condition` input so unrelated PRs report a `skipped` check_run that satisfies the required `require-label / require-label` rule, instead of producing no check_run at all.

## Why

- It failed to execute here: https://github.com/autowarefoundation/autoware/pull/7098

The repository ruleset requires `require-label / require-label`, but the calling job was gated by `if: needs.changed-files.outputs.should-run == 'true'`. On PRs that touched none of the watched paths, the reusable workflow was never invoked, no check_run with that name was ever reported, and the required check stayed unsatisfied — even though the PR was legitimately unrelated to health-check. With this change the required check always reports: `skipped` on unrelated PRs, `success`/`failure` on relevant ones, depending on whether the `run:health-check` label is present. Heavy downstream jobs continue to gate on `require-label.outputs.result == 'true'`, so they still run only on labeled, in-scope PRs.

This mirrors the canonical pattern already in use in [autoware_core's build-test-tidy-pr workflow](https://github.com/autowarefoundation/autoware_core/blob/main/.github/workflows/build-test-tidy-pr.yaml) and the matrix `health-check` job in [.github/workflows/health-check-pr.yaml](https://github.com/autowarefoundation/autoware/blob/5b27e88e84683deb4afaf0aa917f80082a608871/.github/workflows/health-check-pr.yaml).

---

## Test plan

- [ ] After merge, open a PR that touches **no** watched paths (e.g. `.devcontainer/**` only) and verify `require-label / require-label` reports `skipped` on the head SHA — required check satisfied.
- [ ] Open a PR that touches a watched path (e.g. `docker/**` or `repositories/*.repos`) **without** the `run:health-check` label and verify `require-label / require-label` reports `failure` (label missing).
- [ ] Add the `run:health-check` label and verify the check flips to `success` and the heavy downstream jobs (`health-check (...) / docker-build`, `install-dev-env-required`, `install-artifacts`) run on the relevant workflow.
- [ ] Inspect via the API to confirm the check_run name renders as `require-label / require-label`:
  ```
  gh api repos/autowarefoundation/autoware/commits/<HEAD_SHA>/check-runs --jq '.check_runs[] | select(.name=="require-label") | {workflow: .name, conclusion}'
  ```