### PR TITLE
chore: update agnocast to 2.4.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,9 @@ src/**/.*
 src/**/*.asc
 src/**/*.gif
 src/**/*.md
+# ros2agnocast_discovery_agent installs this via setup.py data_files;
+# removing it fails colcon build in the container (can't copy 'systemd/README.md').
+!src/**/systemd/README.md
 src/**/*.svg
 
 # Ignore generated files by colcon

--- a/ansible/roles/agnocast/defaults/main.yaml
+++ b/ansible/roles/agnocast/defaults/main.yaml
@@ -1,4 +1,4 @@
-agnocast_version: 2.3.5
+agnocast_version: 2.4.0
 agnocast_heaphook_package: agnocast-heaphook-v{{ agnocast_version }}
 agnocast_kmod_package: agnocast-kmod-v{{ agnocast_version }}
 agnocast_force_kmod_install: false

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -7,7 +7,7 @@ repositories:
   core/agnocast:
     type: git
     url: https://github.com/autowarefoundation/agnocast.git
-    version: 2.3.5
+    version: 2.4.0
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
## Description

Update agnocast from 2.3.5 to 2.4.0 (`repositories/autoware.repos` and the `agnocast` ansible role).

Also adds one `.dockerignore` exception. 2.4.0 introduces `ros2agnocast_discovery_agent`, whose `setup.py` installs `systemd/README.md` — the operating instructions for the `agnocast-domain-bridge.service.example` shipped next to it. `src/**/*.md` (added in #5009 to cut image size) excludes it from the Docker build context, so `colcon build` fails in the container with `can't copy 'systemd/README.md'` while a local build passes.

The exception restores a single 2 KB file. #5009's saving came mostly from `.git` — its own description says "the most effective one is `.git`" — and `.svg`/`.asc`/`.gif` stay excluded; all 636 `.md` files under `src/` total 3.3 MB on a local checkout. Same shape as #5187 and #5263, which restored `.csv`/`.png` for the same reason.

## How was this PR tested?

Confirmed the `2.4.0` tag exists in https://github.com/autowarefoundation/agnocast, and that `agnocast-heaphook-v2.4.0` and `agnocast-kmod-v2.4.0` are available from the agnocast PPA.

Health-check failed before the `.dockerignore` change with `error: can't copy 'systemd/README.md'` in `ros2agnocast_discovery_agent` on all five jobs ([run](https://github.com/autowarefoundation/autoware/actions/runs/33482347758)).

Verified the exception with a scratch `docker build` over the same layout: `systemd/README.md` reaches the context while other `src/**/*.md` files stay excluded.
