### PR TITLE
feat(`autoware.repos`): `autoware_simple_planning_simulator`

### DIFF
--- a/repositories/autoware-nightly.repos
+++ b/repositories/autoware-nightly.repos
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
     version: main
+  core/autoware_simple_planning_simulator:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_simple_planning_simulator.git
+    version: main    # Should be updated to a specific version after the first release of autoware_simple_planning_simulator
   core/autoware_system_designer:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -40,6 +40,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
     version: 0.5.0
+  core/autoware_simple_planning_simulator:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_simple_planning_simulator.git
+    version: main    # Should be updated to a specific version after the first release of autoware_simple_planning_simulator
   core/autoware_system_designer:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -40,10 +40,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
     version: 0.5.0
-  core/autoware_simple_planning_simulator:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_simple_planning_simulator.git
-    version: main    # Should be updated to a specific version after the first release of autoware_simple_planning_simulator
   core/autoware_system_designer:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git


### PR DESCRIPTION
## Description

:warning: PLEASE DO NOT MERGE THIS PR UNTIL THE FIRST RELEASE OF `autoware_simple_planning_simulator` AND ALSO THE PORTING OF SIMULATOR-DEPENDENT PACKAGES :warning:

This PR is one of the tasks based on the discussion [here](https://github.com/orgs/autowarefoundation/discussions/6892).

- Add `autoware_simple_planning_simulator` repository to `autoware.repos`.
- Split simulator-dependent packages out of `autoware_universe` into the new repository.

We must merge the following PR first:
- https://github.com/autowarefoundation/autoware_simple_planning_simulator/pull/1

Then we must merge the following PRs at the same timing (including this PR):
- https://github.com/autowarefoundation/autoware/pull/7130
- https://github.com/autowarefoundation/autoware_universe/pull/12641
- https://github.com/autowarefoundation/autoware_universe/pull/12642
- https://github.com/autowarefoundation/autoware_universe/pull/12643

## Related links

- https://github.com/orgs/autowarefoundation/discussions/6892
- https://github.com/autowarefoundation/autoware_simple_planning_simulator.git
- https://github.com/autowarefoundation/autoware_simple_planning_simulator/pull/1
- https://github.com/autowarefoundation/autoware_universe/pull/12641

## How was this PR tested?

- ~~Not tested yet; the new repository is still under development, and also we need to create some PRs that ports simulator-dependent packages from `autoware_universe` to `autoware_simple_planning_simulator`. This PR is to update the repository manifest in advance of the first release of `autoware_simple_planning_simulator`.~~
- ~~We are going to do tests once all the PRs for the first release of `autoware_simple_planning_simulator` are ready.~~
- Tested as follows:
```bash
$ git clone git@github.com:autowarefoundation/autoware.git
$ cd autoware

# Add the following repository in `autoware.repos` to test this PR's change
'''
  core/autoware_simple_planning_simulator:
    type: git
    url: https://github.com/autowarefoundation/autoware_simple_planning_simulator.git
    version: main    # Should be updated to a specific version after the first release of autoware_simple_planning_simulator
'''

$ vcs import src < repositories/autoware.repos
$ vcs import src < repositories/autoware-nightly.repos

# Emulate the situation that all package port PRs are merged
$ rm -rf src/universe/autoware_universe/simulator/autoware_dummy_perception_publisher src/universe/autoware_universe/simulator/autoware_learning_based_vehicle_model src/universe/autoware_universe/simulator/autoware_simple_planning_simulator

$ rosdep install -y --from-paths ./src --ignore-src --rosdistro $ROS_DISTRO
$ colcon build --base-paths ./src --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
$ source ~/autoware/install/setup.bash
$ MAP_NAME=sample-map-planning ros2 launch autoware_launch \
    planning_simulator.launch.xml \
    map_path:=$HOME/autoware_map/$MAP_NAME \
    vehicle_model:=sample_vehicle \
    sensor_model:=sample_sensor_kit
```
- I verified setting start/goal pose and autonomous driving are performed without error

## Notes for reviewers

- This change only updates the repository manifest; no package code changes in this repository.

## Interface changes

- None.

### Topic changes

- None.

## Effects on system behavior

- None at runtime; repository layout updated.