### PR TITLE
refactor(ansible): drive the model downloads with one loop task

### DIFF
--- a/ansible/roles/artifacts/meta/main.yaml
+++ b/ansible/roles/artifacts/meta/main.yaml
@@ -1,4 +1,4 @@
 dependencies:
-  # Runs first: the download tasks below write into data_dir as the user, not as root.
+  # Runs first: the download task below writes into data_dir as the user, not as root.
   - role: autoware.dev_env.autoware_data_ownership
   - role: autoware.dev_env.huggingface_cli

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -1,282 +1,41 @@
-# yabloc_pose_initializer
-# v0.1 is the complete upstream PINTO export, the same file set the old archive delivered. Pruning it to the
-# files the node can actually use (tag v1.0) is a separate follow-up.
-- name: Download yabloc_pose_initializer model bundle ({{ revision }})
-  vars:
-    revision: v0.1
+# dest is relative to data_dir and defaults to the repository name.
+- name: Download the model bundles from Hugging Face
   ansible.builtin.command:
     cmd: >-
-      hf download AutowareFoundation/yabloc_pose_initializer
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/yabloc_pose_initializer"
+      hf download AutowareFoundation/{{ item.repo }}
+      --revision {{ item.revision }}
+      --local-dir "{{ data_dir }}/{{ item.dest | default(item.repo) }}"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
   changed_when: false
