### PR TITLE
feat(docker): bake runtime deps into devel images

### DIFF
--- a/docker/core.Dockerfile
+++ b/docker/core.Dockerfile
@@ -89,6 +89,16 @@ RUN --mount=type=bind,source=src/core/autoware_core,target=/tmp/autoware/src/cor
       --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     rm -rf build log
 
+RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    rosdep install -y --from-paths /tmp/autoware/src/core \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" \
+      --dependency-types=exec
+
 FROM ${BASE_IMAGE} AS core
 ARG ROS_DISTRO
 ENV AUTOWARE_RUNTIME=1

--- a/docker/universe-cuda.Dockerfile
+++ b/docker/universe-cuda.Dockerfile
@@ -66,6 +66,19 @@ RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
       --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     rm -rf build log
 
+COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/autoware/
+
+RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    rosdep install -y --from-paths /tmp/autoware/src \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" \
+      --dependency-types=exec && \
+    rm -rf /tmp/autoware
+
 FROM ${BASE_CUDA_RUNTIME_IMAGE} AS universe-cuda
 ARG ROS_DISTRO
 ENV AUTOWARE_RUNTIME=1

--- a/docker/universe.Dockerfile
+++ b/docker/universe.Dockerfile
@@ -55,6 +55,19 @@ RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
       --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     rm -rf build log
 
+COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/autoware/
+
+RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    rosdep install -y --from-paths /tmp/autoware/src \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" \
+      --dependency-types=exec && \
+    rm -rf /tmp/autoware
+
 FROM ${CORE_IMAGE} AS universe
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO


### PR DESCRIPTION
- `core-devel`, `universe-devel`, and `universe-devel-cuda` now resolve `rosdep --dependency-types=exec` in addition to the existing build/test/buildtool resolution, mirroring the pattern the runtime stages (`core`, `universe`, `universe-cuda`) already use.
- `universe-devel` and `universe-devel-cuda` re-COPY `src/**/package.xml` because `universe-dependencies` deletes `/tmp/autoware` before `universe-devel` inherits.

## Why

The published `*-devel` images shipped with build/test deps only, so anyone using a devel image to actually launch what they built had to run rosdep themselves (or hop to a separate runtime image just to run). Baking exec deps in costs ~1.9 GB per variant on disk but lets `ros2 launch` work out of the box from the devel image.

---

- Removes the need for the runtime-deps wrapper Dockerfile in #7098 once these images are republished.

## Test plan

- [ ] Build the affected targets locally:

  ```bash
  docker buildx bake -f docker/docker-bake.hcl core-devel
  docker buildx bake -f docker/docker-bake.hcl universe-devel
  docker buildx bake -f docker/docker-bake.hcl universe-devel-cuda
  ```

- [ ] Confirm `rosdep` is fully satisfied for exec deps (expected output: `All required rosdeps installed successfully`):

  ```bash
  docker run --rm -v "$(pwd)/src/core:/tmp/src:ro" autoware:core-devel-jazzy bash -lc "rosdep check --from-paths /tmp/src --ignore-src --rosdistro jazzy --dependency-types=exec"
  docker run --rm -v "$(pwd)/src:/tmp/src:ro" autoware:universe-devel-jazzy bash -lc "rosdep check --from-paths /tmp/src --ignore-src --rosdistro jazzy --dependency-types=exec"
  docker run --rm --gpus all -v "$(pwd)/src:/tmp/src:ro" autoware:universe-devel-cuda-jazzy bash -lc "rosdep check --from-paths /tmp/src --ignore-src --rosdistro jazzy --dependency-types=exec"
  ```

- [ ] Spot-check a runtime-only package is present (would have been missing on the previous devel images):

  ```bash
  docker run --rm autoware:universe-devel-jazzy bash -c "dpkg -s ros-jazzy-rviz2 | head -2"
  ```

  - [ ] Output begins with `Package: ros-jazzy-rviz2` followed by `Status: install ok installed`

- [ ] Image size delta vs `main` is approximately +1.9 GB per devel variant (`docker image ls autoware`).