### PR TITLE
fix(agnocast): delete limitation to humble

### DIFF
--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -52,7 +52,6 @@
     - role: autoware.dev_env.gdown
     - role: autoware.dev_env.build_tools
     - role: autoware.dev_env.agnocast
-      when: rosdistro == 'humble'
 
     # Autoware module dependencies
     - role: autoware.dev_env.acados

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -91,7 +91,7 @@
     content: |
       Types: deb
       URIs: http://ppa.launchpad.net/t4-system-software/agnocast/ubuntu
-      Suites: jammy
+      Suites: {{ ansible_distribution_release }}
       Components: main
       Signed-By: /etc/apt/keyrings/agnocast-ppa.gpg
     mode: "0644"


### PR DESCRIPTION
## Description
Limitation to ubuntu22.04/ros2-humble is deleted for Agnocast installation.
Agnocast has already supported ubuntu24.04/ros2-jazzy.

## How was this PR tested?
Checked that the ansible script successfully works in ubuntu24.04/ros2-jazzy environment.