-
-# bevfusion
-- name: Download bevfusion model bundle ({{ revision }})
-  vars:
-    revision: v2.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/bevfusion
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/bevfusion"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# camera_streampetr
-- name: Download camera_streampetr model bundle ({{ revision }})
-  vars:
-    revision: v1.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/camera_streampetr
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/camera_streampetr"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# bevdet
-- name: Download tensorrt_bevdet model bundle ({{ revision }})
-  vars:
-    revision: v1.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/tensorrt_bevdet
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/tensorrt_bevdet"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# image_projection_based_fusion
-- name: Download image_projection_based_fusion model bundle ({{ revision }})
-  vars:
-    revision: v5.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/image_projection_based_fusion
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/image_projection_based_fusion"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# lidar_apollo_instance_segmentation
-- name: Download lidar_apollo_instance_segmentation model bundle ({{ revision }})
-  vars:
-    revision: v1.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/lidar_apollo_instance_segmentation
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/lidar_apollo_instance_segmentation"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# lidar_centerpoint
-- name: Download lidar_centerpoint model bundle ({{ revision }})
-  vars:
-    revision: v4.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/lidar_centerpoint
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/lidar_centerpoint"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# lidar_transfusion
-- name: Download lidar_transfusion model bundle ({{ revision }})
-  vars:
-    revision: v2.1
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/lidar_transfusion
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/lidar_transfusion"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# tensorrt_yolox
-# Includes the whole_image_traffic_light_detector models (source tl_detector_yolox_s/v1).
-- name: Download tensorrt_yolox model bundle ({{ revision }})
-  vars:
-    revision: v1.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/tensorrt_yolox
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/tensorrt_yolox"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# traffic_light_classifier
-- name: Download traffic_light_classifier model bundle ({{ revision }})
-  vars:
-    revision: v4.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/traffic_light_classifier
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/traffic_light_classifier"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# diffusion_planner
-# Each version is a tag on one repository, and every tag holds its files at the repository root,
-# so the versions are downloaded separately into the per-version directories the node expects.
-- name: Download diffusion_planner model bundle ({{ revision }})
-  vars:
-    revision: v3.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/diffusion_planner
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-- name: Download diffusion_planner model bundle ({{ revision }})
-  vars:
-    revision: v3.1
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/diffusion_planner
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-- name: Download diffusion_planner model bundle ({{ revision }})
-  vars:
-    revision: v4.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/diffusion_planner
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-- name: Download diffusion_planner model bundle ({{ revision }})
-  vars:
-    revision: v5.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/diffusion_planner
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/diffusion_planner/{{ revision }}"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# tensorrt_vad
-# The local directory is vad, not tensorrt_vad: the node reads $(var data_path)/vad/v0.1.
-- name: Download tensorrt_vad model bundle ({{ revision }})
-  vars:
-    revision: v0.1
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/tensorrt_vad
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/vad/{{ revision }}"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# traffic_light_fine_detector
-- name: Download traffic_light_fine_detector model bundle ({{ revision }})
-  vars:
-    revision: v3.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/traffic_light_fine_detector
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/traffic_light_fine_detector"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# simpl_prediction
-- name: Download simpl_prediction model bundle ({{ revision }})
-  vars:
-    revision: v0.1
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/simpl_prediction
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/simpl_prediction"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# ptv3
-- name: Download ptv3 model bundle ({{ revision }})
-  vars:
-    revision: v4.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/ptv3
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/ptv3"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# lidar_frnet
-- name: Download lidar_frnet model bundle ({{ revision }})
-  vars:
-    revision: v2.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/lidar_frnet
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/lidar_frnet"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
-
-# calibration_status_classifier
-- name: Download calibration_status_classifier model bundle ({{ revision }})
-  vars:
-    revision: v2.0
-  ansible.builtin.command:
-    cmd: >-
-      hf download AutowareFoundation/calibration_status_classifier
-      --revision {{ revision }}
-      --local-dir "{{ data_dir }}/calibration_status_classifier"
-  environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
-    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-  changed_when: false
+  loop_control:
+    label: "{{ item.repo }} {{ item.revision }}"
+  loop:
+    # v0.1 is the complete upstream PINTO export, the same file set the old archive delivered.
+    # Pruning it to the files the node can actually use (tag v1.0) is a separate follow-up.
+    - { repo: yabloc_pose_initializer, revision: v0.1 }
+    - { repo: bevfusion, revision: v2.0 }
+    - { repo: camera_streampetr, revision: v1.0 }
+    - { repo: tensorrt_bevdet, revision: v1.0 }
+    - { repo: image_projection_based_fusion, revision: v5.0 }
+    - { repo: lidar_apollo_instance_segmentation, revision: v1.0 }
+    - { repo: lidar_centerpoint, revision: v4.0 }
+    - { repo: lidar_transfusion, revision: v2.1 }
+    # Also holds the whole_image_traffic_light_detector models.
+    - { repo: tensorrt_yolox, revision: v1.0 }
+    - { repo: traffic_light_classifier, revision: v4.0 }
+    # Each diffusion_planner version is a tag on one repository. Every tag holds the same
+    # filenames at the repository root, so the tags need separate directories or they
+    # overwrite each other.
+    - { repo: diffusion_planner, revision: v3.0, dest: diffusion_planner/v3.0 }
+    - { repo: diffusion_planner, revision: v3.1, dest: diffusion_planner/v3.1 }
+    - { repo: diffusion_planner, revision: v4.0, dest: diffusion_planner/v4.0 }
+    - { repo: diffusion_planner, revision: v5.0, dest: diffusion_planner/v5.0 }
+    # The local directory is vad, not tensorrt_vad: the node reads $(var data_path)/vad/v0.1.
+    - { repo: tensorrt_vad, revision: v0.1, dest: vad/v0.1 }
+    - { repo: traffic_light_fine_detector, revision: v3.0 }
+    - { repo: simpl_prediction, revision: v0.1 }
+    - { repo: ptv3, revision: v4.0 }
+    - { repo: lidar_frnet, revision: v2.0 }
+    - { repo: calibration_status_classifier, revision: v2.0 }


### PR DESCRIPTION
## Description

All 20 `hf download` tasks in the artifacts role were identical except for the repository, the tag and the local directory. One task now loops over a table of `{repo, revision, dest}`. `dest` is relative to `data_dir` and defaults to the repository name.

Five rows set `dest`. The four `diffusion_planner` tags each hold the same filenames at the repository root, so they need separate directories or they overwrite each other. `tensorrt_vad` goes to `vad/v0.1`, because the node reads `$(var data_path)/vad/v0.1`.

The 20 rendered commands, the environment and the destinations are byte-identical to the tasks they replace. The load-bearing comments stay on the table rows. `loop_control: label` keeps the play output at one line per bundle, labeled `<repo> <revision>`.

