### PR TITLE
fix(ansible): declare ansible.posix as a collection dependency

### DIFF
--- a/ansible/galaxy.yml
+++ b/ansible/galaxy.yml
@@ -12,7 +12,8 @@ license:
   - Apache-2.0
 tags:
   - autoware
-dependencies: {}
+dependencies:
+  ansible.posix: ">=1.0.0"
 repository: https://github.com/autowarefoundation/autoware
 documentation: https://autowarefoundation.github.io/autoware-documentation
 homepage: https://www.autoware.org/


### PR DESCRIPTION
## Description

The `autoware.dev_env` collection uses two modules from the `ansible.posix` collection. The `agnocast` role uses `ansible.posix.sysctl`, and the `qt5ct_setup` role uses `ansible.posix.synchronize`. The `galaxy.yml` file declared no dependencies. This PR adds `ansible.posix: ">=1.0.0"` to `dependencies`.

The install paths of Autoware do not show the problem. `ansible/scripts/install-ansible.sh`, the Dockerfiles, and the CI workflows install `ansible==10.*`. That package bundles `ansible.posix` 1.6.2, so the modules resolve. A host with only `ansible-core` has no `ansible.posix`. On such a host, `ansible-playbook autoware.dev_env.install_dev_env` stops at parse time with `couldn't resolve module/action 'ansible.posix.sysctl'`. The `--tags` option does not help, because Ansible resolves every task of every role before it filters by tag. `install_image_deps` stops the same way on `ansible.posix.synchronize`.

With the dependency in `galaxy.yml`, `ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml` resolves it. If `ansible.posix` is already installed, for example from the `ansible` bundle, the resolver uses that copy and downloads nothing. If it is absent, the resolver downloads it from Galaxy.

The dependency goes in `galaxy.yml` and not in `ansible-galaxy-requirements.yaml`. An entry in the requirements file is an explicit request, and `-f` reinstalls an explicit request on every run. That adds a Galaxy download to every Docker build and every CI job. A dependency in `galaxy.yml` is only resolved when it is missing.

The lower bound is `>=1.0.0` because both modules exist in `ansible.posix` since 1.0.0. On a host without the bundle, the resolver picks the newest release on Galaxy, 2.2.2 today.

## How to verify

1. Install `ansible-core` without the `ansible` bundle, for example with `pipx install ansible-core`.
2. Run `ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml`. The output must list `ansible.posix`.
3. Run `ansible-playbook --syntax-check autoware.dev_env.install_dev_env`. The exit code must be 0.

## AI usage

**AI usage:** written with Claude Code. Fatih made the one-line change in `galaxy.yml`. Claude Code traced the two module usages, tested the install paths, and wrote this description.

**Self-review:** Simple PR, fixed the problem for me. And doesn't regress existing behavior.

<details>
<summary><strong>Verification:</strong> With <code>ansible-core</code> only, the collection install now pulls <code>ansible.posix</code> 2.2.2 and all five playbooks pass <code>--syntax-check</code>. With the <code>ansible==10.*</code> bundle that Docker and CI use, the install output is unchanged and <code>ansible-lint</code> passes, but no Docker image was built.</summary>

### Collection install with `ansible-core` 2.21.3

Two copies of `ansible/`, one with the `galaxy.yml` from `main` and one with this change. Each install ran with `ANSIBLE_COLLECTIONS_PATH` set to an empty directory.

- Before: `autoware.dev_env:0.1.0 was installed successfully`, nothing else
- After: the same line, then `Downloading https://galaxy.ansible.com/.../ansible-posix-2.2.2.tar.gz` and `ansible.posix:2.2.2 was installed successfully`

### Playbook syntax check with `ansible-core` 2.21.3

`ansible-playbook --syntax-check autoware.dev_env.<playbook>` against each copy.

- Before: `install_dev_env` exit 4 with `couldn't resolve module/action 'ansible.posix.sysctl'`. `install_image_deps` exit 4 with `couldn't resolve module/action 'ansible.posix.synchronize'`. `install_docker`, `install_nvidia`, `install_rmw` exit 0
- Before: `install_dev_env --tags artifacts --list-tasks` also exits 4 with the `sysctl` error, so `--tags` is not a workaround
- After: all five playbooks exit 0
- Not run: the playbooks themselves, with `sudo`. The check stops at module resolution, which is the error that this PR corrects

### Collection install with the `ansible==10.*` bundle

A venv with `ansible` 10.7.0 (`ansible-core` 2.17.14), the version that `install-ansible.sh`, the Dockerfiles, and the CI workflows install. `ansible-galaxy collection list ansible.posix` shows `ansible.posix 1.6.2` in `site-packages`.

- Before and after: the output is the same two lines, `Installing 'autoware.dev_env:0.1.0'` and `autoware.dev_env:0.1.0 was installed successfully`. No `Downloading` line, no `ansible.posix` line
- Alternative design, `ansible.posix` as a second entry in the requirements file: `Downloading .../ansible-posix-2.2.2.tar.gz` on every run, also with the bundle. This is why the dependency sits in `galaxy.yml`
- Not run: a Docker image build. The `ansible-galaxy` command and the `ansible` version are the same as in `docker/*.Dockerfile`

### `ansible-lint`

The `pre-commit-ansible` hook pins `language_version: python3.14`, which this machine does not have. A venv with `ansible-lint==26.6.0` and `ansible` 14.3.1 (`ansible.posix` 2.2.2 bundled) reproduced the hook. The CI install step ran first, against an empty collections path.

- `ansible-lint -v ansible/` logged `Provisioning collection ansible.posix:>=1.0.0 from galaxy.yml`, then `Passed: 0 failure(s), 0 warning(s) in 89 files processed of 164 encountered`
- The same run with `ANSIBLE_GALAXY_SERVER=http://127.0.0.1:9` and a fresh cache also passed, so the job does not depend on Galaxy
- The local `ansible-lint` 26.8.0 with `ansible-core` 2.21.3 also passed with the same counts
- Not run: the `pre-commit-ansible` workflow itself, on Python 3.14

### Module history

- `gh api repos/ansible-collections/ansible.posix/contents/plugins/modules?ref=1.0.0` lists `sysctl.py` and `synchronize.py`
- `ansible-doc -l ansible.posix` on 2.2.2 lists both modules

</details>
