### PR TITLE
chore(codeowners): add Koichi98 as owner of the agnocast role

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,5 @@
 .devcontainer/** oguzkaganozt@gmail.com yutaka.kondo@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@autoware.org
 .github/** oguzkaganozt@gmail.com yutaka.kondo@tier4.jp isamu.takagi@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@autoware.org
 ansible/** oguzkaganozt@gmail.com yutaka.kondo@tier4.jp isamu.takagi@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@autoware.org
+ansible/roles/agnocast/** oguzkaganozt@gmail.com yutaka.kondo@tier4.jp isamu.takagi@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@autoware.org @Koichi98
 docker/** oguzkaganozt@gmail.com yutaka.kondo@tier4.jp isamu.takagi@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@autoware.org


### PR DESCRIPTION
## Description

Add `@Koichi98` as a code owner of `ansible/roles/agnocast/`. Koichi98 authored the agnocast version bumps in this repository.

- The latest bump: #7292

CODEOWNERS is last-match-wins and does not merge owners across lines. The new `ansible/roles/agnocast/**` line therefore repeats the five `ansible/**` owners and appends `@Koichi98`. Without the repeat, the maintainers stop getting review requests for that role.

- The same reasoning drove #7043.

The entry uses the GitHub handle. CODEOWNERS accepts a handle or an email, and the account has no public email. GitHub requests reviews from a code owner only when that user has write access to the repository. Koichi98 needs that access before the entry takes effect.

- Stacked on #7293. The diff shows only the CODEOWNERS line.

## How to verify

1. Open `.github/CODEOWNERS` on the branch in the GitHub UI. GitHub marks the line if an owner is unknown or has no write access.
2. Run `gh api "repos/autowarefoundation/autoware/codeowners/errors?ref=chore/codeowners-agnocast"` and make sure that the output is `{"errors":[]}`.

## AI usage

**AI usage:** written with Claude Code on request

**Self-review:** Not reviewed yet.

<details>
<summary><strong>Verification:</strong> <code>pre-commit</code> passed on the file. The GitHub CODEOWNERS errors API returns <code>{"errors":[]}</code> for the branch, after Koichi98 received write access.</summary>

### pre-commit

`pre-commit run --files .github/CODEOWNERS`

- `prettier` passed, `fix end of files` passed
- Syntax: the file parses. The one error below is about permissions, not syntax

### CODEOWNERS errors API

`gh api "repos/autowarefoundation/autoware/codeowners/errors?ref=chore/codeowners-agnocast"`, after the push.

- Result: one error, `Unknown owner on line 6: make sure @Koichi98 exists and has write access to the repository`
- The other five owners on the line raise no error
- Re-run after Koichi98 received write access: `{"errors":[]}`
- Not run: a review request test on a real change under `ansible/roles/agnocast/`. The first such PR after merge shows it

### Permission lookup

`gh api repos/autowarefoundation/autoware/collaborators/Koichi98/permission`

- First result: `permission=read role=triage`. This is the effective permission, teams included
- After the access grant: `permission=write role=write`

</details>