One behavior changes. A failed download no longer stops the bundles after it. Ansible runs every loop item, then reports the task as failed, so the play still stops at the task. A user with one bad tag keeps the other bundles, and a failing CI job spends the full remaining download time before it ends.

- Follow-up recorded in the tracker: #7223
- The next changes in line, the `PIPX_BIN_DIR` fix (#7231) and the yabloc `v1.0` pin, become one-line diffs on top of this table.

## How to verify

1. Check out the branch and install the collection:

   ```bash
   gh pr checkout 7268
   ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
   ```

2. Run the role:

   ```bash
   ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
   ```

   Note: a cold run downloads 2.68 GB. If the Hub rate-limits the anonymous downloads, set `HF_TOKEN`.

3. Make sure that the task prints one line per bundle, 20 in total, labeled `<repo> <revision>`.

4. Make sure that the recap shows `failed=0`.

5. Make sure that the versioned destinations are on disk:

   ```bash
   ls ~/autoware_data/ml_models/diffusion_planner   # v3.0  v3.1  v4.0  v5.0
   ls ~/autoware_data/ml_models/vad                 # v0.1
   ```

6. To compare the table against the 20 old tasks, read the diff: `git diff main -- ansible/roles/artifacts/tasks/main.yaml`.

## AI usage

**AI usage:** written with Claude Code from the follow-up list in #7223

**Self-review:** A clean-context Claude Code session reviewed the branch with two agents, an impact trace and an alternatives pass, in one round. The findings, three dropped comments and an unstated behavior change, are fixed on the branch. I read and approved the final diff.

<details>
<summary><strong>Verification:</strong> The 20 rendered commands are byte-identical to the tasks they replace, shown by rendering both file versions through Ansible and diffing the output. The role ran end to end on a warm install with <code>failed=0</code>. Lint is clean.</summary>

### Local playbook run

Ubuntu 24.04, warm `~/autoware_data/ml_models`, collection reinstalled from the working tree.

- The task printed one `ok` line per bundle, 20 in total, labeled `<repo> <revision>`
- Recap: `ok=6 changed=0 unreachable=0 failed=0 skipped=2`
- `real 0m28.070s`
- The `lidar_centerpoint` `v4.0` bundle was not on disk before the run. The run downloaded it, and the `base`, `tiny`, `sigma` and `short_range` variant folders appeared
- Not run locally: the full `install_dev_env` playbook. Its `version_lock` cleanup task needs sudo, which this session cannot provide. The role was run through a minimal playbook that includes `autoware.dev_env.artifacts` with its dependencies. The `run:health-check` CI job runs the full playbook on a cold runner

### Rendered command comparison

Both file versions were copied into playbooks with the `command` module swapped for `ansible.builtin.debug`, run under `ansible-core 2.17.14` with `data_dir=/DATA`, and the 20 rendered strings diffed.

- 20 commands before, 20 commands after, `diff` empty. The `(repo, revision, destination)` triples match in the same order
- The five non-default destinations render as `/DATA/diffusion_planner/v3.0`, `/v3.1`, `/v4.0`, `/v5.0` and `/DATA/vad/v0.1`
- Not run here: the real `hf download` transfers. The test proves the argument strings, not the downloads

### Loop failure semantics

A three-item loop was run with the middle item made to fail, in both shapes.

- Loop shape: the third item still ran after the second failed. Recap `ok=0 changed=0 unreachable=0 failed=1`
- Separate-task shape: the play stopped at the failed task, and the third item never ran
- Not run here: a real failed download against the Hub. The reproduction used a command with a non-zero exit

### Lint and format

- `ansible-lint ansible/roles/artifacts/`: `Passed: 0 failure(s), 0 warning(s)`, profile `production`, at `26.6.0`, the revision pinned in `.pre-commit-config-ansible.yaml`
- `pre-commit run` on the changed files: `prettier` and `yamllint` `Passed`
- Both ran on the final branch state, with the comments back on the table rows
- Not run again after the comment restore: the playbook. That change touches comments only

</details>
