### PR TITLE
feat(ansible): pin yabloc_pose_initializer to the pruned v1.0 bundle

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -12,9 +12,7 @@
   loop_control:
     label: "{{ item.repo }} {{ item.revision }}"
   loop:
-    # v0.1 is the complete upstream PINTO export, the same file set the old archive delivered.
-    # Pruning it to the files the node can actually use (tag v1.0) is a separate follow-up.
-    - { repo: yabloc_pose_initializer, revision: v0.1 }
+    - { repo: yabloc_pose_initializer, revision: v1.0 }
     - { repo: bevfusion, revision: v2.0 }
     - { repo: camera_streampetr, revision: v1.0 }
     - { repo: tensorrt_bevdet, revision: v1.0 }


### PR DESCRIPTION
## Description

Batch D pinned yabloc to tag `v0.1`, the complete upstream PINTO export, so the new hosting delivered the same file set as the old archive. This PR switches the pin to `v1.0`, which keeps the frozen graph the node reads, at the same `saved_model/model_float32.pb` path, plus an ONNX export of the same network.

`v1.0` drops the variant formats of the upstream export, which nothing in Autoware reads. The two files the node can use are byte-identical across the tags.

| | `v0.1` | `v1.0` |
| --- | --- | --- |
| Files | 108 | 6 |
| Download size | 41.8 MB | 1.7 MB |
| `saved_model/model_float32.pb`, the file the node reads | ✅ | ✅ |
| `saved_model/model_float32.onnx` | ✅ | ✅ |
| TFLite, TF.js, OpenVINO IR, Myriad blob, TensorFlow SavedModel and TF-TRT variants | ✅ | ❌ |

An install that already holds the `v0.1` file set keeps the extra files on disk, because `hf download` never deletes. They are inert.

- Tracker entry: #7223
- Batch D, which introduced the `v0.1` pin: #7248

## AI usage

**AI usage:** written with Claude Code from the follow-up list in #7223

**Self-review:** Done ✅

<details>
<summary><strong>Verification:</strong> The <code>.pb</code> the node reads is byte-identical across <code>v0.1</code> and <code>v1.0</code>, and the role run with the new pin ended <code>failed=0</code>.</summary>

### Tag comparison via the Hub API

- `saved_model/model_float32.pb` LFS sha256 at `v0.1` and at `v1.0`: both `c4e373552f4efb91592ed99f49afc6df179f8a95174ceaddd1ab35692f435b47`
- `saved_model/model_float32.onnx` sha256 is also identical across the two tags
- `sha256sum` of the file on this machine matches the same value

### Local playbook run

On the branch rebuilt on top of the merged refactor.

- The merged refactor: #7268
- `ok: [localhost] => (item=yabloc_pose_initializer v1.0)`, recap `failed=0`
- `ansible-lint`: `Passed: 0 failure(s), 0 warning(s)`, profile `production`
- A comment-only amend followed the run (the two yabloc comment lines were dropped); the playbook was not re-run for it
- Not run: the yabloc node itself. No camera rosbag was played against the model. The file identity above is the argument that runtime behavior cannot change

</details>
