### PR TITLE
feat(ansible): download diffusion_planner, tensorrt_vad from Hugging Face

### DIFF
--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -2,7 +2,7 @@
 
 The Autoware perception stack uses models for inference. These models are downloaded by running `ansible-playbook autoware.dev_env.install_dev_env --tags artifacts`.
 
-The models are hosted on [Hugging Face](https://huggingface.co/AutowareFoundation) under the `AutowareFoundation` organization. `diffusion_planner` and `tensorrt_vad` have not been migrated yet and are still hosted by Web.Auto.
+Every model is hosted on [Hugging Face](https://huggingface.co/AutowareFoundation), under the `AutowareFoundation` organization. Each download is pinned to a tag.
 
 Default `data_dir` location is `~/autoware_data/ml_models` (part of the asset-typed `~/autoware_data/` layout: `assets/`, `maps/`, `ml_models/`, `recordings/`, `scenarios/`).
 
@@ -68,7 +68,7 @@ This step should be repeated when a new playbook is added.
 ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
 ```
 
-This will download the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role. Model bundles fetched from Hugging Face are pinned to a version tag instead; their integrity relies on the Hub and the transport, not on checksums pinned here.
+This will download the artifacts to the specified directory. Each model bundle is pinned to a version tag on Hugging Face. Their integrity relies on the Hub and the transport, not on checksums pinned in this role.
 
 Every task in this role downloads as the user that runs the playbook, so the artifacts stay owned by that user. No task in this role uses sudo. Two of its dependencies do, and each one only under a condition:
 

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -142,153 +142,74 @@
   changed_when: false
 
 # diffusion_planner
-- name: Create diffusion_planner directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/diffusion_planner"
-    mode: "755"
-    state: directory
+# Each version is a tag on one repository, and every tag holds its files at the repository root,
+# so the versions are downloaded separately into the per-version directories the node expects.
+- name: Download diffusion_planner model bundle ({{ revision }})
+  vars:
+    revision: v3.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/diffusion_planner
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
-- name: Create diffusion_planner v3.0 directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/diffusion_planner/v3.0"
-    mode: "755"
-    state: directory
+- name: Download diffusion_planner model bundle ({{ revision }})
+  vars:
+    revision: v3.1
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/diffusion_planner
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
-- name: Download diffusion_planner/v3.0/diffusion_planner.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.0/diffusion_planner.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v3.0/diffusion_planner.onnx"
-    mode: "644"
-    checksum: sha256:3026918b55869b02ea561c1e1b9fed05c34092294c035d743f1d1cb756f4abcc
+- name: Download diffusion_planner model bundle ({{ revision }})
+  vars:
+    revision: v4.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/diffusion_planner
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
-- name: Download diffusion_planner/v3.0/diffusion_planner.param.json
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.0/diffusion_planner.param.json
-    dest: "{{ data_dir }}/diffusion_planner/v3.0/diffusion_planner.param.json"
-    mode: "644"
-    checksum: sha256:d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04
-
-- name: Create diffusion_planner/v3.1 directory
-  ansible.builtin.file:
-    path: "{{ data_dir }}/diffusion_planner/v3.1"
-    mode: "755"
-    state: directory
-
-- name: Download diffusion_planner/v3.1/diffusion_planner.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.1/diffusion_planner.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v3.1/diffusion_planner.onnx"
-    mode: "644"
-    checksum: sha256:a063d323af20d962048315dc0969e4d3cad46e81a20299f39d74a470d58b148b
-
-- name: Download diffusion_planner/v3.1/diffusion_planner.param.json
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.1/diffusion_planner.param.json
-    dest: "{{ data_dir }}/diffusion_planner/v3.1/diffusion_planner.param.json"
-    mode: "644"
-    checksum: sha256:d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04
-
-- name: Create diffusion_planner v4.0 directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/diffusion_planner/v4.0"
-    mode: "755"
-    state: directory
-
-- name: Download diffusion_planner/v4.0/diffusion_planner.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v4.0/diffusion_planner.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v4.0/diffusion_planner.onnx"
-    mode: "644"
-    checksum: sha256:6fd21662a655e7c262ffa465fc0d93b51d8a7fe1b56f95c6abd110f6cfa15ffd
-
-- name: Download diffusion_planner/v4.0/diffusion_planner.param.json
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v4.0/diffusion_planner.param.json
-    dest: "{{ data_dir }}/diffusion_planner/v4.0/diffusion_planner.param.json"
-    mode: "644"
-    checksum: sha256:d74dfe1b960c67c5e0a7ea5c62f691ade2614aa92062b8f86dd9b0860e81d323
-
-- name: Create diffusion_planner v5.0 directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/diffusion_planner/v5.0"
-    mode: "755"
-    state: directory
-
-- name: Download diffusion_planner/v5.0/diffusion_planner.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner.onnx"
-    mode: "644"
-    checksum: sha256:87a0969ded325fe52ecfec59beb717976396ebfb6800e2cfe2b9f34238d32c77
-
-- name: Download diffusion_planner/v5.0/diffusion_planner_encoder.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner_encoder.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner_encoder.onnx"
-    mode: "644"
-    checksum: sha256:2856886a3ed63b963cb18b457876d0bbd8916d345549ee5f199ceb49e3fcca49
-
-- name: Download diffusion_planner/v5.0/diffusion_planner_decoder.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner_decoder.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner_decoder.onnx"
-    mode: "644"
-    checksum: sha256:eb30c0c0c8e80b8460d293d600c7b8c9e21f615ff6ce8de5ed01670c3d1057ca
-
-- name: Download diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx"
-    mode: "644"
-    checksum: sha256:07acfb58a5de1f25587fa86deb39a6de5605f8d93518e97f960ee27145f4a732
-
-- name: Download diffusion_planner/v5.0/diffusion_planner.param.json
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner.param.json
-    dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner.param.json"
-    mode: "644"
-    checksum: sha256:ee3145b68fd1e1e44e532933dfe66cfee4384fbd637382c87ab5190c66a8e268
+- name: Download diffusion_planner model bundle ({{ revision }})
+  vars:
+    revision: v5.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/diffusion_planner
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # tensorrt_vad
-- name: Create tensorrt_vad directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/vad"
-    mode: "755"
-    state: directory
-
-- name: Create tensorrt_vad v0.1 directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/vad/v0.1"
-    mode: "755"
-    state: directory
-
-- name: Download tensorrt_vad/vad-carla-tiny_backbone.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny_backbone.onnx
-    dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny_backbone.onnx"
-    mode: "644"
-    checksum: sha256:04b925f2750fd1c4adf16b5aae9c149d0baa39185e99d141232ebe20bddba4da
-
-- name: Download tensorrt_vad/vad-carla-tiny_head.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny_head.onnx
-    dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny_head.onnx"
-    mode: "644"
-    checksum: sha256:31f49a592a764ce82bbe6e26d0bfc99dc8a9613628884dc73dd5e67521ff3e9e
-
-- name: Download tensorrt_vad/vad-carla-tiny_head_no_prev.onnx
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny_head_no_prev.onnx
-    dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny_head_no_prev.onnx"
-    mode: "644"
-    checksum: sha256:6a89d479e0717b1e526f1aa3a1137c631a9ef854e810d0328a035aae11818c2a
-
-- name: Download tensorrt_vad/vad-carla-tiny.param.json
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny.param.json
-    dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny.param.json"
-    mode: "644"
-    checksum: sha256:03d3187fed3c70f761456afc2e93e18c1765113b1c1580ffa78ab42b10dbd179
+# The local directory is vad, not tensorrt_vad: the node reads $(var data_path)/vad/v0.1.
+- name: Download tensorrt_vad model bundle ({{ revision }})
+  vars:
+    revision: v0.1
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/tensorrt_vad
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/vad/{{ revision }}"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # traffic_light_fine_detector
 - name: Download traffic_light_fine_detector model bundle ({{ revision }})


### PR DESCRIPTION
## Description

Batch E is the last batch of the artifact hosting migration. It removes the 15 pinned `get_url` tasks and the 7 directory tasks around them. Five `hf download` tasks take their place, and each one is pinned to a tag.

- Tracking issue: #7223
- Pilot, `lidar_centerpoint`: #7188
- Batch A, the small and well-versioned models: #7224
- Batch B, 3D detection: #7229
- Batch C, camera and traffic light: #7244
- Batch D, archive-based: #7248
- The ownership repair that this batch depends on: #7260

| Model | Revision | Installs into | Replaces |
|---|---|---|---|
| [`diffusion_planner`](https://huggingface.co/AutowareFoundation/diffusion_planner) | `v3.0`, `v3.1`, `v4.0`, `v5.0` | `diffusion_planner/<tag>` | `planning/models/diffusion_planner/<version>` |
| [`tensorrt_vad`](https://huggingface.co/AutowareFoundation/tensorrt_vad) | `v0.1` | `vad/v0.1` | `planning/models/tensorrt_vad/carla_tiny/v0.1` |

The same 15 files land on disk, at the same paths, so the launch files need no change. After this PR the role has no `get_url` task left, and every model comes from Hugging Face.

Two points need more explanation.

**Four revisions of one repository.** Each `diffusion_planner` version is a tag on the same repository, and each tag holds its files at the repository root. The role therefore runs `hf download` once per tag. The `--local-dir` option gives the per-version directory that the node reads. The node reads `$(var data_path)/diffusion_planner/v5.0` through `base_model_directory`, and this batch keeps that path unchanged.

- The node change that introduced `base_model_directory`: autowarefoundation/autoware_universe#13148

**Artifacts that root owns.** Every `get_url` task that this role once had ran with `become: true`. An install made before the migration therefore holds model files that root owns, in every model directory, and one directory that root owns: `diffusion_planner/v3.1`. That one directory is a slip in the task that added v3.1, because the other six directory tasks never used `become`.

- The PR that added the directory task with `become: true`: #6873

The root-owned files alone do no harm. `hf` replaces a file with `unlink`, and that needs permission on the parent directory, not on the file. The root-owned directory does stop the install. `hf` runs as the user that runs the playbook, and it cannot create its `.cache/huggingface` directory inside.

The `autoware_data_ownership` role corrects this once, and the `artifacts` role already depends on it. The repair runs only when a path under `~/autoware_data` has another owner. Ansible therefore skips it on a clean install, and on an install that the role already corrected.

- The role that corrects the ownership: #7260

After this batch the `artifacts` role has no task that uses `become`, so this state cannot come back.

## The files are the same files

The 15 files on Hugging Face are byte-identical to the files that the removed pins delivered.

- Each tag tree gives an LFS `oid` for the 10 `.onnx` files. That `oid` is the sha256 of the file, and all 10 are equal to the removed pins.
- The 5 `.param.json` files are too small for LFS. A direct download from each tag gives 5 more hashes, and they are equal too.

The install therefore gets the same 15 files as before. It gets no more files, and no fewer.

## How to verify manually

### 1. Check out the branch

```bash
cd ~/projects/autoware
gh pr checkout 7258
```

### 2. Install the artifacts

```bash
ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
ansible-playbook autoware.dev_env.install_dev_env --tags artifacts \
  -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
```

Keep `--ask-become-pass`. The `autoware_data_ownership` dependency needs it on an install that root owns. The `artifacts` role itself has no task that uses `become`.

Expect five tasks with the name `Download <model> model bundle (vX.Y)` to report `ok`. The recap must show `failed=0`. On an install made before the migration, the task `Take ownership of the Autoware data directory` reports `changed`.

To see which paths that task corrects, run this command before the playbook:

```bash
find "$(readlink -f ~/autoware_data)" ! -user "$USER" -printf '%u:%g %y %p\n'
```

After the playbook, the same command must print nothing.

### 3. Verify the delivered files

```bash
cd "$HOME/autoware_data/ml_models" && sha256sum -c <<'EOF'
3026918b55869b02ea561c1e1b9fed05c34092294c035d743f1d1cb756f4abcc  diffusion_planner/v3.0/diffusion_planner.onnx
d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04  diffusion_planner/v3.0/diffusion_planner.param.json
a063d323af20d962048315dc0969e4d3cad46e81a20299f39d74a470d58b148b  diffusion_planner/v3.1/diffusion_planner.onnx
d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04  diffusion_planner/v3.1/diffusion_planner.param.json
6fd21662a655e7c262ffa465fc0d93b51d8a7fe1b56f95c6abd110f6cfa15ffd  diffusion_planner/v4.0/diffusion_planner.onnx
d74dfe1b960c67c5e0a7ea5c62f691ade2614aa92062b8f86dd9b0860e81d323  diffusion_planner/v4.0/diffusion_planner.param.json
87a0969ded325fe52ecfec59beb717976396ebfb6800e2cfe2b9f34238d32c77  diffusion_planner/v5.0/diffusion_planner.onnx
ee3145b68fd1e1e44e532933dfe66cfee4384fbd637382c87ab5190c66a8e268  diffusion_planner/v5.0/diffusion_planner.param.json
eb30c0c0c8e80b8460d293d600c7b8c9e21f615ff6ce8de5ed01670c3d1057ca  diffusion_planner/v5.0/diffusion_planner_decoder.onnx
2856886a3ed63b963cb18b457876d0bbd8916d345549ee5f199ceb49e3fcca49  diffusion_planner/v5.0/diffusion_planner_encoder.onnx
07acfb58a5de1f25587fa86deb39a6de5605f8d93518e97f960ee27145f4a732  diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx
03d3187fed3c70f761456afc2e93e18c1765113b1c1580ffa78ab42b10dbd179  vad/v0.1/vad-carla-tiny.param.json
04b925f2750fd1c4adf16b5aae9c149d0baa39185e99d141232ebe20bddba4da  vad/v0.1/vad-carla-tiny_backbone.onnx
31f49a592a764ce82bbe6e26d0bfc99dc8a9613628884dc73dd5e67521ff3e9e  vad/v0.1/vad-carla-tiny_head.onnx
6a89d479e0717b1e526f1aa3a1137c631a9ef854e810d0328a035aae11818c2a  vad/v0.1/vad-carla-tiny_head_no_prev.onnx
EOF
```

All 15 lines must print `OK`. These are the hashes that this PR removes from the role.

### 4. Verify that no download comes from outside Hugging Face

```bash
grep -c "ansible.builtin.get_url" ansible/roles/artifacts/tasks/main.yaml
```

The count must be 0. The file holds no other use of `get_url` either.

## Effects on an install

The 15 files are 699.1 MB in total: 300.9 MB for `diffusion_planner` and 398.2 MB for `vad`. This PR does not change that size.

An existing install does not download the weights a second time. The `hf` command hashes the local files and compares them with the LFS entries. It then gets only the small files that are not in LFS. It also leaves a `.cache/huggingface` directory in each destination, as in the earlier batches.

The playbook ran on Ubuntu 24.04 against such an install. The recap was `ok=27 changed=0 failed=0`. All 20 download tasks reported `ok`, and `Take ownership of the Autoware data directory` reported `skipped`. The weights kept their earlier mtime, so `hf` did not fetch them again.

## AI usage

**AI usage:** written with Claude Code, from the batch plan in the tracking issue above.

**Self-review:** Done ✅

**Verification:** the role delivers the same 15 files as before, and the playbook ran end to end on Ubuntu 24.04 with `ok=27 changed=0 failed=0`.

<details>
<summary>What ran, and what did not</summary>

### The files are the same 15 files

- The LFS `oid` of each tag tree gave the sha256 of the 10 `.onnx` files, and all 10 match the removed pins
- The 5 `.param.json` files are too small for LFS, so a direct download from each tag gave 5 more hashes, and they match too

### The playbook

Ubuntu 24.04.4, against an install that already holds every model.

- The recap was `ok=27 changed=0 unreachable=0 failed=0 skipped=21`
- All 20 `Download <model> model bundle` tasks reported `ok`
- `Take ownership of the Autoware data directory` reported `skipped`
- `Install pipx` reported `skipped`, so neither dependency needed sudo for its own work
- The weights kept their `2026-07-27` mtime, so `hf` did not fetch them again

### The checks after that run

- `sha256sum -c` on the 15 files gave 15 lines of `OK`
- `find "$(readlink -f ~/autoware_data)" ! -user "$USER"` gave 0 paths
- `grep -c ansible.builtin.get_url ansible/roles/artifacts/tasks/main.yaml` gave 0
- `ansible-lint --profile production` on the role passed, with 0 failures and 0 warnings
- `pre-commit` on the two changed files passed

### What did not run

- Ubuntu 22.04
- The `install-artifacts` job in CI, which waits for the `run:health-check` label
- A node that reads these models. The paths do not change, so the launch files are untouched, but no node was started.

</details>
