### PR TITLE
fix(ansible): keep autoware_data owned by the user

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
     "lockfiles",
     "metapackage",
     "runpip",
+    "selectattr",
     "selstate",
     "showmanual"
   ]

--- a/.cspell.json
+++ b/.cspell.json
@@ -6,7 +6,6 @@
     "lockfiles",
     "metapackage",
     "runpip",
-    "selectattr",
     "selstate",
     "showmanual"
   ]

--- a/.github/workflows/health-check-ansible-artifacts.yaml
+++ b/.github/workflows/health-check-ansible-artifacts.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           files: |
             ansible/roles/artifacts/**
+            ansible/roles/autoware_data_ownership/**
             ansible/playbooks/install_dev_env.yaml
             ansible/scripts/install-ansible.sh
             ansible-galaxy-requirements.yaml

--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -70,6 +70,13 @@ ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=
 
 This will download the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role. Model bundles fetched from Hugging Face are pinned to a version tag instead; their integrity relies on the Hub and the transport, not on checksums pinned here.
 
+Every task in this role downloads as the user that runs the playbook, so the artifacts stay owned by that user. No task in this role uses sudo. Two of its dependencies do, and each one only under a condition:
+
+- `autoware_data_ownership` corrects an install that root owns
+- `huggingface_cli` installs pipx when pipx is absent
+
+Keep `--ask-become-pass` while either condition can be true.
+
 ### Migrating from the legacy layout
 
 Earlier versions of this role downloaded directly into `~/autoware_data/`. To match the new

--- a/ansible/roles/artifacts/meta/main.yaml
+++ b/ansible/roles/artifacts/meta/main.yaml
@@ -1,2 +1,4 @@
 dependencies:
+  # Runs first: the download tasks below write into data_dir as the user, not as root.
+  - role: autoware.dev_env.autoware_data_ownership
   - role: autoware.dev_env.huggingface_cli

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -155,7 +155,6 @@
     state: directory
 
 - name: Download diffusion_planner/v3.0/diffusion_planner.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.0/diffusion_planner.onnx
     dest: "{{ data_dir }}/diffusion_planner/v3.0/diffusion_planner.onnx"
@@ -163,7 +162,6 @@
     checksum: sha256:3026918b55869b02ea561c1e1b9fed05c34092294c035d743f1d1cb756f4abcc
 
 - name: Download diffusion_planner/v3.0/diffusion_planner.param.json
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.0/diffusion_planner.param.json
     dest: "{{ data_dir }}/diffusion_planner/v3.0/diffusion_planner.param.json"
@@ -171,14 +169,12 @@
     checksum: sha256:d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04
 
 - name: Create diffusion_planner/v3.1 directory
-  become: true
   ansible.builtin.file:
     path: "{{ data_dir }}/diffusion_planner/v3.1"
     mode: "755"
     state: directory
 
 - name: Download diffusion_planner/v3.1/diffusion_planner.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.1/diffusion_planner.onnx
     dest: "{{ data_dir }}/diffusion_planner/v3.1/diffusion_planner.onnx"
@@ -186,7 +182,6 @@
     checksum: sha256:a063d323af20d962048315dc0969e4d3cad46e81a20299f39d74a470d58b148b
 
 - name: Download diffusion_planner/v3.1/diffusion_planner.param.json
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.1/diffusion_planner.param.json
     dest: "{{ data_dir }}/diffusion_planner/v3.1/diffusion_planner.param.json"
@@ -200,7 +195,6 @@
     state: directory
 
 - name: Download diffusion_planner/v4.0/diffusion_planner.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v4.0/diffusion_planner.onnx
     dest: "{{ data_dir }}/diffusion_planner/v4.0/diffusion_planner.onnx"
@@ -208,7 +202,6 @@
     checksum: sha256:6fd21662a655e7c262ffa465fc0d93b51d8a7fe1b56f95c6abd110f6cfa15ffd
 
 - name: Download diffusion_planner/v4.0/diffusion_planner.param.json
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v4.0/diffusion_planner.param.json
     dest: "{{ data_dir }}/diffusion_planner/v4.0/diffusion_planner.param.json"
@@ -222,7 +215,6 @@
     state: directory
 
 - name: Download diffusion_planner/v5.0/diffusion_planner.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner.onnx
     dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner.onnx"
@@ -230,7 +222,6 @@
     checksum: sha256:87a0969ded325fe52ecfec59beb717976396ebfb6800e2cfe2b9f34238d32c77
 
 - name: Download diffusion_planner/v5.0/diffusion_planner_encoder.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner_encoder.onnx
     dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner_encoder.onnx"
@@ -238,7 +229,6 @@
     checksum: sha256:2856886a3ed63b963cb18b457876d0bbd8916d345549ee5f199ceb49e3fcca49
 
 - name: Download diffusion_planner/v5.0/diffusion_planner_decoder.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner_decoder.onnx
     dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner_decoder.onnx"
@@ -246,7 +236,6 @@
     checksum: sha256:eb30c0c0c8e80b8460d293d600c7b8c9e21f615ff6ce8de5ed01670c3d1057ca
 
 - name: Download diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx
     dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx"
@@ -254,7 +243,6 @@
     checksum: sha256:07acfb58a5de1f25587fa86deb39a6de5605f8d93518e97f960ee27145f4a732
 
 - name: Download diffusion_planner/v5.0/diffusion_planner.param.json
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v5.0/diffusion_planner.param.json
     dest: "{{ data_dir }}/diffusion_planner/v5.0/diffusion_planner.param.json"
@@ -275,7 +263,6 @@
     state: directory
 
 - name: Download tensorrt_vad/vad-carla-tiny_backbone.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny_backbone.onnx
     dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny_backbone.onnx"
@@ -283,7 +270,6 @@
     checksum: sha256:04b925f2750fd1c4adf16b5aae9c149d0baa39185e99d141232ebe20bddba4da
 
 - name: Download tensorrt_vad/vad-carla-tiny_head.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny_head.onnx
     dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny_head.onnx"
@@ -291,7 +277,6 @@
     checksum: sha256:31f49a592a764ce82bbe6e26d0bfc99dc8a9613628884dc73dd5e67521ff3e9e
 
 - name: Download tensorrt_vad/vad-carla-tiny_head_no_prev.onnx
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny_head_no_prev.onnx
     dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny_head_no_prev.onnx"
@@ -299,7 +284,6 @@
     checksum: sha256:6a89d479e0717b1e526f1aa3a1137c631a9ef854e810d0328a035aae11818c2a
 
 - name: Download tensorrt_vad/vad-carla-tiny.param.json
-  become: true
   ansible.builtin.get_url:
     url: https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/vad-carla-tiny.param.json
     dest: "{{ data_dir }}/vad/v0.1/vad-carla-tiny.param.json"

--- a/ansible/roles/autoware_data_ownership/README.md
+++ b/ansible/roles/autoware_data_ownership/README.md
@@ -16,8 +16,8 @@ Remove this role when the installs in use have all migrated. The roles that writ
 
 ## Inputs
 
-| Name | Default | Description |
-| --- | --- | --- |
+| Name                           | Default                                      | Description                                                   |
+| ------------------------------ | -------------------------------------------- | ------------------------------------------------------------- |
 | `autoware_data_ownership__dir` | `{{ ansible_facts.env.HOME }}/autoware_data` | The directory to take ownership of, with everything under it. |
 
 ## Manual correction

--- a/ansible/roles/autoware_data_ownership/README.md
+++ b/ansible/roles/autoware_data_ownership/README.md
@@ -12,7 +12,10 @@ Older installs downloaded into this directory as root. A root-owned directory st
 
 When `~/autoware_data` does not exist, the role does nothing. When the user already owns every path in it, the role does nothing. Only the repair needs sudo, so a clean install needs no password.
 
-Remove this role when the installs in use have all migrated. The roles that write into `~/autoware_data` no longer use `become`, so a corrected install cannot return to the root-owned state.
+Remove this role when the installs in use have all migrated. Nothing in this repository creates a root-owned path under `~/autoware_data` any more, so a corrected install cannot return to that state:
+
+- The roles that write into it no longer use `become`
+- The compose files under `docker/` set `create_host_path: false`, so Compose stops on a missing mount source instead of creating it as root
 
 ## Inputs
 
@@ -23,5 +26,7 @@ Remove this role when the installs in use have all migrated. The roles that writ
 ## Manual correction
 
 ```bash
-sudo chown -R "$USER:$USER" ~/autoware_data
+sudo chown -Rh "$USER:$USER" "$(readlink -f ~/autoware_data)"
 ```
+
+`readlink -f` resolves `~/autoware_data` when it is a symbolic link, so a tree that sits on another disk is corrected too. `-h` acts on a symbolic link inside the tree instead of the file it points to, so a link that points out of `~/autoware_data` leaves the owner of its target alone. The role runs this same command.

--- a/ansible/roles/autoware_data_ownership/README.md
+++ b/ansible/roles/autoware_data_ownership/README.md
@@ -1,0 +1,27 @@
+# Role: autoware_data_ownership
+
+This role makes the user that runs the playbook the owner of `~/autoware_data` and of every path under it.
+
+`~/autoware_data` holds the maps, the ML models, the recordings and the scenarios. It sits in the home directory of the user because every consumer reads it as that user:
+
+- The ansible roles that download into it
+- The ROS nodes that write TensorRT engine files next to the models
+- The containers under `docker/`, which mount it for the unprivileged `aw` user
+
+Older installs downloaded into this directory as root. A root-owned directory stops all three consumers. This role corrects such an install one time.
+
+When `~/autoware_data` does not exist, the role does nothing. When the user already owns every path in it, the role does nothing. Only the repair needs sudo, so a clean install needs no password.
+
+Remove this role when the installs in use have all migrated. The roles that write into `~/autoware_data` no longer use `become`, so a corrected install cannot return to the root-owned state.
+
+## Inputs
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `autoware_data_ownership__dir` | `{{ ansible_facts.env.HOME }}/autoware_data` | The directory to take ownership of, with everything under it. |
+
+## Manual correction
+
+```bash
+sudo chown -R "$USER:$USER" ~/autoware_data
+```

--- a/ansible/roles/autoware_data_ownership/defaults/main.yaml
+++ b/ansible/roles/autoware_data_ownership/defaults/main.yaml
@@ -1,0 +1,1 @@
+autoware_data_ownership__dir: "{{ ansible_facts.env.HOME }}/autoware_data"

--- a/ansible/roles/autoware_data_ownership/tasks/main.yaml
+++ b/ansible/roles/autoware_data_ownership/tasks/main.yaml
@@ -1,0 +1,34 @@
+# autoware_data lives in the home directory of the user, and every consumer reads it as that user:
+# the ansible roles, the ROS nodes that write TensorRT engine files next to the models, and the
+# containers in docker/, which mount it for the unprivileged 'aw' user. Older installs downloaded
+# into it as root, so the tree has to be normalized once before anything writes into it again.
+- name: Check whether the Autoware data directory exists
+  ansible.builtin.stat:
+    path: "{{ autoware_data_ownership__dir }}"
+  register: autoware_data_ownership__root
+
+- name: List the paths under the Autoware data directory
+  ansible.builtin.find:
+    paths: "{{ autoware_data_ownership__dir }}"
+    recurse: true
+    file_type: any
+    hidden: true
+  register: autoware_data_ownership__tree
+  when: autoware_data_ownership__root.stat.exists
+
+# skipped_paths is non-empty when find could not read a directory. That is itself an ownership
+# problem the walk cannot see through, so it has to trigger the repair rather than mask it.
+- name: Take ownership of the Autoware data directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ autoware_data_ownership__dir }}"
+    state: directory
+    owner: "{{ ansible_facts.user_id }}"
+    group: "{{ ansible_facts.user_gid }}"
+    recurse: true
+  when:
+    - autoware_data_ownership__root.stat.exists
+    - autoware_data_ownership__root.stat.uid != ansible_facts.user_uid
+      or autoware_data_ownership__tree.files
+      | selectattr('uid', 'ne', ansible_facts.user_uid) | list | length > 0
+      or autoware_data_ownership__tree.skipped_paths | length > 0

--- a/ansible/roles/autoware_data_ownership/tasks/main.yaml
+++ b/ansible/roles/autoware_data_ownership/tasks/main.yaml
@@ -1,34 +1,28 @@
-# autoware_data lives in the home directory of the user, and every consumer reads it as that user:
-# the ansible roles, the ROS nodes that write TensorRT engine files next to the models, and the
-# containers in docker/, which mount it for the unprivileged 'aw' user. Older installs downloaded
-# into it as root, so the tree has to be normalized once before anything writes into it again.
-- name: Check whether the Autoware data directory exists
-  ansible.builtin.stat:
-    path: "{{ autoware_data_ownership__dir }}"
-  register: autoware_data_ownership__root
+# Older installs downloaded into autoware_data as root, which stops every consumer: the ansible
+# roles, the ROS nodes that write TensorRT engine files, and the 'aw' user in the docker/ containers.
+# The path is resolved first so that the guard and the repair act on one real path. Both then keep
+# the default link behaviour, so a link that points out of the tree keeps the owner of its target.
+- name: Resolve the Autoware data directory
+  ansible.builtin.command:
+    cmd: readlink -f {{ autoware_data_ownership__dir | quote }}
+  register: autoware_data_ownership__real
+  changed_when: false
+  failed_when: false
+  check_mode: false
 
-- name: List the paths under the Autoware data directory
-  ansible.builtin.find:
-    paths: "{{ autoware_data_ownership__dir }}"
-    recurse: true
-    file_type: any
-    hidden: true
-  register: autoware_data_ownership__tree
-  when: autoware_data_ownership__root.stat.exists
+- name: Look for a path under the Autoware data directory that the user does not own
+  ansible.builtin.command:
+    cmd: find {{ autoware_data_ownership__real.stdout | quote }} ! -user {{ ansible_facts.user_id | quote }} -print -quit
+  register: autoware_data_ownership__foreign
+  when: autoware_data_ownership__real.stdout | length > 0
+  changed_when: false
+  failed_when: false
+  # Without this the guard does not run under --check, and the repair can never be reported.
+  check_mode: false
 
-# skipped_paths is non-empty when find could not read a directory. That is itself an ownership
-# problem the walk cannot see through, so it has to trigger the repair rather than mask it.
 - name: Take ownership of the Autoware data directory
   become: true
-  ansible.builtin.file:
-    path: "{{ autoware_data_ownership__dir }}"
-    state: directory
-    owner: "{{ ansible_facts.user_id }}"
-    group: "{{ ansible_facts.user_gid }}"
-    recurse: true
-  when:
-    - autoware_data_ownership__root.stat.exists
-    - autoware_data_ownership__root.stat.uid != ansible_facts.user_uid
-      or autoware_data_ownership__tree.files
-      | selectattr('uid', 'ne', ansible_facts.user_uid) | list | length > 0
-      or autoware_data_ownership__tree.skipped_paths | length > 0
+  ansible.builtin.command:
+    cmd: chown -Rh {{ ansible_facts.user_id | quote }}:{{ ansible_facts.user_gid | quote }} {{ autoware_data_ownership__real.stdout | quote }}
+  when: autoware_data_ownership__foreign.stdout | default('') | length > 0
+  changed_when: true

--- a/ansible/roles/demo_artifacts/meta/main.yaml
+++ b/ansible/roles/demo_artifacts/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  # Runs first: the download tasks below write into autoware_data as the user, not as root.
+  - role: autoware.dev_env.autoware_data_ownership

--- a/ansible/roles/demo_artifacts/tasks/main.yaml
+++ b/ansible/roles/demo_artifacts/tasks/main.yaml
@@ -14,7 +14,6 @@
     state: directory
 
 - name: Download maps/sample-map-planning.zip
-  become: true
   ansible.builtin.get_url:
     url: https://autoware-files.s3.us-west-2.amazonaws.com/maps/demos/sample-map-planning.zip
     dest: "{{ demo_artifacts__autoware_data_dir }}/maps/sample-map-planning.zip"
@@ -28,7 +27,6 @@
 
 # sample-map-rosbag (rosbag-replay-simulation demo)
 - name: Download maps/sample-map-rosbag.zip
-  become: true
   ansible.builtin.get_url:
     url: https://autoware-files.s3.us-west-2.amazonaws.com/maps/demos/sample-map-rosbag.zip
     dest: "{{ demo_artifacts__autoware_data_dir }}/maps/sample-map-rosbag.zip"
@@ -48,7 +46,6 @@
     state: directory
 
 - name: Download recordings/bags/sample-rosbag.zip
-  become: true
   ansible.builtin.get_url:
     url: https://autoware-files.s3.us-west-2.amazonaws.com/recordings/bags/demos/sample-rosbag.zip
     dest: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/sample-rosbag.zip"

--- a/docker/devcontainer/core-devel.compose.yaml
+++ b/docker/devcontainer/core-devel.compose.yaml
@@ -15,6 +15,11 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ../..:/home/aw/autoware
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data
+        target: /home/aw/autoware_data
+        bind:
+          create_host_path: false
     working_dir: /home/aw/autoware
     command: bash

--- a/docker/devcontainer/universe-devel-cuda.compose.yaml
+++ b/docker/devcontainer/universe-devel-cuda.compose.yaml
@@ -19,7 +19,12 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ../..:/home/aw/autoware
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data
+        target: /home/aw/autoware_data
+        bind:
+          create_host_path: false
     working_dir: /home/aw/autoware
     deploy:
       resources:

--- a/docker/devcontainer/universe-devel.compose.yaml
+++ b/docker/devcontainer/universe-devel.compose.yaml
@@ -15,6 +15,11 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ../..:/home/aw/autoware
-      - ${HOME}/autoware_data:/home/aw/autoware_data
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data
+        target: /home/aw/autoware_data
+        bind:
+          create_host_path: false
     working_dir: /home/aw/autoware
     command: bash

--- a/docker/examples/basic/README.md
+++ b/docker/examples/basic/README.md
@@ -11,6 +11,12 @@ Three flavors of "drop me into a shell" container. All three use the `universe-d
 
 `dev-nvidia` uses `universe-devel-cuda-jazzy`; the other two use `universe-devel-jazzy`.
 
+## Prerequisites
+
+- `~/autoware_data/maps` and `~/autoware_data/ml_models` on the host, which the `artifacts` and `demo_artifacts` ansible roles create
+
+Compose does not create these. It stops with `bind source path does not exist` when one is missing, because a path that Compose creates belongs to root, and the unprivileged `aw` user in the container cannot write it.
+
 On NVIDIA hosts running the proprietary driver, `dev-dri` silently falls back to `llvmpipe` (no `nvidia-drm` loader in Mesa) — use `dev-nvidia` instead. Software rendering is fine for text-heavy rviz but laggy on dense point clouds.
 
 Verify you actually got hardware acceleration inside the container:

--- a/docker/examples/basic/dev-cpu.compose.yaml
+++ b/docker/examples/basic/dev-cpu.compose.yaml
@@ -12,6 +12,15 @@ services:
       - LIBGL_ALWAYS_SOFTWARE=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
-      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data/maps
+        target: /home/aw/autoware_data/maps
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${HOME}/autoware_data/ml_models
+        target: /home/aw/autoware_data/ml_models
+        bind:
+          create_host_path: false
     command: bash

--- a/docker/examples/basic/dev-dri.compose.yaml
+++ b/docker/examples/basic/dev-dri.compose.yaml
@@ -16,6 +16,15 @@ services:
       - render
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
-      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data/maps
+        target: /home/aw/autoware_data/maps
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${HOME}/autoware_data/ml_models
+        target: /home/aw/autoware_data/ml_models
+        bind:
+          create_host_path: false
     command: bash

--- a/docker/examples/basic/dev-nvidia.compose.yaml
+++ b/docker/examples/basic/dev-nvidia.compose.yaml
@@ -14,8 +14,17 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
-      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data/maps
+        target: /home/aw/autoware_data/maps
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${HOME}/autoware_data/ml_models
+        target: /home/aw/autoware_data/ml_models
+        bind:
+          create_host_path: false
     deploy:
       resources:
         reservations:

--- a/docker/examples/demos/awsim/docker-compose.yaml
+++ b/docker/examples/demos/awsim/docker-compose.yaml
@@ -15,8 +15,17 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
-      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data/maps
+        target: /home/aw/autoware_data/maps
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${HOME}/autoware_data/ml_models
+        target: /home/aw/autoware_data/ml_models
+        bind:
+          create_host_path: false
     deploy:
       resources:
         reservations:

--- a/docker/examples/demos/planning-simulator/docker-compose.yaml
+++ b/docker/examples/demos/planning-simulator/docker-compose.yaml
@@ -11,8 +11,17 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
-      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data/maps
+        target: /home/aw/autoware_data/maps
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${HOME}/autoware_data/ml_models
+        target: /home/aw/autoware_data/ml_models
+        bind:
+          create_host_path: false
     command:
       - bash
       - -c

--- a/docker/examples/demos/scenario-simulator/docker-compose.yaml
+++ b/docker/examples/demos/scenario-simulator/docker-compose.yaml
@@ -12,8 +12,17 @@ services:
       - QT_X11_NO_MITSHM=1
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps
-      - ${HOME}/autoware_data/ml_models:/home/aw/autoware_data/ml_models
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data/maps
+        target: /home/aw/autoware_data/maps
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${HOME}/autoware_data/ml_models
+        target: /home/aw/autoware_data/ml_models
+        bind:
+          create_host_path: false
       - cyclonedds-config:/shared-config:rw
     healthcheck:
       test:
@@ -53,8 +62,19 @@ services:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - CYCLONEDDS_URI=file:///shared-config/cyclonedds.xml
     volumes:
-      - ${HOME}/autoware_data/maps:/home/aw/autoware_data/maps:ro
-      - ${HOME}/autoware_data/scenarios:/home/aw/autoware_data/scenarios:ro
+      # create_host_path is off: Compose creates a missing source as root, which 'aw' cannot write.
+      - type: bind
+        source: ${HOME}/autoware_data/maps
+        target: /home/aw/autoware_data/maps
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${HOME}/autoware_data/scenarios
+        target: /home/aw/autoware_data/scenarios
+        read_only: true
+        bind:
+          create_host_path: false
       - cyclonedds-config:/shared-config:ro
     command:
       - bash


### PR DESCRIPTION
## Description

`~/autoware_data` sits in the home directory of the user because every consumer reads it as that user:

- The ansible roles that download into it
- The ROS nodes that write TensorRT engine files next to the models
- The containers under `docker/`, which mount it for the unprivileged `aw` user

The directory was never meant to hold a path that root owns. A path that root owns stops all three consumers above.

Two things in this repository create such a path.

The download tasks used `become: true`, so many installs hold model files and one model directory that root owns. Older Dockerfiles also installed as root.

The compose files under `docker/` used the short mount syntax. That syntax creates a missing host path, and the Docker daemon creates it as root. A user who starts a demo before the ansible run therefore gets the same problem on a clean machine.

The container still starts in that state. Autoware then reads an empty `maps` directory and an empty `ml_models` directory. The run fails later with a message about the data, not about the mount. The user also cannot remove the new directories without sudo.

This PR removes both causes, and corrects the installs that already have the problem.

## What changes

**A new role, `autoware_data_ownership`.** It gives `~/autoware_data` and every path under it to the user that runs the playbook. It does nothing when the directory does not exist, and nothing when the user already owns every path. Only the correction needs sudo, so a clean install needs no password.

The artifacts health check now also runs when this role changes. Its path filter listed `ansible/roles/artifacts/**` only, so a change to the new role alone got no coverage.

**`artifacts` and `demo_artifacts` depend on the new role.** A role dependency runs before the role that declares it, so the tree is user-owned before any task writes into it. The dependency inherits the tags of its parent, so it runs under `--tags artifacts` and under `--tags demo_artifacts`. Ansible runs it once per host even when both parents are selected, so `--list-tasks` prints it under both parents but only one run happens.

**No task writes into `~/autoware_data` as root any more.** This removes `become: true` from 16 tasks in `artifacts` and from 3 tasks in `demo_artifacts`. The `Install unzip` task in `demo_artifacts` keeps `become: true`, because apt needs it.

One of the 16 is the task `Create diffusion_planner/v3.1 directory`. That task is the reason a directory that root owns exists at all. Every other directory task in the role was already correct.

**Compose stops instead of creating a mount source.** Every bind mount of `~/autoware_data` under `docker/` moves to the long syntax with `create_host_path: false`. Compose then stops with `bind source path does not exist` when a path is missing, and it no longer creates that path as root. This changes 17 mounts in 9 files.

No ansible role creates `~/autoware_data/scenarios`, so that path was root-owned even after a complete install. The three devcontainers already create `~/autoware_data` on the host with their `initializeCommand`, so that flow does not change.

This is a change of behaviour for a user who has not run the ansible roles. That user now reads a clear error, instead of a run that breaks later with an empty directory. The demo READMEs already list these paths as prerequisites. `docker/examples/basic/README.md` had no such list, and this PR adds one.

## How the role decides to run

The role resolves `~/autoware_data` with `readlink -f`. It then looks for the first path under the resolved directory that the user does not own. The correction runs only when that search prints a path.

`find` and `chown` both keep the default behaviour for a symbolic link. They act on the link itself, and they do not descend into it. Two results follow from this. A link that points out of `~/autoware_data` keeps the owner of its target. The search and the correction also read and write one set of paths, so a corrected tree stops the search.

`readlink -f` resolves the directory when it sits on another disk behind a symbolic link. The role corrects the real directory in that case. When the path cannot be resolved, `readlink -f` prints nothing and the role does nothing.

## How to verify manually

### 1. Check out the branch

```bash
cd ~/projects/autoware
gh pr checkout 7260
ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
```

### 2. Look at the paths that root owns

```bash
find "$HOME/autoware_data" ! -user "$USER" -printf '%u:%g %y %p\n'
```

### 3. Run the playbook

```bash
ansible-playbook autoware.dev_env.install_dev_env --tags artifacts --ask-become-pass
```

On an install made before this PR, the task `Take ownership of the Autoware data directory` reports `changed`. On a clean install it reports `skipped`, and the run needs no password.

### 4. Look again

```bash
find "$HOME/autoware_data" ! -user "$USER" -printf '%u:%g %y %p\n'
```

The command must print nothing. A second run of the playbook skips the correction.

### 5. Check that Compose no longer creates a mount source

A throwaway `HOME` gives the compose file an empty tree to mount, so this check leaves the real `~/autoware_data` alone.

```bash
HOME=$(mktemp -d) docker compose -f docker/examples/basic/dev-cpu.compose.yaml up
```

Compose must stop with `bind source path does not exist`, and it must create no directory under the temporary tree. Before this PR it created that path as root.

Compose pulls the image of the demo first when the machine does not hold it yet, which takes several GB.

## Relation to the Hugging Face migration

Batch E carried a smaller form of this correction, scoped to the artifacts directory. This PR replaces it, so batch E drops those two tasks and rebases on this one. Batch E also deletes 15 of the 16 tasks that lose `become: true` here, so the rebase resolves in favor of the deletion.

- Batch E: #7258
- Tracking issue: #7223

## AI usage

**AI usage:** written with Claude Code, from a review of batch E, then corrected twice from a review of this branch
**Self-review:** 
<img width="1737" height="1406" alt="image" src="https://github.com/user-attachments/assets/7a37a022-190f-4679-bce2-73f1471a2fee" />


**Verification:** the role and the compose change both ran on Ubuntu 24.04. The planning simulator demo drove to a goal with the compose file from this PR.

<details>
<summary>What ran, and what did not</summary>

### Versions

- ansible-core 2.17.14, the version that `ansible/scripts/install-ansible.sh` pins
- GNU findutils 4.9.0 and GNU coreutils 9.4, in a container of `ubuntu:24.04`
- Docker 29.7.2 and Compose v5.4.0

### The role, on the host

Six inputs skip the correction, and none asks for a password:

- An absent path
- A regular file
- A clean tree
- A symbolic link to a directory
- A tree that holds a link to a path outside it
- A dangling symbolic link

The real `~/autoware_data` of the host also skips. A run with `--check` also skips.

### The role, end to end in a container

A container of `ubuntu:24.04` with passwordless sudo ran the final role against a tree that root owns.

- The first run reported `changed=1`, and made every path user-owned
- The user then created a file in the directory that root owned before
- That write is the one `hf` and the TensorRT engine writer need
- After `sudo -k`, the second run reported `changed=0` and `skipped=1`

The same container ran the role against two trees that hold a symbolic link.

- In a tree that holds a link to a path outside it, the correction fixed the tree and the link
- The directory outside the tree, and the file in it, keep root as the owner
- When `~/autoware_data` is itself a symbolic link, the correction fixed the resolved directory and its contents
- A second run skips in both cases

Seven shell fixtures measured the guard and the correction against the GNU tools directly.

### The compose files

`docker compose config` accepts all nine changed files. The resolved configuration shows 17 `autoware_data` mounts, each with `create_host_path: false`. Two of them keep `read_only: true`, which matches the two `:ro` mounts before the change.

Three tests ran against `docker/examples/basic/dev-cpu.compose.yaml`, with the image `ghcr.io/autowarefoundation/autoware:universe-devel-jazzy`. Each one used a throwaway `HOME`, so the real `~/autoware_data` stayed out of the test.

- With the mount source absent, Compose stopped with `bind source path does not exist`, and created nothing
- With the mount entries put back into the short syntax, the container started. The daemon created `autoware_data`, `autoware_data/maps` and `autoware_data/ml_models` as `root:root`, and `rm` then refused to remove them
- With the mount source present, the container ran, read a file through the mount, and reported `id -u` as 1000

### The planning simulator demo

`docker/examples/demos/planning-simulator/docker-compose.yaml` ran with the image `ghcr.io/autowarefoundation/autoware:universe-jazzy`. Both `autoware_data` mounts in that file carry the long syntax from this PR.

- Compose bound both sources, and the container started
- Autoware read `sample-map-planning` through the mount, as the unprivileged `aw` user
- A goal pose in rviz produced a route of four segments
- The vehicle drove, and `/api/routing/state` then reported `3`, which is ARRIVED
- The vehicle stopped about 3 cm from the goal position

The tree of this host is already user-owned, so the correction skipped during this run.

### Not checked

- Ubuntu 22.04
- A run of `artifacts` or `demo_artifacts` that downloads a real artifact
- The CUDA image
- The devcontainer files, which mount the whole `~/autoware_data` instead of two directories under it

</details>
