### PR TITLE
feat(autoware_system_designer): update version to v0.4.1

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -43,7 +43,7 @@ repositories:
   core/autoware_system_designer:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git
-    version: v0.4.0
+    version: v0.4.1
   # Temporary pin, see https://github.com/autowarefoundation/autoware_core/issues/1031
   core/external/rviz_2d_overlay_plugins:
     type: git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -43,7 +43,7 @@ repositories:
   core/autoware_system_designer:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git
-    version: v0.3.2
+    version: v0.4.0
   # Temporary pin, see https://github.com/autowarefoundation/autoware_core/issues/1031
   core/external/rviz_2d_overlay_plugins:
     type: git


### PR DESCRIPTION
## Description

update autoware_system_designer version to v0.4.1

## How was this PR tested?

locally built and logging-sim and planning-sim worked (by existing ros launcher)

PR CIs could load the autoware_system_designer
https://results.pre-commit.ci/run/github/429697802/1779941278.dMSGj3skSZmDhKL8IXoNcg

<img width="1090" height="904" alt="image" src="https://github.com/user-attachments/assets/66b26e9e-24ff-4484-81a4-5759b1202374" />

