### PR TITLE
ci(docker): strip provenance from bake metadata to fix Build summary

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -230,7 +230,7 @@ jobs:
           TAG_VERSION: ${{ steps.meta.outputs.version }}
           TAG_REF: ${{ steps.meta.outputs.ref }}
           USE_REGISTRY_CONTEXTS: ${{ inputs.bake-group != 'ci-base' }}
-          # Drop SLSA provenance from the bake --metadata-file output. buildx
+          # Drop provenance from the bake --metadata-file output. buildx
           # embeds it by default, and it is almost entirely a ~38 KB
           # github_event_payload dump per target. For multi-target groups
           # (ci-core, ci-universe) the metadata then exceeds Linux's 128 KiB

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -230,14 +230,8 @@ jobs:
           TAG_VERSION: ${{ steps.meta.outputs.version }}
           TAG_REF: ${{ steps.meta.outputs.ref }}
           USE_REGISTRY_CONTEXTS: ${{ inputs.bake-group != 'ci-base' }}
-          # Drop provenance from the bake --metadata-file output. buildx
-          # embeds it by default, and it is almost entirely a ~38 KB
-          # github_event_payload dump per target. For multi-target groups
-          # (ci-core, ci-universe) the metadata then exceeds Linux's 128 KiB
-          # single-env-var limit, so the downstream `Build summary` step that
-          # passes it via BAKE_METADATA fails to start bash with "Argument
-          # list too long". The summary only reads containerimage.digest;
-          # image attestations are already off via `provenance: false` below.
+          # Without this, BAKE_METADATA exceeds 128 KiB on multi-target
+          # groups and the summary step fails to start bash (E2BIG).
           BUILDX_METADATA_PROVENANCE: disabled
         with:
           source: .

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -230,6 +230,15 @@ jobs:
           TAG_VERSION: ${{ steps.meta.outputs.version }}
           TAG_REF: ${{ steps.meta.outputs.ref }}
           USE_REGISTRY_CONTEXTS: ${{ inputs.bake-group != 'ci-base' }}
+          # Drop SLSA provenance from the bake --metadata-file output. buildx
+          # embeds it by default, and it is almost entirely a ~38 KB
+          # github_event_payload dump per target. For multi-target groups
+          # (ci-core, ci-universe) the metadata then exceeds Linux's 128 KiB
+          # single-env-var limit, so the downstream `Build summary` step that
+          # passes it via BAKE_METADATA fails to start bash with "Argument
+          # list too long". The summary only reads containerimage.digest;
+          # image attestations are already off via `provenance: false` below.
+          BUILDX_METADATA_PROVENANCE: disabled
         with:
           source: .
           push: true


### PR DESCRIPTION
## Description

The `📊 Build summary` step in `.github/workflows/docker-build.yaml` fails for the `ci-core` and `ci-universe` bake groups with:

```
##[error]An error occurred trying to start process '/usr/bin/bash' ...
Argument list too long
```

Example failure: [run 25897515158, job `jazzy-amd64 / build-core / ci-core`](https://github.com/autowarefoundation/autoware/actions/runs/25897515158/job/76240267514). The build itself succeeds — only the summary step fails.

### Root cause

The summary step receives the bake metadata via `BAKE_METADATA: ${{ steps.bake.outputs.metadata }}` as an environment variable. By default (`BUILDX_METADATA_PROVENANCE=min`) buildx embeds SLSA provenance into the `--metadata-file` output. Measured from the failing run:

| Item | Size |
|------|------|
| Full metadata (`ci-core`, 3 targets) | ~137 KB |
| `buildx.build.provenance` (3 targets) | ~121 KB (98% of total) |
| └ `invocation.environment.github_event_payload` | 38 KB × 3 |
| Metadata without provenance | ~2.7 KB |

The provenance is almost entirely the GitHub `push` webhook payload captured into `github_event_payload`. The resulting ~137 KB value exceeds the Linux per-environment-variable limit (`MAX_ARG_STRLEN` = 128 KiB), so `execve` of bash fails with `E2BIG`. Single-target groups like `ci-base` (~41 KB) stay under the limit and pass.

### Fix

Set `BUILDX_METADATA_PROVENANCE: disabled` on the `🔨 Build and push` bake step. This removes `buildx.build.provenance` from `steps.bake.outputs.metadata`, shrinking it from ~137 KB to ~2.7 KB. The summary step only reads `containerimage.digest`, and image attestations are already disabled via `provenance: false`, so nothing else is affected.

## How was this PR tested?

- Reproduced the `E2BIG` threshold locally: a 136,897-byte environment variable fails bash startup with `argument list too long` (matching the CI error), while the 2,773-byte post-fix size starts cleanly.
- Verified YAML validity and `pre-commit` (`yamllint`, `prettier`) pass on the changed workflow.
- Full end-to-end confirmation requires a `docker-build` workflow run on this branch.