### PR TITLE
Update patent search workflow to module-based BigQuery review

### DIFF
--- a/.agents/skills/autoware-patent-search/SKILL.md
+++ b/.agents/skills/autoware-patent-search/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: autoware-patent-search
+description: Review Autoware pull requests or code changes for patent-sensitive autonomous-driving features, search the two target patent databases, Google Patents and J-PlatPat, generate non-legal claim-comparison scaffolds, and outline monitoring alerts. Use when asked to check Autoware changes for IP/patent review candidates, generate patent search keywords in English/Japanese, search patents in Google Patents and J-PlatPat, compare candidate assignees for user review, draft claim charts for attorney review, configure patent monitoring, or produce a non-legal patent-sensitivity report for planning, control, fallback/MRM, route planning, perception-to-planning interactions, maps, traffic signals, infrastructure, pedestrians, or other vehicle-interaction behavior.
+---
+
+# Autoware Patent Search
+
+## Core rule
+
+Do not make a legal conclusion about infringement, validity, freedom to operate, or non-infringement. Treat the output as technical triage for IP counsel or patent professionals. Say that results are candidates for review, not determinations. If the user asks for automated infringement judgment, convert it into a non-legal claim-comparison worksheet with a human-review disposition; do not output an infringement/non-infringement verdict.
+
+Use the product/project name **Autoware** consistently.
+
+## Workflow
+
+1. Identify changed Autoware functionality from the PR diff, files, package manifests, class/function names, launch files, parameters, message types, and ROS node names.
+2. Decide whether the change introduces or materially modifies a patent-sensitive autonomous-driving technical feature. Prioritize:
+   - behavior, trajectory, motion, route, or lane planning
+   - vehicle control
+   - fallback behavior, MRM, fail-operational behavior, degradation, emergency stops, or safety monitors
+   - interactions with vehicles, pedestrians, traffic signals, maps, V2X, infrastructure, or prediction
+3. Extract inputs, outputs, algorithmic steps, thresholds, state machines, optimization objectives, data associations, map queries, and message topics.
+4. Generate bilingual search terms using `references/search-taxonomy.md` and optionally the helper script:
+   ```bash
+   python .agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py --feature "lane change path generation with collision check" --jp "車線変更 経路生成 衝突判定"
+   ```
+   The older `google_patents_queries.py` wrapper remains available for compatibility.
+5. Search only the two target patent databases, **Google Patents** and **J-PlatPat**, using multiple query variants. When internet access and either target database UI/API is available, actually open the database results, capture candidate patent identifiers, titles, assignees, publication/application dates, abstracts/snippets, and URLs. If access is blocked, record that limitation and provide reproducible queries instead:
+   - **Google Patents** for broad international cross-searching, English/Japanese keyword variants, CPC hints, and assignee filters.
+   - **J-PlatPat** for Japan-focused patent searches. Use Japanese terms first, then English technical terms where useful. Because J-PlatPat URLs and session behavior can change, record the exact keywords and filters entered even when a stable deep link is unavailable.
+   - Combine broad domain terms with implementation-specific words such as state machine, cost function, drivable area, occupancy grid, predicted path, stop line, emergency stop, or MRM.
+   - Add CPC/IPC hints from `references/search-taxonomy.md` when the feature is clear.
+6. Assignee/company handling:
+   - Do **not** decide which company's IP is infringed.
+   - Do **not** limit the search to one company by default.
+   - If the user provides companies, add them as assignee filters and report candidates for the user to inspect.
+   - If the user wants to decide the company risk themselves, present a candidate-assignee table with database, query, publication/application number, assignee, title, and why it might be relevant.
+7. Read patent abstracts/claims at a high level and compare technical concepts only. Do not overstate similarity.
+8. For claim charts, generate a **claim-comparison scaffold** only:
+   - identify claim elements from candidate patent text at a high level
+   - map each element to Autoware files, functions, parameters, topics, or behavior evidence when available
+   - record differences, assumptions, and uncertainty
+   - leave the final disposition as "Needs IP review" or "Not enough evidence" rather than infringement/non-infringement
+9. For continuous monitoring, define saved queries for Google Patents and J-PlatPat, cadence, alert routing, and deduplication keys. Alerts should say "new candidate for IP review" and must not use legal conclusion language.
+10. If requirements, scope, or definition of done are unclear, propose a lightweight review charter before doing a full search. Include scope, the two target databases, excluded conclusions, evidence to capture, and completion criteria.
+11. Produce the required report format below.
+
+## Requirements and definition-of-done co-design
+
+When the user has not finalized requirements, suggest this starting point and refine it with them:
+
+- **Purpose**: find patent documents worth IP-professional review for Autoware technical changes.
+- **Databases**: only Google Patents and J-PlatPat are in scope. Do not add any additional patent database unless the user explicitly changes the target scope in a later request.
+- **Scope**: changed Autoware behavior and its directly affected planning/control/safety interfaces.
+- **Out of scope**: legal opinions, automated infringement/non-infringement conclusions, claim charts presented as legal analysis, validity opinions, or freedom-to-operate sign-off.
+- **Evidence captured**: exact queries, database used, date searched, filters, result links or identifiers, candidate assignees, publication/application dates, relevant abstracts/snippets, and technical reason for relevance.
+- **Definition of done**: every patent-sensitive changed feature has bilingual keywords, Google Patents and J-PlatPat search attempts, candidate results or a no-candidate explanation, optional claim-comparison scaffold when candidates exist, risk level, monitoring recommendation, and next human review action.
+
+## Required report format
+
+For each relevant change, output:
+
+1. Technical feature summary
+2. Changed packages, files, classes, functions, and ROS nodes
+3. Inputs and outputs
+4. Algorithmic steps
+5. Why the feature may be patent-sensitive
+6. English patent search keywords
+7. Japanese patent search keywords
+8. Google Patents and J-PlatPat searches performed, with exact queries/filters used
+9. Candidate patent documents and assignees for user/IP review, if any
+10. Possible patent classification hints, if inferable
+11. Risk level: High / Medium / Watch / Low
+12. Reason for the risk level
+13. Non-legal claim-comparison scaffold, if requested or if strong candidates exist
+14. Continuous-monitoring query/alert recommendation, if requested
+15. Recommended next review action
+
+If no relevant patent-sensitive technical feature is found, state that no candidate was identified and explain the changed files/functions reviewed.
+
+## Risk level guidance
+
+- **High**: New or materially changed planning/control/fallback algorithm with specific decision logic, optimization, prediction interaction, map/traffic interaction, or safety/MRM behavior.
+- **Medium**: Meaningful modification to an existing autonomous-driving algorithm or node behavior, including thresholds, state transitions, or object/trajectory handling.
+- **Watch**: Refactor, parameter, interface, visualization, or tooling change that touches patent-sensitive modules but does not clearly alter core behavior.
+- **Low**: Documentation, build, CI, dependency, formatting, tests, or non-AD behavior with no apparent autonomous-driving technical algorithm change.
+
+## Patent matching, claim-comparison, and monitoring automation
+
+- **Actual database search**: perform live searches in Google Patents and J-PlatPat when available. Record target database, query, filters, date, result count if visible, candidate publication/application numbers, assignees, titles, links, and why each candidate is technically relevant.
+- **Automated matching**: rank candidates by technical overlap signals such as shared feature terms, CPC/IPC/FI/F-term hints, assignee scope requested by the user, and overlap between claim concepts and Autoware behavior evidence. Treat ranking as triage only.
+- **Claim-comparison scaffold**: use `scripts/patent_review_scaffold.py` after collecting candidates into CSV. The worksheet may compare claim elements to Autoware evidence, but final legal disposition must remain for human/IP-professional review.
+- **Continuous monitoring**: save the exact Google Patents and J-PlatPat queries generated by `scripts/patent_cross_search_queries.py`, run them on a cadence such as weekly or monthly, deduplicate alerts by target database plus publication/application number, and alert only with "new candidate for IP review" language while avoiding legal conclusion wording.
+
+## Search tips
+
+- Use URLs produced by the helper script as starting points, then refine manually in each database.
+- Search English and Japanese terms separately; Japanese patent documents may have English machine translations, but Japanese technical terms often reveal different results.
+- Prefer broad technical terms first, then add implementation-specific words.
+- Search by CPC/IPC only as a supplement; classifications are hints, not proof that a result is relevant.
+- Record the exact search queries used in the final report when the user asks for traceability.
+
+## Resources
+
+- `references/search-taxonomy.md`: bilingual terms, database notes, and CPC/IPC hints for Autoware autonomous-driving review.
+- `scripts/patent_cross_search_queries.py`: generate Google Patents URLs and J-PlatPat query plans from feature phrases, Japanese terms, CPC codes, and optional assignees.
+- `scripts/google_patents_queries.py`: compatibility wrapper that emits Google Patents URLs only.
+- `scripts/patent_review_scaffold.py`: generate a non-legal candidate table, claim-comparison worksheet, and monitoring plan from reviewed candidate patent records.

--- a/.agents/skills/autoware-patent-search/SKILL.md
+++ b/.agents/skills/autoware-patent-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoware-patent-search
-description: Review Autoware pull requests or code changes for patent-sensitive autonomous-driving features, search the two target patent databases, Google Patents and J-PlatPat, generate non-legal claim-comparison scaffolds, and outline monitoring alerts. Use when asked to check Autoware changes for IP/patent review candidates, generate patent search keywords in English/Japanese, search patents in Google Patents and J-PlatPat, compare candidate assignees for user review, draft claim charts for attorney review, configure patent monitoring, or produce a non-legal patent-sensitivity report for planning, control, fallback/MRM, route planning, perception-to-planning interactions, maps, traffic signals, infrastructure, pedestrians, or other vehicle-interaction behavior.
+description: Review existing Autoware modules for patent-sensitive autonomous-driving technical features, generate Google Patents Public Data BigQuery searches, and produce non-legal candidate patent review reports. Use when asked to evaluate Autoware modules, packages, directories, or components for IP/patent review candidates; generate patent search keywords in English/Japanese; generate BigQuery SQL for Google Patents Public Data; produce non-legal patent-sensitivity reports for planning, control, fallback/MRM, route planning, perception-to-planning interactions, maps, traffic signals, infrastructure, pedestrians, or other vehicle-interaction behavior.
 ---
 
 # Autoware Patent Search
