### PR TITLE
fix(ansible): honor PIPX_BIN_DIR when locating the hf CLI

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -6,7 +6,7 @@
       --revision {{ item.revision }}
       --local-dir "{{ data_dir }}/{{ item.dest | default(item.repo) }}"
   environment:
-    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    PATH: "{{ ansible_facts.env.PIPX_BIN_DIR | default(ansible_facts.env.HOME ~ '/.local/bin', true) }}:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
   changed_when: false
   loop_control:


### PR DESCRIPTION
## Description

The download task hardcoded `~/.local/bin` as the pipx bin directory, but `install-ansible.sh` honors the documented `PIPX_BIN_DIR` override. A developer who sets it got `hf: command not found` from a role whose install step had reported success.

The `PATH` now prefers `PIPX_BIN_DIR` and falls back to `~/.local/bin` when the variable is unset or empty. Since the loop refactor this is one line for all 20 downloads.

- Closes #7231
- The refactor that consolidated the 20 `environment:` blocks: #7268

## How to verify

The change moves the `hf` lookup to `PIPX_BIN_DIR`. An `hf` wrapper that records its own use shows which binary the role runs.

1. Check out the branch and install the collection:

   ```bash
   gh pr checkout 7270
   ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
   ```

2. Create a bin directory with an `hf` wrapper that records its use:

   ```bash
   mkdir -p /tmp/pipx-bin
   cat > /tmp/pipx-bin/hf <<'EOF'
   #!/bin/sh
   touch /tmp/pipx-bin/used
   exec "$HOME"/.local/bin/hf "$@"
   EOF
   chmod +x /tmp/pipx-bin/hf
   ```

3. Run the artifacts role with the override set:

   ```bash
   PIPX_BIN_DIR=/tmp/pipx-bin ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
   ```

   Note: a warm install finishes in under a minute. A cold run downloads 2.68 GB.

4. Make sure that the recap shows `failed=0` and that the marker file exists:

   ```bash
   ls /tmp/pipx-bin/used
   ```

   The marker proves that the downloads ran the `hf` from `PIPX_BIN_DIR`.

5. To see the old behavior, delete the marker and repeat step 3 on `main`. The run passes, but no marker appears: the old code ignores `PIPX_BIN_DIR` and takes `hf` from `~/.local/bin`.

6. A run without `PIPX_BIN_DIR` in the environment uses the `~/.local/bin` fallback and behaves as before.

## AI usage

**AI usage:** written with Claude Code from the issue description

**Self-review:** I verified this with the steps shared above, can merge 👍

<details>
<summary><strong>Verification:</strong> The role ran with a stripped <code>PATH</code> twice: once resolving <code>hf</code> through the fallback, once through <code>PIPX_BIN_DIR</code> alone. Both runs ended <code>failed=0</code>.</summary>

Both runs were made on the rebased branch, on top of the merged refactor.

- The merged refactor: #7268

### Fallback path

`env -i HOME=$HOME USER=$USER PATH=/usr/bin:/bin ansible-playbook <role test playbook>`, so `~/.local/bin` is not on the inherited `PATH` and `PIPX_BIN_DIR` is unset.

- All 20 bundles `ok`, recap `failed=0`
- `hf` resolved through the `~/.local/bin` fallback of the new expression

### PIPX_BIN_DIR path

Same stripped environment, plus `PIPX_BIN_DIR=<scratch dir>` where the scratch dir holds only a symlink to `hf`.

- All 20 bundles `ok`, recap `failed=0`
- `hf` is findable only through `PIPX_BIN_DIR` in this run, so the new expression was exercised, not the fallback
- Not run: the failing case on the old code (a machine where `hf` is absent from `~/.local/bin`). The failure mode is documented in #7231

### The marker check from How to verify

The wrapper test ran on this machine, warm install, on both sides of the change.

- On the branch: recap `failed=0`, and `/tmp/pipx-bin/used` appeared
- On `main`, same command and a deleted marker: recap `failed=0`, and no marker appeared. The old code ignores `PIPX_BIN_DIR`
- Not run as written: the steps here ran through a minimal playbook that includes only the artifacts role, because `install_dev_env` asks for sudo that this session cannot provide

</details>
