### PR TITLE
feat(autoware.repos): bump the cuda_blackboard version to 0.4.0

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -99,7 +99,7 @@ repositories:
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git
-    version: 0.3.0
+    version: 0.4.0
   universe/external/negotiated:
     type: git
     url: https://github.com/osrf/negotiated.git


### PR DESCRIPTION
## Description
This PR updates `cuda_blackboard` from 0.3.0 to the latest release, 0.4.0.
The 0.4.0 release adds a new feature that improves performance while maintaining backward compatibility.

<details>
<summary>What was updated in cuda_blackboard</summary>
Up to 0.3.0, `cuda_blackboard` adopts the following workflow:

```mermaid
sequenceDiagram
    box Singleton (one instance per process)
    participant BB as CudaBlackboard[T]
end
participant CUDAPUB as CudaBlackboardPublisher[T]
participant USERPUB as Publisher
participant CUDASUB as CudaBlackboardSubscribers[T]
participant USERSUB as Subscribers

USERPUB->>USERPUB: cuda_blackboard::make_unique[T]()
activate USERPUB
Note over USERPUB: cudaMalloc device memory<br>(blocking driver allocation)
deactivate USERPUB

Note over USERPUB: fill device buffer (GPU kernels)
Note over USERPUB: wait until GPU work is complete

USERPUB->>CUDAPUB: publish()
CUDAPUB->>BB: registerData(producer_name, std::move(ptr), tickets)
BB-->>CUDAPUB: uint64_t instance_id

CUDAPUB-)CUDASUB: publish<br>(actual passed data is std_msgs::UInt64{instance_id})

CUDASUB->>BB: queryData(instance_id)
BB-->>CUDASUB: shared_ptr[const T]
Note over BB: tickets -= 1, if tickets == 0 -> erase entry<br>(blackboard loses ownership of the buffer)

CUDASUB-->>+USERSUB: shared_ptr[const T]
Note over USERSUB: run user callback(shared_ptr[const T])
Note over USERSUB: wait until GPU work is complete
USERSUB-->>-CUDASUB: end callback

Note over BB,CUDASUB: last reference dropped<br>cudaFree returns memory to the driver<br>(blocking, synchronous)
```

In particular, it relies on `cudaMalloc` and `cudaFree`, which are known as "expensive" and "implicitly blocking" APIs, that can block other CUDA operations in the same process. This can cause performance problems for cases where multiple Autoware nodes run in a single process by a composable node container.

For this reason, 0.4.0 adopts the following workflow:

```mermaid
sequenceDiagram
    box Singletons (one instance per process)
    participant POOL as CudaMemPoolContext
    participant BB as CudaBlackboard[T]
    end
    participant CUDAPUB as CudaBlackboardPublisher[T]
    participant USERPUB as user Publisher

    participant CUDASUB as CudaBlackboardSubscribers[T]
    participant USERSUB as user Subscribers

    USERPUB->>POOL: cuda_blackboard::make_unique[T]()
    Note over POOL: allocate & zero-init device memory from pool<br>(blocks until memory is ready)
    POOL-->>USERPUB: CudaUniquePtr[T]

    Note over USERPUB: fill device buffer (GPU kernels)
    Note over USERPUB: wait until GPU work is complete
    USERPUB->>CUDAPUB: publish()

    CUDAPUB->>BB: registerData(producer_name, std::move(ptr), tickets)
    BB-->>CUDAPUB: uint64_t instance_id

    CUDAPUB-)CUDASUB: publish<br>(actual passed data is std_msgs::UInt64{instance_id})

    CUDASUB->>BB: queryData(instance_id)
    Note over BB: tickets -= 1, if tickets == 0 -> erase entry<br>(blackboard loses ownership of the buffer)
    BB-->>CUDASUB: shared_ptr[const T]

    activate CUDASUB
    Note over CUDASUB: make user_stream wait until<br>data is ready (cudaStreamWaitEvent)
    CUDASUB-->>+USERSUB: shared_ptr[const T]
    Note over USERSUB: run user callback(shared_ptr[const T])
    USERSUB-->>-CUDASUB: end callback
    Note over CUDASUB: enqueue consumer dependency to the free stream
    deactivate CUDASUB

    Note over POOL,CUDASUB: last shared_ptr dropped<br>cudaFreeAsync enqueued on the pool's free stream 
```

Now `cuda_blackboard` utilizes a pooled memory region for repeated allocation to publish topics, which is less expensive and asynchronous (non-blocking). This is handled inside the blackboard, so user code doesn't need to take care of it. Also, for performance-sensitive usage, additional support is introduced. It is now allowed to pass a CUDA stream to a cuda_blackboard subscriber on construction and reduce the synchronization overhead.

</details>

## How was this PR tested?
```bash
$ vcs import src < repositories/autoware.repos
$ vcs status ./src/
# ...
=== ./src/universe/external/cuda_blackboard (git) ===
HEAD detached at 0.4.0
nothing to commit, working tree clean
# ...
```

For the tests covering the contents of the new cuda_blackboard, please see [this PR](https://github.com/autowarefoundation/cuda_blackboard/pull/22) for details.

## Related Links
- New release of cuda_blackboard introduced by this PR: https://github.com/autowarefoundation/cuda_blackboard/releases/tag/0.4.0
- Main feature-introduction PR on cuda_blackboard: https://github.com/autowarefoundation/cuda_blackboard/pull/22