@@ -11,98 +11,127 @@ Do not make a legal conclusion about infringement, validity, freedom to operate,
 
 Use the product/project name **Autoware** consistently.
 
+## MVP scope
+
+The MVP is **module-based**, not PR-diff-based. Evaluate an existing Autoware module, package, directory, or component and identify potentially relevant third-party patent documents for human IP review.
+
+Suggested MVP targets include:
+
+- planning, behavior planning, trajectory planning, obstacle avoidance, lane change, and stop decision
+- vehicle control
+- fallback, MRM, safety monitor, fail-operational, degradation, and emergency stop behavior
+- perception-to-planning interfaces and prediction-to-planning interactions
+- route planning, maps, traffic signals, infrastructure, pedestrians, and other vehicle-interaction behavior
+
+Google Patents Public Data queried through **BigQuery** is the primary retrieval mechanism. Do not require a Google Patents-specific API, do not automate or scrape Google Patents web pages, and do not use non-Google patent databases. Google Patents search URLs may be generated only as supporting links for human review.
+
 ## Workflow
 
-1. Identify changed Autoware functionality from the PR diff, files, package manifests, class/function names, launch files, parameters, message types, and ROS node names.
-2. Decide whether the change introduces or materially modifies a patent-sensitive autonomous-driving technical feature. Prioritize:
+1. Accept an Autoware module, package, directory, or component as input.
+2. Inspect available module evidence, including README files, source files, launch/config files, parameters, ROS nodes, topics, classes, functions, package manifests, and tests.
+3. Extract patent-sensitive technical features from the existing implementation. Prioritize:
    - behavior, trajectory, motion, route, or lane planning
    - vehicle control
    - fallback behavior, MRM, fail-operational behavior, degradation, emergency stops, or safety monitors
-   - interactions with vehicles, pedestrians, traffic signals, maps, V2X, infrastructure, or prediction
-3. Extract inputs, outputs, algorithmic steps, thresholds, state machines, optimization objectives, data associations, map queries, and message topics.
-4. Generate bilingual search terms using `references/search-taxonomy.md` and optionally the helper script:
+   - interactions with vehicles, pedestrians, traffic signals, maps, V2X, infrastructure, prediction, or perception outputs
+4. Extract inputs, outputs, algorithmic steps, behavior logic, thresholds, state machines, optimization objectives, data associations, map queries, and message topics.
+5. Generate bilingual search terms using `references/search-taxonomy.md` and optionally the helper script:
    ```bash
-   python .agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py --feature "lane change path generation with collision check" --jp "車線変更 経路生成 衝突判定"
+   python .agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py \
+     --module "planning/behavior_path_planner" \
+     --feature "lane change path generation with collision check using predicted objects" \
+     --keyword "behavior planning" \
+     --jp "車線変更 経路生成 衝突判定 予測物体" \
+     --cpc B60W --cpc G05D1/00
    ```
-   The older `google_patents_queries.py` wrapper remains available for compatibility.
-5. Search only the two target patent databases, **Google Patents** and **J-PlatPat**, using multiple query variants. When internet access and either target database UI/API is available, actually open the database results, capture candidate patent identifiers, titles, assignees, publication/application dates, abstracts/snippets, and URLs. If access is blocked, record that limitation and provide reproducible queries instead:
-   - **Google Patents** for broad international cross-searching, English/Japanese keyword variants, CPC hints, and assignee filters.
-   - **J-PlatPat** for Japan-focused patent searches. Use Japanese terms first, then English technical terms where useful. Because J-PlatPat URLs and session behavior can change, record the exact keywords and filters entered even when a stable deep link is unavailable.
-   - Combine broad domain terms with implementation-specific words such as state machine, cost function, drivable area, occupancy grid, predicted path, stop line, emergency stop, or MRM.
-   - Add CPC/IPC hints from `references/search-taxonomy.md` when the feature is clear.
-6. Assignee/company handling:
-   - Do **not** decide which company's IP is infringed.
-   - Do **not** limit the search to one company by default.
-   - If the user provides companies, add them as assignee filters and report candidates for the user to inspect.
-   - If the user wants to decide the company risk themselves, present a candidate-assignee table with database, query, publication/application number, assignee, title, and why it might be relevant.
-7. Read patent abstracts/claims at a high level and compare technical concepts only. Do not overstate similarity.
-8. For claim charts, generate a **claim-comparison scaffold** only:
-   - identify claim elements from candidate patent text at a high level
-   - map each element to Autoware files, functions, parameters, topics, or behavior evidence when available
-   - record differences, assumptions, and uncertainty
-   - leave the final disposition as "Needs IP review" or "Not enough evidence" rather than infringement/non-infringement
-9. For continuous monitoring, define saved queries for Google Patents and J-PlatPat, cadence, alert routing, and deduplication keys. Alerts should say "new candidate for IP review" and must not use legal conclusion language.
-10. If requirements, scope, or definition of done are unclear, propose a lightweight review charter before doing a full search. Include scope, the two target databases, excluded conclusions, evidence to capture, and completion criteria.
-11. Produce the required report format below.
+6. Generate reproducible BigQuery Standard SQL for Google Patents Public Data. Use combinations of English technical keywords, Japanese technical keywords, CPC/IPC hints, assignee/company filters, publication/application metadata, and title/abstract/description/claims text where available.
+7. Run the SQL when BigQuery access is available. If BigQuery access is unavailable, record that limitation and provide the reproducible SQL query instead. The example SQL in this repository has been structurally validated, but it has not been executed in this environment.
+8. As the next validation step, a human reviewer should configure a Google Cloud project with BigQuery access and run either a BigQuery dry run or a small `LIMIT 10` query before relying on candidate retrieval results.
+9. Use optional Google Patents search URLs only as human-review links. Do not treat URLs as the main retrieval source.
+10. Read candidate patent titles, abstracts, snippets, and claims at a high level and compare technical concepts only. Do not overstate similarity.
+11. For claim charts, generate a **claim-comparison scaffold** only:
+    - identify claim elements from candidate patent text at a high level
+    - map each element to Autoware files, functions, parameters, topics, or behavior evidence when available
+    - record differences, assumptions, and uncertainty
+    - leave the final disposition as "Needs IP review" or "Not enough evidence" rather than infringement/non-infringement
+12. For continuous monitoring, save BigQuery SQL queries, cadence, alert routing, and deduplication keys. Alerts should say "new candidate for IP review" and must not use legal conclusion language.
+13. Produce the required report format below.
 
 ## Requirements and definition-of-done co-design
 
 When the user has not finalized requirements, suggest this starting point and refine it with them:
 
-- **Purpose**: find patent documents worth IP-professional review for Autoware technical changes.
-- **Databases**: only Google Patents and J-PlatPat are in scope. Do not add any additional patent database unless the user explicitly changes the target scope in a later request.
-- **Scope**: changed Autoware behavior and its directly affected planning/control/safety interfaces.
-- **Out of scope**: legal opinions, automated infringement/non-infringement conclusions, claim charts presented as legal analysis, validity opinions, or freedom-to-operate sign-off.
-- **Evidence captured**: exact queries, database used, date searched, filters, result links or identifiers, candidate assignees, publication/application dates, relevant abstracts/snippets, and technical reason for relevance.
-- **Definition of done**: every patent-sensitive changed feature has bilingual keywords, Google Patents and J-PlatPat search attempts, candidate results or a no-candidate explanation, optional claim-comparison scaffold when candidates exist, risk level, monitoring recommendation, and next human review action.
+- **Purpose**: find patent documents worth IP-professional review for existing Autoware modules.
+- **Primary patent data source**: Google Patents Public Data through BigQuery. Do not add any additional patent database unless the user explicitly changes scope in a later request.
+- **Supporting links**: Google Patents web URLs may be generated for human review, but candidate retrieval is BigQuery-first.
+- **Scope**: module behavior and directly affected planning/control/safety/perception-to-planning interfaces.
+- **Out of scope**: legal opinions, automated infringement/non-infringement conclusions, validity opinions, freedom-to-operate sign-off, Google Patents browser automation, web scraping, or non-Google patent databases.
+- **Evidence captured**: module files/classes/functions/nodes/topics reviewed, exact BigQuery SQL, whether the SQL was only structurally validated or actually executed, date searched, filters, candidate publication/application identifiers, assignees, dates, titles/abstract snippets, CPC/IPC hints, optional Google Patents links, and technical reason for relevance.
+- **Definition of done**: every patent-sensitive feature in the selected module has English/Japanese keywords, CPC/IPC hints if inferable, reproducible BigQuery SQL, candidate results or a no-candidate explanation, optional claim-comparison scaffold when candidates exist, risk level, and next human IP review action.
 
 ## Required report format
 
-For each relevant change, output:
+For each Autoware module, output:
 
-1. Technical feature summary
-2. Changed packages, files, classes, functions, and ROS nodes
-3. Inputs and outputs
-4. Algorithmic steps
-5. Why the feature may be patent-sensitive
-6. English patent search keywords
-7. Japanese patent search keywords
-8. Google Patents and J-PlatPat searches performed, with exact queries/filters used
-9. Candidate patent documents and assignees for user/IP review, if any
-10. Possible patent classification hints, if inferable
-11. Risk level: High / Medium / Watch / Low
-12. Reason for the risk level
-13. Non-legal claim-comparison scaffold, if requested or if strong candidates exist
-14. Continuous-monitoring query/alert recommendation, if requested
-15. Recommended next review action
+1. Module/package name
+2. Files/classes/functions/ROS nodes/topics reviewed
+3. Technical feature summary
+4. Inputs and outputs
+5. Algorithmic steps or behavior logic
+6. Why the feature may be patent-sensitive
+7. English patent search keywords
+8. Japanese patent search keywords
+9. CPC/IPC hints
+10. BigQuery SQL queries generated for Google Patents Public Data
+11. Candidate patent documents and assignees
+12. Technical reason for relevance
+13. Risk level: High / Medium / Watch / Low
+14. Reason for risk level
+15. Recommended next human IP review action
 
