### PR TITLE
ci: trigger changed-files gates on file deletions

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -16,7 +16,7 @@ jobs:
   changed-files:
     runs-on: ubuntu-24.04
     outputs:
-      should-build: ${{ steps.check.outputs.any_changed == 'true' || steps.last-success.outputs.sha == '' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag') }}
+      should-build: ${{ steps.check.outputs.any_modified == 'true' || steps.last-success.outputs.sha == '' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/health-check-ansible-artifacts.yaml
+++ b/.github/workflows/health-check-ansible-artifacts.yaml
@@ -16,7 +16,7 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      should-run: ${{ steps.check.outputs.any_changed }}
+      should-run: ${{ steps.check.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/health-check-ansible.yaml
+++ b/.github/workflows/health-check-ansible.yaml
@@ -16,7 +16,7 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      should-run: ${{ steps.check.outputs.any_changed }}
+      should-run: ${{ steps.check.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/health-check-pr.yaml
+++ b/.github/workflows/health-check-pr.yaml
@@ -16,7 +16,7 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      should-run: ${{ steps.check.outputs.any_changed }}
+      should-run: ${{ steps.check.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
- Switch the `changed-files` gate from `any_changed` to `any_modified` in four workflows so that **deletions** (not just adds/modifies/renames) trigger the job.
- Closes a silent gap where a deletion-only change merges/publishes without its health check or docker build ever running.

## Why

`changed-files`-gated workflows skip their real work on PRs/pushes that **only delete** files under their path filter, because the gate reads `any_changed`, which excludes deletions. The companion required check treats the skip as a pass, so a deletion-only change passes silently without the workflow ever running.

The fix swaps the gate output to `any_modified`, which is identical except it also counts deleted files:

| Output | Returns `true` when matched files… | Change types covered |
|---|---|---|
| [`any_changed`](https://github.com/step-security/changed-files#output_any_changed) | …have changed | Added, Copied, Modified, Renamed **(ACMR)** |
| [`any_modified`](https://github.com/step-security/changed-files#output_any_modified) | …have been modified | Added, Copied, Modified, Renamed, **Deleted** **(ACMRD)** |

Verbatim from the [`step-security/changed-files`](https://github.com/step-security/changed-files) outputs docs:

> **`any_changed`** — Returns `true` when any of the filenames provided using the `files*` or `files_ignore*` inputs have changed. […] i.e. *includes a combination of all added, copied, modified and renamed files (ACMR)*.

> **`any_modified`** — Returns `true` when any of the filenames provided using the `files*` or `files_ignore*` inputs have been modified. […] i.e. *includes a combination of all added, copied, modified, renamed, and deleted files (ACMRD)*.

Affected workflows:

- [`.github/workflows/health-check-ansible.yaml`](https://github.com/autowarefoundation/autoware/blob/59468eedea0e2f40c5ad7265082dacfc81631392/.github/workflows/health-check-ansible.yaml)
- [`.github/workflows/health-check-ansible-artifacts.yaml`](https://github.com/autowarefoundation/autoware/blob/59468eedea0e2f40c5ad7265082dacfc81631392/.github/workflows/health-check-ansible-artifacts.yaml)
- [`.github/workflows/health-check-pr.yaml`](https://github.com/autowarefoundation/autoware/blob/59468eedea0e2f40c5ad7265082dacfc81631392/.github/workflows/health-check-pr.yaml)
- [`.github/workflows/docker-build-and-push.yaml`](https://github.com/autowarefoundation/autoware/blob/59468eedea0e2f40c5ad7265082dacfc81631392/.github/workflows/docker-build-and-push.yaml)

---

- Found while reviewing #7169 (a deletion-only ansible PR that silently skipped the `install-dev-env` health check).
- Loosely related: #7052.

## Test plan

No pre-emptive testing. The `any_changed` vs `any_modified` semantics (deletions included only in the latter) are unambiguous from the [action outputs docs](https://github.com/step-security/changed-files#output_any_modified), so this trusts the docs. The deletion-trigger behaviour will be exercised naturally by the next deletion-only PR that touches a covered path, where it actually matters.
