### PR TITLE
feat(ansible): update lidar_centerpoint model bundle to v4.0

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -87,7 +87,7 @@
 # lidar_centerpoint
 - name: Download lidar_centerpoint model bundle ({{ revision }})
   vars:
-    revision: v3.0
+    revision: v4.0
   ansible.builtin.command:
     cmd: >-
       hf download AutowareFoundation/lidar_centerpoint

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -114,7 +114,7 @@
 # lidar_centerpoint
 - name: Download lidar_centerpoint model bundle ({{ revision }})
   vars:
-    revision: v3.0
+    revision: v4.0
   ansible.builtin.command:
     cmd: >-
       hf download AutowareFoundation/lidar_centerpoint


### PR DESCRIPTION
## Description

Bumps the `lidar_centerpoint` model bundle revision downloaded by the ansible `artifacts` role from `v3.0` to `v4.0`.

`v4.0` restructures the bundle from a flat directory into one self-contained folder per variant, with uniform file names:

```text
lidar_centerpoint/
├── base/         # model_name: centerpoint
├── tiny/         # model_name: centerpoint_tiny
├── sigma/        # model_name: centerpoint_sigma
└── short_range/  # model_name: centerpoint_short_range
```

Each folder holds `pts_voxel_encoder.onnx`, `pts_backbone_neck_head.onnx`, `ml_package.param.yaml`, `detection_class_remapper.param.yaml` and `deploy_metadata.yaml`. `sigma` and `short_range` weights are published for the first time.

## Related links

Model bundle PR (draft, awaiting the `v4.0` tag): <https://huggingface.co/AutowareFoundation/lidar_centerpoint/discussions/1>

**This PR must land together with:**

- autowarefoundation/autoware_universe#13087 — node and package side of the restructure
- autowarefoundation/autoware_launch#1930 — launcher and param-mirror side of the restructure

The `v3.0` bundle layout does not work with the new code, and the `v4.0` layout does not work with the current code. Deployments pinned to `v3.0` data plus pre-merge code are unaffected.

## How was this PR tested?

The `v4.0` layout was staged locally and used as the artifacts directory for the `autoware_universe` / `autoware_launch` launch smoke tests. The ansible task itself is blocked until a maintainer tags `v4.0` on the Hugging Face repository, and has not been run against the real tag yet.

## Notes for reviewers

The `v4.0` tag does not exist yet — this PR cannot be merged before it is created. Contributors cannot push tags to the model repository, so the tag is requested in the bundle PR description.

## Interface changes

None.

## Effects on system behavior

`ansible-playbook … --tags artifacts` fetches the new layout into `~/autoware_data/ml_models/lidar_centerpoint/`. Files from a previous `v3.0` download are left in place by `hf download --local-dir` and can be removed by hand.