-If no relevant patent-sensitive technical feature is found, state that no candidate was identified and explain the changed files/functions reviewed.
+If no relevant patent-sensitive technical feature is found, state that no candidate feature was identified and explain the module files/functions reviewed.
+
+## Candidate language
+
+Use candidate-only language such as:
+
+- "candidate for IP review"
+- "potentially relevant patent document"
+- "technical overlap candidate"
+- "needs human IP review"
+- "not enough evidence"
+
+Do not state or imply infringement, non-infringement, validity, invalidity, or FTO clearance.
 
 ## Risk level guidance
 
-- **High**: New or materially changed planning/control/fallback algorithm with specific decision logic, optimization, prediction interaction, map/traffic interaction, or safety/MRM behavior.
-- **Medium**: Meaningful modification to an existing autonomous-driving algorithm or node behavior, including thresholds, state transitions, or object/trajectory handling.
-- **Watch**: Refactor, parameter, interface, visualization, or tooling change that touches patent-sensitive modules but does not clearly alter core behavior.
+- **High**: Existing module contains or exposes a planning/control/fallback algorithm with specific decision logic, optimization, prediction interaction, map/traffic interaction, or safety/MRM behavior and close technical-overlap candidates are found.
+- **Medium**: Existing module has meaningful autonomous-driving behavior logic, thresholds, state transitions, or object/trajectory handling and plausible candidates are found.
+- **Watch**: Module touches patent-sensitive interfaces or parameters, but the behavior is generic, incomplete, or candidate overlap is weak.
 - **Low**: Documentation, build, CI, dependency, formatting, tests, or non-AD behavior with no apparent autonomous-driving technical algorithm change.
 
 ## Patent matching, claim-comparison, and monitoring automation
 
-- **Actual database search**: perform live searches in Google Patents and J-PlatPat when available. Record target database, query, filters, date, result count if visible, candidate publication/application numbers, assignees, titles, links, and why each candidate is technically relevant.
-- **Automated matching**: rank candidates by technical overlap signals such as shared feature terms, CPC/IPC/FI/F-term hints, assignee scope requested by the user, and overlap between claim concepts and Autoware behavior evidence. Treat ranking as triage only.
+- **BigQuery retrieval**: generate and, when available, run Google Patents Public Data Standard SQL against `patents-public-data.patents.publications`. Search localized title, abstract, description, and claims text where available, along with CPC/IPC, assignee, publication/application dates, and publication/application identifiers. In this repository, generated SQL examples are structurally validated but not executed; next validation is a human BigQuery dry run or small `LIMIT 10` query after Google Cloud project setup.
+- **Optional human-review links**: include Google Patents web links such as `https://patents.google.com/patent/<publication_number>` in candidate tables or optional search URL sections. Do not scrape these pages.
+- **Automated matching**: rank candidates by technical overlap signals such as shared feature terms, CPC/IPC hints, assignee scope requested by the user, and overlap between claim concepts and Autoware behavior evidence. Treat ranking as triage only.
 - **Claim-comparison scaffold**: use `scripts/patent_review_scaffold.py` after collecting candidates into CSV. The worksheet may compare claim elements to Autoware evidence, but final legal disposition must remain for human/IP-professional review.
-- **Continuous monitoring**: save the exact Google Patents and J-PlatPat queries generated by `scripts/patent_cross_search_queries.py`, run them on a cadence such as weekly or monthly, deduplicate alerts by target database plus publication/application number, and alert only with "new candidate for IP review" language while avoiding legal conclusion wording.
+- **Continuous monitoring**: save the exact BigQuery SQL generated by `scripts/patent_cross_search_queries.py`, run it on a cadence such as weekly or monthly, deduplicate alerts by publication/application number, and alert only with "new candidate for IP review" language while avoiding legal conclusion wording.
 
 ## Search tips
 
-- Use URLs produced by the helper script as starting points, then refine manually in each database.
-- Search English and Japanese terms separately; Japanese patent documents may have English machine translations, but Japanese technical terms often reveal different results.
-- Prefer broad technical terms first, then add implementation-specific words.
+- Start from module evidence: README descriptions, package manifests, launch/config parameters, ROS topics, classes, functions, and algorithm-specific constants.
+- Search English and Japanese terms separately and together; Japanese technical terms remain useful in Google Patents Public Data localized text fields.
+- Prefer broad technical terms first, then add implementation-specific words such as state machine, cost function, drivable area, occupancy grid, predicted path, stop line, emergency stop, or MRM.
 - Search by CPC/IPC only as a supplement; classifications are hints, not proof that a result is relevant.
-- Record the exact search queries used in the final report when the user asks for traceability.
+- Record the exact BigQuery SQL used in the final report when the user asks for traceability.
 
 ## Resources
 
-- `references/search-taxonomy.md`: bilingual terms, database notes, and CPC/IPC hints for Autoware autonomous-driving review.
-- `scripts/patent_cross_search_queries.py`: generate Google Patents URLs and J-PlatPat query plans from feature phrases, Japanese terms, CPC codes, and optional assignees.
-- `scripts/google_patents_queries.py`: compatibility wrapper that emits Google Patents URLs only.
+- `references/search-taxonomy.md`: module-based bilingual terms and CPC/IPC hints for Google Patents Public Data review.
+- `scripts/patent_cross_search_queries.py`: legacy-named helper that generates BigQuery SQL for Google Patents Public Data plus optional human-review Google Patents URLs.
+- `scripts/google_patents_queries.py`: compatibility wrapper that emits optional Google Patents review URLs only.
 - `scripts/patent_review_scaffold.py`: generate a non-legal candidate table, claim-comparison worksheet, and monitoring plan from reviewed candidate patent records.
+- `examples/module_review_lane_change.md`: sample module-based output report with candidate placeholders.
+- `examples/lane_change_bigquery.sql`: sample BigQuery SQL generated for a lane-change module review.
+- `examples/patent_review_sample/`: test-only workflow documentation/sample data; not an Autoware runtime module.

--- a/.agents/skills/autoware-patent-search/agents/openai.yaml
+++ b/.agents/skills/autoware-patent-search/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Autoware Patent Search"
+  short_description: "Search patent DBs and scaffold Autoware IP review charts/alerts."
+  default_prompt: "Review this Autoware change for patent-sensitive technical features, search only Google Patents and J-PlatPat when available, and generate non-legal candidate matching, claim-comparison, and monitoring notes for IP review."

--- a/.agents/skills/autoware-patent-search/agents/openai.yaml
+++ b/.agents/skills/autoware-patent-search/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Autoware Patent Search"
-  short_description: "Search patent DBs and scaffold Autoware IP review charts/alerts."
-  default_prompt: "Review this Autoware change for patent-sensitive technical features, search only Google Patents and J-PlatPat when available, and generate non-legal candidate matching, claim-comparison, and monitoring notes for IP review."
+  short_description: "Generate BigQuery patent triage for Autoware modules."
+  default_prompt: "Review this existing Autoware module for patent-sensitive technical features, generate Google Patents Public Data BigQuery SQL for candidate retrieval, and produce non-legal candidate matching, claim-comparison, and monitoring notes for human IP review."

