### PR TITLE
feat(ansible): update lidar_centerpoint model bundle to v4.1

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -18,7 +18,7 @@
     - { repo: tensorrt_bevdet, revision: v1.0 }
     - { repo: image_projection_based_fusion, revision: v5.0 }
     - { repo: lidar_apollo_instance_segmentation, revision: v1.0 }
-    - { repo: lidar_centerpoint, revision: v4.0 }
+    - { repo: lidar_centerpoint, revision: v4.1 }
     - { repo: lidar_transfusion, revision: v2.1 }
     # Also holds the whole_image_traffic_light_detector models.
     - { repo: tensorrt_yolox, revision: v1.0 }


### PR DESCRIPTION
## Description

Pins the `lidar_centerpoint` model bundle to `v4.1`. The v4.1 manifests declare the bundle version and carry `model_params.yaw_norm_thresholds`, both of which the node requires as of autowarefoundation/autoware_universe#13211.

## Related PRs

- universe: autowarefoundation/autoware_universe#13211
- launch: autowarefoundation/autoware_launch#1949
- data: [AutowareFoundation/lidar_centerpoint PR #2](https://huggingface.co/AutowareFoundation/lidar_centerpoint/discussions/2) (tag `v4.1`)

Merge only after the `v4.1` tag exists on the Hugging Face repository.
