### PR TITLE
chore: ignore generated autoware-index.repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ capture/
 
 # Node.js
 node_modules/
+
+# Autoware Index
+repositories/autoware-index.repos


### PR DESCRIPTION
[`aw-index-cli`](https://github.com/autowarefoundation/aw-index-cli) composes a user-specific `repositories/autoware-index.repos` file from the [Autoware Index](https://autowarefoundation.github.io/autoware-index/) registry, and the index browse site's Repos builder downloads the same file. It is generated per user, so it should not be tracked.