--- a/.agents/skills/autoware-patent-search/examples/lane_change_bigquery.sql
+++ b/.agents/skills/autoware-patent-search/examples/lane_change_bigquery.sql
@@ -1,0 +1,52 @@
+-- Google Patents Public Data candidate search for Autoware module: planning/behavior_path_planner/lane_change
+-- Technical triage only; results are candidates for human IP-professional review.
+SELECT
+  p.publication_number,
+  p.application_number,
+  p.publication_date,
+  p.filing_date,
+  (SELECT text FROM UNNEST(p.title_localized) LIMIT 1) AS title,
+  (SELECT text FROM UNNEST(p.abstract_localized) LIMIT 1) AS abstract,
+  ARRAY(SELECT a.name FROM UNNEST(p.assignee_harmonized) a LIMIT 10) AS assignees,
+  ARRAY(SELECT c.code FROM UNNEST(p.cpc) c LIMIT 10) AS cpc_codes,
+  (IF((EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%autonomous vehicle%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%autonomous vehicle%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%autonomous vehicle%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%autonomous vehicle%')), 1, 0) +
+  IF((EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%automated driving%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%automated driving%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%automated driving%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%automated driving%')), 1, 0) +
+  IF((EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%trajectory planning%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%trajectory planning%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%trajectory planning%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%trajectory planning%')), 1, 0) +
+  IF((EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%vehicle control%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%vehicle control%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%vehicle control%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%vehicle control%')), 1, 0)) AS broad_context_match_count,
+  CONCAT('https://patents.google.com/patent/', p.publication_number) AS google_patents_url
+FROM `patents-public-data.patents.publications` AS p
+WHERE (
+    (EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%lane change path generation with collision check using predicted objects%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%lane change path generation with collision check using predicted objects%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%lane change path generation with collision check using predicted objects%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%lane change path generation with collision check using predicted objects%'))
+    OR (EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%behavior planning%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%behavior planning%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%behavior planning%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%behavior planning%'))
+    OR (EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%safety margin%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%safety margin%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%safety margin%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%safety margin%'))
+    OR (EXISTS (SELECT 1 FROM UNNEST(p.title_localized) txt WHERE LOWER(txt.text) LIKE '%車線変更 経路生成 衝突判定 予測物体%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.abstract_localized) txt WHERE LOWER(txt.text) LIKE '%車線変更 経路生成 衝突判定 予測物体%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.description_localized) txt WHERE LOWER(txt.text) LIKE '%車線変更 経路生成 衝突判定 予測物体%') OR
+      EXISTS (SELECT 1 FROM UNNEST(p.claims_localized) txt WHERE LOWER(txt.text) LIKE '%車線変更 経路生成 衝突判定 予測物体%'))
+  )
+  AND (EXISTS (SELECT 1 FROM UNNEST(p.cpc) c WHERE STARTS_WITH(c.code, 'B60W')) OR EXISTS (SELECT 1 FROM UNNEST(p.cpc) c WHERE STARTS_WITH(c.code, 'G05D1/00')) OR EXISTS (SELECT 1 FROM UNNEST(p.cpc) c WHERE STARTS_WITH(c.code, 'G08G1/00')))
+  AND (EXISTS (SELECT 1 FROM UNNEST(p.assignee_harmonized) a WHERE LOWER(a.name) LIKE '%toyota%') OR EXISTS (SELECT 1 FROM UNNEST(p.assignee_harmonized) a WHERE LOWER(a.name) LIKE '%toyota motor%'))
+  AND p.publication_date >= 20180101
+ORDER BY broad_context_match_count DESC, p.publication_date DESC
+LIMIT 25;

--- a/.agents/skills/autoware-patent-search/examples/module_review_lane_change.md
+++ b/.agents/skills/autoware-patent-search/examples/module_review_lane_change.md
@@ -1,0 +1,76 @@
+# Sample module-based patent review report: lane change planning
+
+This is sample output for validating the `autoware-patent-search` MVP workflow. It is technical triage only and is not a legal opinion about infringement, validity, freedom to operate, or non-infringement.
+
+## 1. Module/package name
+
+`planning/behavior_path_planner/lane_change` (example module target)
+
+## 2. Files/classes/functions/ROS nodes/topics reviewed
+
+Sample placeholders for a real module review:
+
+- README/package documentation: `README.md`
+- Launch/config/parameters: lane-change safety threshold and collision-check parameters
+- Source/classes/functions: lane-change path generation, predicted-object collision check, safety evaluation
+- ROS interfaces: route/lanelet inputs, predicted objects, candidate path output, behavior-planning status topics
+
+## 3. Technical feature summary
+
+Lane-change path generation that evaluates candidate paths against predicted objects and applies collision-check or safety-margin logic before accepting a lane-change maneuver.
+
+## 4. Inputs and outputs
+
+- Inputs: ego pose/velocity, route/lanelet map, predicted objects, candidate lane-change paths, safety thresholds
+- Outputs: accepted/rejected lane-change path, behavior-planning status, optional diagnostic or debug markers
+
+## 5. Algorithmic steps or behavior logic
+
+1. Generate candidate lane-change paths from current lane to target lane.
+2. Estimate object interactions using predicted object trajectories.
+3. Apply collision or safety-margin checks over the candidate path horizon.
+4. Accept, reject, or defer the lane-change maneuver based on safety logic.
+
+## 6. Why the feature may be patent-sensitive
+
+The feature combines autonomous-driving behavior planning, path generation, object prediction, and collision/safety decision logic. These are common areas for patent filings, so matching patent documents should be treated as candidates for human IP review.
+
+## 7. English patent search keywords
+
+lane change, path generation, collision check, predicted objects, behavior planning, autonomous vehicle, trajectory planning, safety margin
+
+## 8. Japanese patent search keywords
+
+車線変更, 経路生成, 衝突判定, 予測物体, 行動計画, 自動運転, 安全余裕
+
+## 9. CPC/IPC hints
+
+- B60W
+- G05D1/00
+- G08G1/00
+
+## 10. BigQuery SQL queries generated for Google Patents Public Data
+
+See `examples/lane_change_bigquery.sql`. The SQL is structurally validated in this repository, but it has not been executed in this environment.
+
+## 11. Candidate patent documents and assignees
+
+| Publication | Assignee | Title | Status |
+| --- | --- | --- | --- |
+| TBD from BigQuery result | TBD | TBD | candidate for IP review |
+
+## 12. Technical reason for relevance
+
+Placeholder candidates should be reviewed for overlap with lane-change path generation, predicted-object collision checks, safety margins, and autonomous-driving behavior-planning decision logic.
+
+## 13. Risk level
+
+Watch
+
+## 14. Reason for risk level
+
+This sample describes a patent-sensitive technical area, but candidate patent documents have not been retrieved or reviewed in this placeholder report.
+
+## 15. Recommended next human IP review action
+
+After configuring a Google Cloud project with BigQuery access, run a BigQuery dry run or a small `LIMIT 10` query, then collect candidate publication records, and have an IP professional review the technical overlap. Use "needs human IP review" or "not enough evidence" as dispositions; do not make legal conclusions.

--- a/.agents/skills/autoware-patent-search/examples/patent_review_sample/README.md
+++ b/.agents/skills/autoware-patent-search/examples/patent_review_sample/README.md
@@ -1,0 +1,14 @@
+# Patent review workflow sample data
+
+This directory contains test-only documentation and sample configuration data for
+validating the `autoware-patent-search` module-based BigQuery workflow.
+
+These files are **not** an Autoware runtime module and should not be installed,
+launched, or proposed upstream. They are intentionally stored under the skill's
+`examples/` directory so reviewers can exercise the patent-review workflow
+without changing the real Autoware source tree or repository dependencies.
+
+The sample configuration represents a conceptual behavior-planning review target:
+lane-change path generation with a predicted-object collision-check margin. Use
+it as workflow documentation/test data for extracting technical features,
+bilingual search keywords, CPC/IPC hints, and BigQuery SQL.

--- a/.agents/skills/autoware-patent-search/examples/patent_review_sample/lane_change_safety_threshold.param.yaml
+++ b/.agents/skills/autoware-patent-search/examples/patent_review_sample/lane_change_safety_threshold.param.yaml
@@ -1,0 +1,10 @@
+# Test-only patent-review workflow sample data.
+# This file is not an Autoware runtime module, launch input, or upstream proposal.
+# It represents a conceptual lane-change behavior-planning threshold for examples.
+
+/**:
+  ros__parameters:
+    # Sample collision-check margin for lane-change path generation.
+    # Raising this value makes the validation scenario conceptually more conservative
+    # around predicted objects during lane-change safety evaluation.
+    lane_change_predicted_object_collision_margin_m: 1.8

--- a/.agents/skills/autoware-patent-search/references/search-taxonomy.md
+++ b/.agents/skills/autoware-patent-search/references/search-taxonomy.md
@@ -1,13 +1,21 @@
 # Autoware patent-search taxonomy
 
-Use these terms to build cross-database patent queries. Mix broad domain terms with the changed algorithm's specific terms.
+Use these terms to build module-based Google Patents Public Data BigQuery queries. Mix broad domain terms with the existing module's specific functions, topics, parameters, and behavior logic.
 
-## Target databases
+## Primary patent data source
 
-Only use these patent databases unless the user explicitly changes scope later:
+Use **Google Patents Public Data via BigQuery** as the primary retrieval mechanism. Generate reproducible Standard SQL against `patents-public-data.patents.publications`. Optional Google Patents search URLs may be produced only as supporting human-review links.
 
-- **Google Patents**: useful for international full-text searching, English/Japanese terms, CPC hints, and assignee filters.
-- **J-PlatPat**: useful for Japan-focused searches, FI/F-term exploration, Japanese terminology, and Japanese assignee names. Prefer recording the keywords and filters used because stable deep links may not always be available.
+Do not use non-Google patent databases for this MVP unless the user explicitly changes scope later.
+
+## Suggested MVP module targets
+
+- planning, behavior planning, trajectory planning, route planning
+- obstacle avoidance, lane change, stop decision, drivable area generation
+- vehicle control, lateral control, longitudinal control, trajectory tracking
+- fallback, MRM, safety monitor, fail operational, emergency stop, degradation
+- perception-to-planning interfaces, object prediction, predicted paths, occupancy grids
+- traffic signals, intersections, stop lines, maps, lanelets, infrastructure, V2X
 
 ## English terms
 
@@ -45,9 +53,9 @@ Use these only when the user asks to review a particular company's portfolio or 
 - English examples: Toyota, Honda, Nissan, Denso, Aisin, Hitachi Astemo, Bosch, Continental, Mobileye, Waymo, Aptiv, ZF
 - Japanese examples: トヨタ, 本田技研, ホンダ, 日産, デンソー, アイシン, 日立Astemo, ボッシュ, コンチネンタル
 
-## CPC/IPC and Japan classification hints
+## CPC/IPC classification hints
 
-Use these only as search hints:
+Use these only as search hints, not legal conclusions:
 
 - B60W: vehicle control systems for different vehicle sub-units, ADAS, automated driving control
 - G05D1/00: control of position, course, altitude, or attitude of vehicles
@@ -57,4 +65,3 @@ Use these only as search hints:
 - G06V20/56: image/video understanding for autonomous driving scenes
 - G01C21/00: navigation and route guidance
 - H04W4/40: vehicle communication services, V2X-related communication
-- J-PlatPat FI/F-term exploration is useful after a relevant Japanese document is found; record FI/F-term values if they appear in candidate results.

--- a/.agents/skills/autoware-patent-search/references/search-taxonomy.md
+++ b/.agents/skills/autoware-patent-search/references/search-taxonomy.md
@@ -1,0 +1,60 @@
+# Autoware patent-search taxonomy
+
+Use these terms to build cross-database patent queries. Mix broad domain terms with the changed algorithm's specific terms.
+
+## Target databases
+
+Only use these patent databases unless the user explicitly changes scope later:
+
+- **Google Patents**: useful for international full-text searching, English/Japanese terms, CPC hints, and assignee filters.
+- **J-PlatPat**: useful for Japan-focused searches, FI/F-term exploration, Japanese terminology, and Japanese assignee names. Prefer recording the keywords and filters used because stable deep links may not always be available.
+
+## English terms
+
+- autonomous vehicle, automated driving, self-driving vehicle, ADAS
+- behavior planning, behavior planner, maneuver planning, decision making
+- trajectory planning, path planning, motion planning, route planning
+- vehicle control, lateral control, longitudinal control, trajectory tracking
+- lane change, lane keeping, lane departure, obstacle avoidance, path generation
+- drivable area, occupancy grid, cost map, predicted path, object prediction
+- collision checking, time-to-collision, risk assessment, safety margin
+- traffic signal recognition, stop line, intersection handling, right of way
+- pedestrian interaction, vulnerable road user, cut-in vehicle, following vehicle
+- minimum risk maneuver, MRM, fallback, fail operational, emergency stop, degradation
+- HD map, lanelet, road boundary, map matching, localization uncertainty
+- V2X, infrastructure, cooperative driving, connected vehicle
+
+## Japanese terms
+
+- 自動運転, 自律走行, 運転支援, 先進運転支援, ADAS
+- 行動計画, 経路計画, 軌道計画, 走行計画, 動作計画
+- 車両制御, 横制御, 縦制御, 軌道追従
+- 車線変更, 車線維持, 障害物回避, 経路生成
+- 走行可能領域, 占有格子, コストマップ, 予測経路, 物体予測
+- 衝突判定, 衝突回避, 衝突リスク, 安全余裕, 車間距離
+- 信号機, 停止線, 交差点, 優先権, 右左折
+- 歩行者, 交通参加者, 割り込み車両, 後続車
+- 最小リスク操作, MRM, フォールバック, フェイルオペレーショナル, 緊急停止, 縮退運転
+- 高精度地図, レーンレット, 道路境界, マップマッチング, 自己位置推定誤差
+- 路車間通信, V2X, インフラ協調, 協調走行
+
+## Company/assignee search terms
+
+Use these only when the user asks to review a particular company's portfolio or wants candidate assignees surfaced for their own review.
+
+- English examples: Toyota, Honda, Nissan, Denso, Aisin, Hitachi Astemo, Bosch, Continental, Mobileye, Waymo, Aptiv, ZF
+- Japanese examples: トヨタ, 本田技研, ホンダ, 日産, デンソー, アイシン, 日立Astemo, ボッシュ, コンチネンタル
+
+## CPC/IPC and Japan classification hints
+
+Use these only as search hints:
+
+- B60W: vehicle control systems for different vehicle sub-units, ADAS, automated driving control
+- G05D1/00: control of position, course, altitude, or attitude of vehicles
+- G08G1/00: traffic control systems, road vehicle traffic management
+- B62D15/00: steering control and path following
+- B60T7/00 or B60T8/00: braking control and vehicle safety braking
+- G06V20/56: image/video understanding for autonomous driving scenes
+- G01C21/00: navigation and route guidance
+- H04W4/40: vehicle communication services, V2X-related communication
+- J-PlatPat FI/F-term exploration is useful after a relevant Japanese document is found; record FI/F-term values if they appear in candidate results.

--- a/.agents/skills/autoware-patent-search/scripts/google_patents_queries.py
+++ b/.agents/skills/autoware-patent-search/scripts/google_patents_queries.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compatibility wrapper that emits Google Patents search URLs for Autoware IP triage."""
+"""Compatibility wrapper that emits optional Google Patents review URLs."""
 
 from __future__ import annotations
 

--- a/.agents/skills/autoware-patent-search/scripts/google_patents_queries.py
+++ b/.agents/skills/autoware-patent-search/scripts/google_patents_queries.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper that emits Google Patents search URLs for Autoware IP triage."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from patent_cross_search_queries import build_google_queries  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--feature", required=True, help="English feature phrase to search")
+    parser.add_argument("--jp", help="Japanese feature phrase to search")
+    parser.add_argument("--cpc", action="append", default=[], help="CPC code hint, repeatable")
+    parser.add_argument("--assignee", action="append", default=[], help="Optional assignee filter, repeatable")
+    args = parser.parse_args()
+
+    for plan in build_google_queries(args.feature, args.jp, args.cpc, args.assignee):
+        print(plan.query)
+        print(plan.url)
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py
+++ b/.agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Generate Google Patents URLs and J-PlatPat query plans for Autoware IP triage."""
+"""Generate BigQuery SQL for Google Patents Public Data Autoware IP triage.
+
+The filename is retained for compatibility with existing skill instructions. The
+primary output is reproducible Standard SQL for the Google Patents Public Data
+BigQuery dataset. Optional Google Patents search URLs are emitted only as
+human-review links.
+"""
 
 from __future__ import annotations
 
@@ -9,14 +15,20 @@ import re
 from urllib.parse import quote_plus
 
 
+GOOGLE_PATENTS_PUBLICATIONS_TABLE = "`patents-public-data.patents.publications`"
 DEFAULT_CONTEXT = [
-    '"autonomous vehicle"',
-    '"automated driving"',
-    '"trajectory planning"',
-    '"vehicle control"',
+    "autonomous vehicle",
+    "automated driving",
+    "trajectory planning",
+    "vehicle control",
 ]
-
-JPLATPAT_URL = "https://www.j-platpat.inpit.go.jp/"
+TEXT_FIELDS = [
+    "title_localized",
+    "abstract_localized",
+    "description_localized",
+    "claims_localized",
+]
+CPC_BROAD_RE = re.compile(r"^[A-HY][0-9]{2}[A-Z]$", re.IGNORECASE)
 
 CPC_BROAD_RE = re.compile(r"^[A-HY][0-9]{2}[A-Z]$", re.IGNORECASE)
 
@@ -49,15 +61,173 @@ def google_assignee_filter(name: str) -> str:
 class QueryPlan:
     database: str
     query: str
-    url: str | None = None
-    note: str | None = None
+    url: str
+
+
+@dataclass(frozen=True)
+class BigQueryPlan:
+    source: str
+    module: str
+    sql: str
+    human_review_urls: list[str]
+
+
+def sql_string(value: str) -> str:
+    """Return a BigQuery Standard SQL string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def like_pattern(value: str) -> str:
+    """Return an escaped LIKE contains pattern for BigQuery."""
+    return "%" + value.lower().replace("%", r"\%").replace("_", r"\_") + "%"
+
+
+def google_cpc_filter(code: str) -> str:
+    """Return Google Patents URL CPC filter syntax for a classification hint.
+
+    Broad subclasses (for example B60W) use Google Patents metadata-style
+    ``cpc:`` syntax, which includes child classifications. More specific CPC
+    groups use field syntax with ``/low`` so children remain included instead of
+    matching only the exact classification.
+    """
+    normalized = code.strip().upper()
+    if CPC_BROAD_RE.fullmatch(normalized):
+        return f"cpc:{normalized}"
+    return f"CPC={normalized}/low"
+
+
+def google_assignee_filter(name: str) -> str:
+    """Return Google Patents URL assignee metadata filter syntax."""
+    cleaned = name.strip()
+    if not cleaned:
+        return ""
+    if re.search(r"\s", cleaned):
+        return f'assignee:"{cleaned}"'
+    return f"assignee:{cleaned}"
 
 
 def google_url_for(query: str) -> str:
     return f"https://patents.google.com/?q=({quote_plus(query)})"
 
 
+def normalized_terms(*term_groups: str | None) -> list[str]:
+    terms: list[str] = []
+    for term in term_groups:
+        if term and term.strip() and term.strip() not in terms:
+            terms.append(term.strip())
+    return terms
+
+
+def feature_terms(feature: str, keywords: list[str], jp: str | None) -> list[str]:
+    """Return terms that must drive candidate retrieval for the reviewed feature."""
+    return normalized_terms(feature, *keywords, jp)
+
+
+def context_terms() -> list[str]:
+    """Return broad autonomous-driving context terms used only as support signals."""
+    return normalized_terms(*DEFAULT_CONTEXT)
+
+
+def text_term_condition(term: str) -> str:
+    field_conditions = []
+    pattern = sql_string(like_pattern(term))
+    for field in TEXT_FIELDS:
+        field_conditions.append(
+            f"EXISTS (SELECT 1 FROM UNNEST(p.{field}) txt "
+            f"WHERE LOWER(txt.text) LIKE {pattern})"
+        )
+    return "(" + " OR\n      ".join(field_conditions) + ")"
+
+
+def text_query_condition(terms: list[str], indent: str = "    ") -> str:
+    return "(\n" + indent + ("\n" + indent + "OR ").join(text_term_condition(term) for term in terms) + "\n  )"
+
+
+def text_score_expression(terms: list[str]) -> str:
+    if not terms:
+        return "0"
+    return " +\n  ".join(f"IF({text_term_condition(term)}, 1, 0)" for term in terms)
+
+
+def cpc_condition(cpc: list[str]) -> str:
+    codes = [code.strip().upper() for code in cpc if code.strip()]
+    if not codes:
+        return ""
+    parts = [
+        f"EXISTS (SELECT 1 FROM UNNEST(p.cpc) c WHERE STARTS_WITH(c.code, {sql_string(code)}))"
+        for code in codes
+    ]
+    return "(" + " OR ".join(parts) + ")"
+
+
+def assignee_condition(assignees: list[str]) -> str:
+    names = [name.strip() for name in assignees if name.strip()]
+    if not names:
+        return ""
+    parts = [
+        "EXISTS (SELECT 1 FROM UNNEST(p.assignee_harmonized) a "
+        f"WHERE LOWER(a.name) LIKE {sql_string(like_pattern(name))})"
+        for name in names
+    ]
+    return "(" + " OR ".join(parts) + ")"
+
+
+def date_condition(field: str, value: str | None, operator: str) -> str:
+    if not value:
+        return ""
+    return f"p.{field} {operator} {value.replace('-', '')}"
+
+
+def build_bigquery_sql(
+    module: str,
+    feature: str,
+    keywords: list[str],
+    jp: str | None,
+    cpc: list[str],
+    assignee: list[str],
+    publication_after: str | None = None,
+    publication_before: str | None = None,
+    limit: int = 50,
+) -> str:
+    """Build a reproducible Google Patents Public Data SQL query."""
+    required_feature_terms = feature_terms(feature, keywords, jp)
+    if not required_feature_terms:
+        raise ValueError("At least one feature-specific term is required via --feature, --keyword, or --jp")
+    broad_context_terms = context_terms()
+    where_clauses = [text_query_condition(required_feature_terms)]
+    for optional_condition in [
+        cpc_condition(cpc),
+        assignee_condition(assignee),
+        date_condition("publication_date", publication_after, ">="),
+        date_condition("publication_date", publication_before, "<="),
+    ]:
+        if optional_condition:
+            where_clauses.append(optional_condition)
+
+    where_sql = "\n  AND ".join(where_clauses)
+    cpc_select = "ARRAY(SELECT c.code FROM UNNEST(p.cpc) c LIMIT 10) AS cpc_codes"
+    assignee_select = "ARRAY(SELECT a.name FROM UNNEST(p.assignee_harmonized) a LIMIT 10) AS assignees"
+    return f"""-- Google Patents Public Data candidate search for Autoware module: {module}
+-- Technical triage only; results are candidates for human IP-professional review.
+SELECT
+  p.publication_number,
+  p.application_number,
+  p.publication_date,
+  p.filing_date,
+  (SELECT text FROM UNNEST(p.title_localized) LIMIT 1) AS title,
+  (SELECT text FROM UNNEST(p.abstract_localized) LIMIT 1) AS abstract,
+  {assignee_select},
+  {cpc_select},
+  ({text_score_expression(broad_context_terms)}) AS broad_context_match_count,
+  CONCAT('https://patents.google.com/patent/', p.publication_number) AS google_patents_url
+FROM {GOOGLE_PATENTS_PUBLICATIONS_TABLE} AS p
+WHERE {where_sql}
+ORDER BY broad_context_match_count DESC, p.publication_date DESC
+LIMIT {limit};"""
+
+
 def build_google_queries(feature: str, jp: str | None, cpc: list[str], assignee: list[str]) -> list[QueryPlan]:
+    """Build optional Google Patents URL queries for human review links."""
     queries: list[str] = [feature]
     for context in DEFAULT_CONTEXT:
         queries.append(f"{feature} {context}")
@@ -76,52 +246,72 @@ def build_google_queries(feature: str, jp: str | None, cpc: list[str], assignee:
     return [QueryPlan("Google Patents", query, google_url_for(query)) for query in queries]
 
 
-def build_jplatpat_queries(feature: str, jp: str | None, cpc: list[str], assignee: list[str]) -> list[QueryPlan]:
-    base_terms = [term for term in [jp, f"{jp} 自動運転" if jp else None, feature] if term]
-    queries: list[str] = list(base_terms)
-    for name in assignee:
-        for term in base_terms:
-            queries.append(f"{term} / 出願人・権利者: {name}")
-    for code in cpc:
-        queries.append(f"{jp or feature} / 分類: {code}")
-    note = "Enter these terms in J-PlatPat patent/utility model search; record filters and result identifiers because stable deep links may be session-dependent."
-    return [QueryPlan("J-PlatPat", query, JPLATPAT_URL, note) for query in queries]
-
-
-def build_queries(feature: str, jp: str | None, cpc: list[str], assignee: list[str], databases: list[str]) -> list[QueryPlan]:
-    plans: list[QueryPlan] = []
-    selected = {database.lower() for database in databases}
-    if "google" in selected or "google-patent" in selected or "google-patents" in selected:
-        plans.extend(build_google_queries(feature, jp, cpc, assignee))
-    if "jplatpat" in selected or "j-platpat" in selected:
-        plans.extend(build_jplatpat_queries(feature, jp, cpc, assignee))
-    return plans
+def build_queries(
+    module: str,
+    feature: str,
+    keywords: list[str],
+    jp: str | None,
+    cpc: list[str],
+    assignee: list[str],
+    publication_after: str | None = None,
+    publication_before: str | None = None,
+    limit: int = 50,
+    include_urls: bool = False,
+) -> BigQueryPlan:
+    """Build the Google Patents Public Data query plan for a module."""
+    sql = build_bigquery_sql(
+        module,
+        feature,
+        keywords,
+        jp,
+        cpc,
+        assignee,
+        publication_after,
+        publication_before,
+        limit,
+    )
+    urls = [plan.url for plan in build_google_queries(feature, jp, cpc, assignee)] if include_urls else []
+    return BigQueryPlan("Google Patents Public Data via BigQuery", module, sql, urls)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--feature", required=True, help="English feature phrase to search")
-    parser.add_argument("--jp", help="Japanese feature phrase to search")
-    parser.add_argument("--cpc", action="append", default=[], help="CPC/IPC/FI classification hint, repeatable")
+    parser.add_argument("--module", required=True, help="Autoware module/package/directory/component being reviewed")
+    parser.add_argument("--feature", required=True, help="English technical feature phrase extracted from the module")
+    parser.add_argument("--keyword", action="append", default=[], help="Additional English technical keyword, repeatable")
+    parser.add_argument("--jp", help="Japanese technical keyword phrase to search")
+    parser.add_argument("--cpc", action="append", default=[], help="CPC/IPC classification hint, repeatable")
     parser.add_argument("--assignee", action="append", default=[], help="Optional assignee/company filter, repeatable")
+    parser.add_argument("--publication-after", help="Optional publication_date lower bound, YYYY-MM-DD")
+    parser.add_argument("--publication-before", help="Optional publication_date upper bound, YYYY-MM-DD")
+    parser.add_argument("--limit", type=int, default=50, help="Maximum BigQuery rows to return")
     parser.add_argument(
-        "--database",
-        action="append",
-        choices=["google", "google-patent", "google-patents", "jplatpat", "j-platpat"],
-        default=None,
-        help="Target database to include, repeatable. Defaults to the only supported targets: Google Patents and J-PlatPat.",
+        "--include-review-urls",
+        action="store_true",
+        help="Also print optional Google Patents search URLs for human review; BigQuery SQL remains primary.",
     )
     args = parser.parse_args()
 
-    databases = args.database or ["google", "jplatpat"]
-    for plan in build_queries(args.feature, args.jp, args.cpc, args.assignee, databases):
-        print(f"Database: {plan.database}")
-        print(f"Query: {plan.query}")
-        if plan.url:
-            print(f"URL: {plan.url}")
-        if plan.note:
-            print(f"Note: {plan.note}")
-        print()
+    plan = build_queries(
+        args.module,
+        args.feature,
+        args.keyword,
+        args.jp,
+        args.cpc,
+        args.assignee,
+        args.publication_after,
+        args.publication_before,
+        args.limit,
+        args.include_review_urls,
+    )
+    print(f"Source: {plan.source}")
+    print(f"Module: {plan.module}")
+    print("SQL:")
+    print(plan.sql)
+    if plan.human_review_urls:
+        print("\nOptional Google Patents human-review URLs:")
+        for url in plan.human_review_urls:
+            print(url)
     return 0
 
 

--- a/.agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py
+++ b/.agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Generate Google Patents URLs and J-PlatPat query plans for Autoware IP triage."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from urllib.parse import quote_plus
+
+
+DEFAULT_CONTEXT = [
+    '"autonomous vehicle"',
+    '"automated driving"',
+    '"trajectory planning"',
+    '"vehicle control"',
+]
+
+JPLATPAT_URL = "https://www.j-platpat.inpit.go.jp/"
+
+
+@dataclass(frozen=True)
+class QueryPlan:
+    database: str
+    query: str
+    url: str | None = None
+    note: str | None = None
+
+
+def google_url_for(query: str) -> str:
+    return f"https://patents.google.com/?q=({quote_plus(query)})"
+
+
+def build_google_queries(feature: str, jp: str | None, cpc: list[str], assignee: list[str]) -> list[QueryPlan]:
+    queries: list[str] = [feature]
+    for context in DEFAULT_CONTEXT:
+        queries.append(f"{feature} {context}")
+    if jp:
+        queries.extend([jp, f"{jp} 自動運転"])
+    for code in cpc:
+        queries.append(f"{feature} CPC={code}")
+    for name in assignee:
+        queries.append(f'{feature} assignee="{name}"')
+        if jp:
+            queries.append(f'{jp} assignee="{name}"')
+    return [QueryPlan("Google Patents", query, google_url_for(query)) for query in queries]
+
+
+def build_jplatpat_queries(feature: str, jp: str | None, cpc: list[str], assignee: list[str]) -> list[QueryPlan]:
+    base_terms = [term for term in [jp, f"{jp} 自動運転" if jp else None, feature] if term]
+    queries: list[str] = list(base_terms)
+    for name in assignee:
+        for term in base_terms:
+            queries.append(f"{term} / 出願人・権利者: {name}")
+    for code in cpc:
+        queries.append(f"{jp or feature} / 分類: {code}")
+    note = "Enter these terms in J-PlatPat patent/utility model search; record filters and result identifiers because stable deep links may be session-dependent."
+    return [QueryPlan("J-PlatPat", query, JPLATPAT_URL, note) for query in queries]
+
+
+def build_queries(feature: str, jp: str | None, cpc: list[str], assignee: list[str], databases: list[str]) -> list[QueryPlan]:
+    plans: list[QueryPlan] = []
+    selected = {database.lower() for database in databases}
+    if "google" in selected or "google-patent" in selected or "google-patents" in selected:
+        plans.extend(build_google_queries(feature, jp, cpc, assignee))
+    if "jplatpat" in selected or "j-platpat" in selected:
+        plans.extend(build_jplatpat_queries(feature, jp, cpc, assignee))
+    return plans
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--feature", required=True, help="English feature phrase to search")
+    parser.add_argument("--jp", help="Japanese feature phrase to search")
+    parser.add_argument("--cpc", action="append", default=[], help="CPC/IPC/FI classification hint, repeatable")
+    parser.add_argument("--assignee", action="append", default=[], help="Optional assignee/company filter, repeatable")
+    parser.add_argument(
+        "--database",
+        action="append",
+        choices=["google", "google-patent", "google-patents", "jplatpat", "j-platpat"],
+        default=None,
+        help="Target database to include, repeatable. Defaults to the only supported targets: Google Patents and J-PlatPat.",
+    )
+    args = parser.parse_args()
+
+    databases = args.database or ["google", "jplatpat"]
+    for plan in build_queries(args.feature, args.jp, args.cpc, args.assignee, databases):
+        print(f"Database: {plan.database}")
+        print(f"Query: {plan.query}")
+        if plan.url:
+            print(f"URL: {plan.url}")
+        if plan.note:
+            print(f"Note: {plan.note}")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py
+++ b/.agents/skills/autoware-patent-search/scripts/patent_cross_search_queries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import re
 from urllib.parse import quote_plus
 
 
@@ -16,6 +17,32 @@ DEFAULT_CONTEXT = [
 ]
 
 JPLATPAT_URL = "https://www.j-platpat.inpit.go.jp/"
+
+CPC_BROAD_RE = re.compile(r"^[A-HY][0-9]{2}[A-Z]$", re.IGNORECASE)
+
+
+def google_cpc_filter(code: str) -> str:
+    """Return Google Patents CPC filter syntax for a classification hint.
+
+    Broad subclasses (for example B60W) use Google Patents metadata-style
+    ``cpc:`` syntax, which includes child classifications. More specific CPC
+    groups use field syntax with ``/low`` so children remain included instead of
+    matching only the exact classification.
+    """
+    normalized = code.strip().upper()
+    if CPC_BROAD_RE.fullmatch(normalized):
+        return f"cpc:{normalized}"
+    return f"CPC={normalized}/low"
+
+
+def google_assignee_filter(name: str) -> str:
+    """Return Google Patents assignee metadata filter syntax."""
+    cleaned = name.strip()
+    if not cleaned:
+        return ""
+    if re.search(r"\s", cleaned):
+        return f'assignee:"{cleaned}"'
+    return f"assignee:{cleaned}"
 
 
 @dataclass(frozen=True)
@@ -37,11 +64,15 @@ def build_google_queries(feature: str, jp: str | None, cpc: list[str], assignee:
     if jp:
         queries.extend([jp, f"{jp} 自動運転"])
     for code in cpc:
-        queries.append(f"{feature} CPC={code}")
+        cpc_filter = google_cpc_filter(code)
+        queries.append(f"{feature} {cpc_filter}")
     for name in assignee:
-        queries.append(f'{feature} assignee="{name}"')
+        assignee_filter = google_assignee_filter(name)
+        if not assignee_filter:
+            continue
+        queries.append(f"{feature} {assignee_filter}")
         if jp:
-            queries.append(f'{jp} assignee="{name}"')
+            queries.append(f"{jp} {assignee_filter}")
     return [QueryPlan("Google Patents", query, google_url_for(query)) for query in queries]
 
 

--- a/.agents/skills/autoware-patent-search/scripts/patent_review_scaffold.py
+++ b/.agents/skills/autoware-patent-search/scripts/patent_review_scaffold.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Create non-legal patent review scaffolds for Autoware patent triage.
+"""Create non-legal module-based patent review scaffolds for Autoware triage.
 
 The generated Markdown is for IP-professional review. It does not decide
 infringement, validity, freedom to operate, or non-infringement.
@@ -15,7 +15,7 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class Candidate:
-    database: str
+    source: str
     publication: str
     assignee: str
     title: str
@@ -26,7 +26,7 @@ class Candidate:
 def load_candidates(path: Path) -> list[Candidate]:
     with path.open(newline="", encoding="utf-8") as csv_file:
         reader = csv.DictReader(csv_file)
-        required = {"database", "publication", "assignee", "title", "url", "relevance"}
+        required = {"source", "publication", "assignee", "title", "url", "relevance"}
         missing = required.difference(reader.fieldnames or [])
         if missing:
             raise ValueError(f"Missing required CSV columns: {', '.join(sorted(missing))}")
@@ -35,7 +35,7 @@ def load_candidates(path: Path) -> list[Candidate]:
 
 def candidate_table(candidates: list[Candidate]) -> str:
     lines = [
-        "| Database | Publication | Assignee | Title | Why it may be relevant | URL |",
+        "| Source | Publication | Assignee | Title | Why it may be relevant | URL |",
         "| --- | --- | --- | --- | --- | --- |",
     ]
     for candidate in candidates:
@@ -43,7 +43,7 @@ def candidate_table(candidates: list[Candidate]) -> str:
             "| "
             + " | ".join(
                 [
-                    candidate.database,
+                    candidate.source,
                     candidate.publication,
                     candidate.assignee,
                     candidate.title,
@@ -56,16 +56,26 @@ def candidate_table(candidates: list[Candidate]) -> str:
     return "\n".join(lines)
 
 
-def render_report(feature: str, candidates: list[Candidate]) -> str:
+def render_report(module: str, feature: str, bigquery_sql: str, candidates: list[Candidate]) -> str:
     sections = [
-        "# Autoware Patent Candidate Review Scaffold",
+        "# Autoware Module Patent Candidate Review Scaffold",
         "",
         "> Non-legal technical triage only. This scaffold does not conclude infringement,",
         "> non-infringement, validity, invalidity, or freedom to operate.",
         "",
-        "## Feature under review",
+        "## Module/package under review",
+        "",
+        module,
+        "",
+        "## Technical feature under review",
         "",
         feature,
+        "",
+        "## BigQuery SQL used for Google Patents Public Data",
+        "",
+        "```sql",
+        bigquery_sql or "TBD: paste generated BigQuery SQL here.",
+        "```",
         "",
         "## Candidate patent documents",
         "",
@@ -73,15 +83,15 @@ def render_report(feature: str, candidates: list[Candidate]) -> str:
         "",
         "## Claim-comparison worksheet for IP-professional review",
         "",
-        "| Candidate publication | Claim element | Autoware evidence to compare | Technical similarity notes | Difference / uncertainty | Reviewer disposition |",
+        "| Candidate publication | Claim element | Autoware module evidence to compare | Technical similarity notes | Difference / uncertainty | Reviewer disposition |",
         "| --- | --- | --- | --- | --- | --- |",
-        "| TBD | TBD | File/function/topic/parameter/message | TBD | TBD | Needs IP review |",
+        "| TBD | TBD | File/function/topic/parameter/message | TBD | TBD | Needs human IP review |",
         "",
         "## Monitoring plan",
         "",
-        "- Re-run the saved search queries on a scheduled cadence.",
-        "- Alert only when a newly found publication/application matches the saved feature keywords, assignee filters, or classifications.",
-        "- Include database, query, publication/application number, assignee, title, URL, and reason for alert.",
+        "- Re-run the saved BigQuery SQL on a scheduled cadence.",
+        "- Alert only when a newly found publication/application matches saved module feature keywords, assignee filters, or classifications.",
+        "- Include source, query, publication/application number, assignee, title, URL, and technical reason for alert.",
         "- Route alerts to a human reviewer; do not auto-label them with a legal conclusion.",
     ]
     return "\n".join(sections) + "\n"
@@ -89,12 +99,15 @@ def render_report(feature: str, candidates: list[Candidate]) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--feature", required=True, help="Autoware feature under review")
-    parser.add_argument("--candidates-csv", required=True, type=Path, help="CSV with database,publication,assignee,title,url,relevance columns")
+    parser.add_argument("--module", required=True, help="Autoware module/package/directory/component under review")
+    parser.add_argument("--feature", required=True, help="Autoware technical feature under review")
+    parser.add_argument("--bigquery-sql", type=Path, help="Optional file containing generated Google Patents Public Data SQL")
+    parser.add_argument("--candidates-csv", required=True, type=Path, help="CSV with source,publication,assignee,title,url,relevance columns")
     parser.add_argument("--output", type=Path, help="Markdown output path. Defaults to stdout.")
     args = parser.parse_args()
 
-    report = render_report(args.feature, load_candidates(args.candidates_csv))
+    bigquery_sql = args.bigquery_sql.read_text(encoding="utf-8") if args.bigquery_sql else ""
+    report = render_report(args.module, args.feature, bigquery_sql, load_candidates(args.candidates_csv))
     if args.output:
         args.output.write_text(report, encoding="utf-8")
     else:

--- a/.agents/skills/autoware-patent-search/scripts/patent_review_scaffold.py
+++ b/.agents/skills/autoware-patent-search/scripts/patent_review_scaffold.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Create non-legal patent review scaffolds for Autoware patent triage.
+
+The generated Markdown is for IP-professional review. It does not decide
+infringement, validity, freedom to operate, or non-infringement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Candidate:
+    database: str
+    publication: str
+    assignee: str
+    title: str
+    url: str
+    relevance: str
+
+
+def load_candidates(path: Path) -> list[Candidate]:
+    with path.open(newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        required = {"database", "publication", "assignee", "title", "url", "relevance"}
+        missing = required.difference(reader.fieldnames or [])
+        if missing:
+            raise ValueError(f"Missing required CSV columns: {', '.join(sorted(missing))}")
+        return [Candidate(**{key: row.get(key, "") for key in required}) for row in reader]
+
+
+def candidate_table(candidates: list[Candidate]) -> str:
+    lines = [
+        "| Database | Publication | Assignee | Title | Why it may be relevant | URL |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for candidate in candidates:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    candidate.database,
+                    candidate.publication,
+                    candidate.assignee,
+                    candidate.title,
+                    candidate.relevance,
+                    candidate.url,
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def render_report(feature: str, candidates: list[Candidate]) -> str:
+    sections = [
+        "# Autoware Patent Candidate Review Scaffold",
+        "",
+        "> Non-legal technical triage only. This scaffold does not conclude infringement,",
+        "> non-infringement, validity, invalidity, or freedom to operate.",
+        "",
+        "## Feature under review",
+        "",
+        feature,
+        "",
+        "## Candidate patent documents",
+        "",
+        candidate_table(candidates),
+        "",
+        "## Claim-comparison worksheet for IP-professional review",
+        "",
+        "| Candidate publication | Claim element | Autoware evidence to compare | Technical similarity notes | Difference / uncertainty | Reviewer disposition |",
+        "| --- | --- | --- | --- | --- | --- |",
+        "| TBD | TBD | File/function/topic/parameter/message | TBD | TBD | Needs IP review |",
+        "",
+        "## Monitoring plan",
+        "",
+        "- Re-run the saved search queries on a scheduled cadence.",
+        "- Alert only when a newly found publication/application matches the saved feature keywords, assignee filters, or classifications.",
+        "- Include database, query, publication/application number, assignee, title, URL, and reason for alert.",
+        "- Route alerts to a human reviewer; do not auto-label them with a legal conclusion.",
+    ]
+    return "\n".join(sections) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--feature", required=True, help="Autoware feature under review")
+    parser.add_argument("--candidates-csv", required=True, type=Path, help="CSV with database,publication,assignee,title,url,relevance columns")
+    parser.add_argument("--output", type=Path, help="Markdown output path. Defaults to stdout.")
+    args = parser.parse_args()
+
+    report = render_report(args.feature, load_candidates(args.candidates_csv))
+    if args.output:
+        args.output.write_text(report, encoding="utf-8")
+    else:
+        print(report, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/autoware-patent-search/tests/test_google_patents_queries.py
+++ b/.agents/skills/autoware-patent-search/tests/test_google_patents_queries.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+from urllib.parse import unquote_plus, urlparse, parse_qs
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from patent_cross_search_queries import build_google_queries, google_assignee_filter, google_cpc_filter
+
+
+def decoded_query(url: str) -> str:
+    raw = parse_qs(urlparse(url).query)["q"][0]
+    return unquote_plus(raw)
+
+
+def test_google_cpc_filter_uses_metadata_for_broad_subclass():
+    assert google_cpc_filter("B60W") == "cpc:B60W"
+
+
+def test_google_cpc_filter_uses_low_suffix_for_specific_groups():
+    assert google_cpc_filter("G05D1/00") == "CPC=G05D1/00/low"
+
+
+def test_google_assignee_filter_uses_metadata_prefix():
+    assert google_assignee_filter("Toyota") == "assignee:Toyota"
+    assert google_assignee_filter("Toyota Motor") == 'assignee:"Toyota Motor"'
+
+
+def test_google_query_urls_apply_metadata_and_classification_filters():
+    plans = build_google_queries(
+        "lane change path generation with collision check using predicted objects",
+        "車線変更 経路生成 衝突判定 予測物体",
+        ["B60W", "G05D1/00", "G08G1/00"],
+        ["Toyota", "Denso", "Waymo"],
+    )
+    decoded_queries = [decoded_query(plan.url) for plan in plans if plan.url]
+
+    assert "(lane change path generation with collision check using predicted objects cpc:B60W)" in decoded_queries
+    assert "(lane change path generation with collision check using predicted objects CPC=G05D1/00/low)" in decoded_queries
+    assert "(lane change path generation with collision check using predicted objects CPC=G08G1/00/low)" in decoded_queries
+    assert "(lane change path generation with collision check using predicted objects assignee:Toyota)" in decoded_queries
+    assert "(車線変更 経路生成 衝突判定 予測物体 assignee:Denso)" in decoded_queries

--- a/.agents/skills/autoware-patent-search/tests/test_google_patents_queries.py
+++ b/.agents/skills/autoware-patent-search/tests/test_google_patents_queries.py
@@ -1,11 +1,18 @@
 import sys
 from pathlib import Path
-from urllib.parse import unquote_plus, urlparse, parse_qs
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from patent_cross_search_queries import build_google_queries, google_assignee_filter, google_cpc_filter
+
+from patent_cross_search_queries import (  # noqa: E402
+    build_bigquery_sql,
+    build_google_queries,
+    build_queries,
+    google_assignee_filter,
+    google_cpc_filter,
+)
 
 
 def decoded_query(url: str) -> str:
@@ -26,7 +33,7 @@ def test_google_assignee_filter_uses_metadata_prefix():
     assert google_assignee_filter("Toyota Motor") == 'assignee:"Toyota Motor"'
 
 
-def test_google_query_urls_apply_metadata_and_classification_filters():
+def test_optional_google_query_urls_apply_metadata_and_classification_filters():
     plans = build_google_queries(
         "lane change path generation with collision check using predicted objects",
         "車線変更 経路生成 衝突判定 予測物体",
@@ -40,3 +47,83 @@ def test_google_query_urls_apply_metadata_and_classification_filters():
     assert "(lane change path generation with collision check using predicted objects CPC=G08G1/00/low)" in decoded_queries
     assert "(lane change path generation with collision check using predicted objects assignee:Toyota)" in decoded_queries
     assert "(車線変更 経路生成 衝突判定 予測物体 assignee:Denso)" in decoded_queries
+
+
+def test_build_bigquery_sql_searches_public_data_text_cpc_and_assignee_fields():
+    sql = build_bigquery_sql(
+        module="planning/behavior_path_planner/lane_change",
+        feature="lane change path generation with collision check using predicted objects",
+        keywords=["behavior planning"],
+        jp="車線変更 経路生成 衝突判定 予測物体",
+        cpc=["B60W", "G05D1/00"],
+        assignee=["Toyota Motor"],
+        publication_after="2018-01-01",
+        limit=25,
+    )
+
+    assert "patents-public-data.patents.publications" in sql
+    assert "planning/behavior_path_planner/lane_change" in sql
+    assert "title_localized" in sql
+    assert "abstract_localized" in sql
+    assert "description_localized" in sql
+    assert "claims_localized" in sql
+    assert "STARTS_WITH(c.code, 'B60W')" in sql
+    assert "STARTS_WITH(c.code, 'G05D1/00')" in sql
+    assert "LOWER(a.name) LIKE '%toyota motor%'" in sql
+    assert "p.publication_date >= 20180101" in sql
+    assert "LIMIT 25" in sql
+
+
+def test_build_queries_is_bigquery_first_with_optional_review_urls():
+    plan = build_queries(
+        module="planning/behavior_path_planner/lane_change",
+        feature="lane change path generation with collision check using predicted objects",
+        keywords=["behavior planning"],
+        jp="車線変更 経路生成 衝突判定 予測物体",
+        cpc=["B60W"],
+        assignee=["Toyota"],
+        include_urls=True,
+    )
+
+    assert plan.source == "Google Patents Public Data via BigQuery"
+    assert "FROM `patents-public-data.patents.publications` AS p" in plan.sql
+    assert plan.human_review_urls
+    assert all(url.startswith("https://patents.google.com/?q=") for url in plan.human_review_urls)
+
+
+def test_bigquery_cli_options_do_not_reintroduce_removed_database_paths():
+    script = SCRIPT_DIR / "patent_cross_search_queries.py"
+    help_text = script.read_text()
+    forbidden_database_name = "J-" + "PlatPat"
+    forbidden_cli_alias = "j" + "platpat"
+
+    assert forbidden_database_name not in help_text
+    assert forbidden_cli_alias not in help_text.lower()
+    assert "--database" not in help_text
+    assert "--module" in help_text
+    assert "--include-review-urls" in help_text
+
+
+def test_bigquery_where_requires_feature_terms_not_broad_context_alone():
+    sql = build_bigquery_sql(
+        module="planning/behavior_path_planner/lane_change",
+        feature="lane change path generation",
+        keywords=["collision check", "predicted object"],
+        jp="車線変更",
+        cpc=["B60W"],
+        assignee=[],
+        limit=10,
+    )
+
+    where_sql = sql.split("\nWHERE ", 1)[1].split("\nORDER BY", 1)[0]
+    select_sql = sql.split("\nWHERE ", 1)[0]
+
+    assert "lane change path generation" in where_sql
+    assert "collision check" in where_sql
+    assert "predicted object" in where_sql
+    assert "車線変更" in where_sql
+    assert "autonomous vehicle" not in where_sql
+    assert "automated driving" not in where_sql
+    assert "broad_context_match_count" in select_sql
+    assert "autonomous vehicle" in select_sql
+    assert "STARTS_WITH(c.code, 'B60W')" in where_sql

--- a/.github/codex/prompts/patent-risk-screening.md
+++ b/.github/codex/prompts/patent-risk-screening.md
@@ -1,0 +1,30 @@
+You are performing a patent-risk screening for an autonomous driving software repository.
+
+Scope:
+- Focus only on planning, behavior planning, trajectory planning, control, fallback, and MRM-related changes.
+- Do not make a legal conclusion.
+- Do not say that the code infringes a patent.
+- Identify technical features that should be reviewed by IP counsel.
+
+Task:
+1. Inspect the repository changes.
+2. Identify patent-sensitive technical features.
+3. Extract technical elements.
+4. Generate English and Japanese patent search keywords.
+5. Suggest likely patent search classifications if inferable.
+6. Assign a preliminary risk level: High, Medium, Watch, Low.
+7. Explain why human IP review is or is not needed.
+
+Output in the following structure:
+
+risk_level: High / Medium / Watch / Low
+patent_review_needed: true / false
+technical_domain:
+feature_summary:
+changed_files:
+technical_elements:
+search_keywords_en:
+search_keywords_ja:
+candidate_patent_queries:
+human_review_points:
+reason:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+## Review guidelines
+
+You are not making a legal conclusion about patent infringement.
+
+For each pull request, identify whether the change introduces or materially modifies a patent-sensitive autonomous driving technical feature.
+
+Focus on:
+- behavior planning
+- trajectory planning
+- motion planning
+- vehicle control
+- fallback behavior
+- MRM
+- fail-operational behavior
+- route planning
+- interaction with other vehicles, pedestrians, traffic signals, maps, or infrastructure
+
+For each relevant change, output:
+
+1. Technical feature summary
+2. Changed packages, files, classes, functions, and ROS nodes
+3. Inputs and outputs
+4. Algorithmic steps
+5. Why the feature may be patent-sensitive
+6. English patent search keywords
+7. Japanese patent search keywords
+8. Possible patent classification hints, if inferable
+9. Risk level: High / Medium / Watch / Low
+10. Reason for the risk level
+
+Do not state that the implementation infringes a patent.
+Only flag candidates for intellectual property review.

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -40,6 +40,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
     version: 0.5.0
+  core/autoware_simple_planning_simulator:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_simple_planning_simulator.git
+    version: main    # Should be updated to a specific version after the first release of autoware_simple_planning_simulator
   core/autoware_system_designer:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git

--- a/src/planning/patent_review_sample/README.md
+++ b/src/planning/patent_review_sample/README.md
@@ -1,0 +1,13 @@
+# Patent review workflow sample
+
+This directory contains a test-only Autoware planning sample used to validate the
+`autoware-patent-search` skill in this fork.
+
+The sample configuration represents a conceptual behavior-planning change for
+lane-change path generation: increasing the predicted-object collision-check
+margin used during lane-change safety evaluation. It is intentionally small and
+reviewable so the patent review workflow can identify a planning feature,
+changed inputs/outputs, algorithmic implications, CPC hints, and bilingual search
+keywords without proposing any change to upstream Autoware.
+
+Do not submit this sample change to `autowarefoundation/autoware`.

--- a/src/planning/patent_review_sample/lane_change_safety_threshold.param.yaml
+++ b/src/planning/patent_review_sample/lane_change_safety_threshold.param.yaml
@@ -1,0 +1,10 @@
+# Test-only Autoware planning sample for validating the autoware-patent-search workflow.
+# This file is intentionally placed in this fork and must not be proposed upstream.
+# It represents a conceptual lane-change behavior-planning threshold change.
+
+/**:
+  ros__parameters:
+    # Sample collision-check margin for lane-change path generation.
+    # Raising this value makes the validation scenario conceptually more conservative
+    # around predicted objects during lane-change safety evaluation.
+    lane_change_predicted_object_collision_margin_m: 1.8


### PR DESCRIPTION
This PR brings the module-based Google Patents Public Data / BigQuery patent-search workflow into main.

It includes:
- module-based Autoware review workflow,
- Google Patents Public Data via BigQuery as the primary retrieval mechanism,
- feature-specific term constraints for BigQuery candidate retrieval,
- optional Google Patents human-review URLs,
- no J-PlatPat,
- no scraping,
- no Google Patents-specific API,
- no legal conclusions.