### PR TITLE
fix(ansible): pin huggingface_hub and watch for new majors

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -7,6 +7,7 @@
     "metapackage",
     "runpip",
     "selstate",
-    "showmanual"
+    "showmanual",
+    "xmfcx"
   ]
 }

--- a/.github/workflows/health-check-ansible-artifacts.yaml
+++ b/.github/workflows/health-check-ansible-artifacts.yaml
@@ -28,6 +28,7 @@ jobs:
           files: |
             ansible/roles/artifacts/**
             ansible/roles/autoware_data_ownership/**
+            ansible/roles/huggingface_cli/**
             ansible/playbooks/install_dev_env.yaml
             ansible/scripts/install-ansible.sh
             ansible-galaxy-requirements.yaml

--- a/.github/workflows/watch-huggingface-hub-major.yaml
+++ b/.github/workflows/watch-huggingface-hub-major.yaml
@@ -1,0 +1,69 @@
+# The hf CLI install in ansible/roles/huggingface_cli pins huggingface_hub to one major, so a new
+# major on PyPI is invisible to provisioning. This check makes it visible: it opens one issue per
+# new major, and reads the pinned major from the role file so the two never drift apart.
+
+name: watch-huggingface-hub-major
+
+on:
+  schedule:
+    - cron: 0 0 * * 1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  watch-huggingface-hub-major:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Compare the pinned major with the latest release on PyPI
+        id: compare
+        run: |
+          pinned_major=$(grep -oP 'huggingface_hub==\K[0-9]+' ansible/roles/huggingface_cli/tasks/main.yaml)
+          latest=$(curl -fsSL https://pypi.org/pypi/huggingface_hub/json | jq -r .info.version)
+          latest_major=${latest%%.*}
+          {
+            echo "pinned-major=${pinned_major}"
+            echo "latest=${latest}"
+            echo "latest-major=${latest_major}"
+            echo "new-major=$([ "${latest_major}" -gt "${pinned_major}" ] && echo true || echo false)"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create the issue for the new major
+        if: steps.compare.outputs.new-major == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PINNED_MAJOR: ${{ steps.compare.outputs.pinned-major }}
+          LATEST: ${{ steps.compare.outputs.latest }}
+          LATEST_MAJOR: ${{ steps.compare.outputs.latest-major }}
+        run: |
+          title="Evaluate huggingface_hub ${LATEST_MAJOR}.x for the hf CLI pin"
+          count=$(gh issue list --repo "${GITHUB_REPOSITORY}" --state all --search "\"${title}\" in:title" --json number --jq length)
+          if [ "${count}" -gt 0 ]; then
+            echo "An issue for major ${LATEST_MAJOR} exists. Nothing to do."
+            exit 0
+          fi
+          cat > body.md << EOF
+          @autowarefoundation/autoware-maintainers @xmfcx @mitsudome-r
+
+          huggingface_hub ${LATEST} is on PyPI. The hf CLI install in \`ansible/roles/huggingface_cli\` pins \`huggingface_hub==${PINNED_MAJOR}.*\`, so provisioning stays on the old major and does not pick this release up.
+
+          A new major can change the CLI surface. To move the pin:
+
+          1. Read the huggingface_hub release notes for the breaking changes.
+          2. Run the artifacts role with the new major. Make sure that all downloads pass.
+          3. Update the version bound in \`ansible/roles/huggingface_cli/tasks/main.yaml\` and in the README of the role.
+
+          To stay on ${PINNED_MAJOR}.x, close this issue. The check opens one issue per major.
+
+          This issue comes from the \`${GITHUB_WORKFLOW}\` workflow.
+          EOF
+          gh issue create --repo "${GITHUB_REPOSITORY}" --title "${title}" --body-file body.md --label type:installation --assignee xmfcx --assignee mitsudome-r

--- a/ansible/roles/huggingface_cli/README.md
+++ b/ansible/roles/huggingface_cli/README.md
@@ -9,5 +9,5 @@ None.
 ## Manual Installation
 
 ```bash
-pipx install huggingface_hub
+pipx install --force "huggingface_hub==1.*"
 ```

--- a/ansible/roles/huggingface_cli/tasks/main.yaml
+++ b/ansible/roles/huggingface_cli/tasks/main.yaml
@@ -11,7 +11,9 @@
     update_cache: true
   when: not huggingface_cli__pipx.stat.exists
 
+# The major bound keeps the hf CLI surface stable. --force makes every run converge to the
+# bound, so an install that holds an out-of-range version gets corrected.
 - name: Install huggingface_hub for the hf CLI
   ansible.builtin.command:
-    cmd: /usr/bin/pipx install huggingface_hub
-    creates: ~/.local/bin/hf
+    cmd: /usr/bin/pipx install --force huggingface_hub==1.*
+  changed_when: false


### PR DESCRIPTION
## Description

The role installed whatever `huggingface_hub` was latest on PyPI at provision time, so the `hf` CLI surface differed between machines. The surface already broke once within a major: the entrypoint rename and the `--local-dir` semantics changes.

The install command becomes `/usr/bin/pipx install --force huggingface_hub==1.*`, the same idiom `install-ansible.sh` uses for `ansible==10.*`. `--force` makes every run converge to the bound, so a machine that holds an out-of-range version gets corrected. The `creates:` guard is gone: it never upgraded anything, and it hardcoded the pipx bin directory.

- Closes #7230

The issue suggested `community.general.pipx` options, but #7221 replaced that module with a plain `pipx` command, so the fix lands in the command form.

The pin has a cost: when huggingface_hub 2.0 releases, nothing breaks and nobody notices, because every run keeps converging to 1.x. The new `watch-huggingface-hub-major` workflow pays that cost. Once a week it compares the pinned major, read from the role file itself, with the latest release on PyPI. When a new major appears, it opens one issue with the evaluation steps, assigns @xmfcx and @mitsudome-r, and mentions @autowarefoundation/autoware-maintainers.

Two smaller changes ride along. The differential spell check flagged `xmfcx` in the workflow, so the word joins the local `.cspell.json`. And the `install-artifacts` cold check now also triggers on `ansible/roles/huggingface_cli/**`: the role installs the `hf` binary the artifacts role runs, and the old filter could not see changes to it. That filter change makes the cold artifacts check run on this PR.

Two decisions the diff does not show. The workflow assigns the maintainers instead of relying on the team mention, because GitHub suppresses team notifications that come from the `github-actions` bot. And it opens an issue, not an automatic bump PR: a new major is a breaking change, and a regex edit against a file that can move is not a change anyone verified. The duplicate search covers closed issues too, so closing the issue silences the check for that major.

## AI usage

**AI usage:** written with Claude Code from the issue description

**Self-review:** Not reviewed yet.

<details>
<summary><strong>Verification:</strong> The pinned install upgraded a real machine from 1.24.0 to 1.27.0, and all 20 model downloads passed under the new CLI. The watcher ran end to end on the xmfcx fork: it created the issue once, then deduplicated against it open and closed.</summary>

### Local playbook run

Ubuntu 24.04, pipx-held `huggingface-hub 1.24.0` before the run.

- The install task ran with `--force` and the venv converged to the current 1.x
- `hf version` after the run: `version=1.27.0` (PyPI latest at the time)
- The artifacts role then verified all 20 bundles with the new CLI: recap `failed=0`
- After the rebase onto the merged #7268 and #7269, the role ran again: the install task converged with `--force`, `hf version` stayed `version=1.27.0` (still the newest 1.x), and the artifacts role recap was `failed=0` again
- Not run: a machine without pipx, and a machine with no prior `hf` install. The `run:health-check` CI job covers the cold path

### Watcher logic, run locally

The two `run:` blocks of the workflow ran as shell scripts on this machine. The workflow itself has not executed on GitHub yet.

- With the real data of 2026-08-15: `pinned=1 latest=1.27.0 latest_major=1 new_major=false`, so the issue step stays skipped
- With `pinned_major` forced to 0: the gate evaluates true, the duplicate search over autowarefoundation/autoware returns 0, and the issue body renders with the versions and the mentions filled in
- Not run locally: `gh issue create`. The fork test below covers it. `actionlint` is not installed on this machine

### End-to-end runs on the xmfcx fork

The workflow ran on the default branch of the xmfcx/autoware fork. A test-only commit set the role pin to `huggingface_hub==0.*` to make the gate fire; the workflow file itself was byte-identical to this PR.

- The first dispatch created the issue with the intended title, body, label and assignee: xmfcx/autoware#1
- First run: <https://github.com/xmfcx/autoware/actions/runs/31817046912>
- The second dispatch found that issue and created nothing: `An issue for major 1 exists. Nothing to do.`
- Second run: <https://github.com/xmfcx/autoware/actions/runs/31817111967>
- The third dispatch ran after the issue was closed and also created nothing, so a closed issue silences the check for its major
- Third run: <https://github.com/xmfcx/autoware/actions/runs/31817191372>
- GitHub dropped the `mitsudome-r` assignment on the fork silently, because assignment needs push access to that repository. On autowarefoundation/autoware both assignees have it
- The fork needed issues enabled and the `type:installation` label created before the test. Upstream has both
- The fork `main` was reset to the upstream tip after the test. The schedule trigger itself was not exercised; the three runs used `workflow_dispatch`

### Lint

- `ansible-lint ansible/roles/huggingface_cli/`: `Passed: 0 failure(s), 0 warning(s)`, profile `production`
- `pre-commit run` on the workflow file: `yamllint`, `prettier` and `check yaml` `Passed`

</details>
