### PR TITLE
feat(ansible): add the Kashiwanoha CARLA map to demo_artifacts

### DIFF
--- a/ansible/roles/demo_artifacts/README.md
+++ b/ansible/roles/demo_artifacts/README.md
@@ -4,8 +4,9 @@ Downloads sample maps and rosbag recordings used by the Autoware demos:
 
 - [Planning simulation](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/) — uses `sample-map-planning`
 - [Rosbag replay simulation](https://autowarefoundation.github.io/autoware-documentation/main/demos/rosbag-replay-simulation/) — uses `sample-map-rosbag` and `sample-rosbag`
+- [CARLA simulation](../../../docker/examples/demos/carla/README.md) — uses `carla-kashiwanoha`
 
-The artifacts are hosted on the `autoware-files` S3 bucket.
+The maps and the recordings are hosted on the `autoware-files` S3 bucket. The CARLA map is hosted on [Hugging Face](https://huggingface.co/datasets/AutowareFoundation/map-carla-kashiwanoha), pinned to tag `0.2.0`. The download drops the demo video in that dataset, which no node reads.
 
 ## Layout
 
@@ -14,6 +15,7 @@ After running the role, the following layout is created under `demo_artifacts__a
 ```console
 ~/autoware_data
 ├── maps
+│   ├── carla-kashiwanoha/
 │   ├── sample-map-planning/
 │   ├── sample-map-planning.zip
 │   ├── sample-map-rosbag/
@@ -23,6 +25,17 @@ After running the role, the following layout is created under `demo_artifacts__a
         ├── sample-rosbag/
         └── sample-rosbag.zip
 ```
+
+`carla-kashiwanoha/` is a complete map directory:
+
+```console
+~/autoware_data/maps/carla-kashiwanoha
+├── kashiwanoha.xodr          # read by CARLA, to build the world
+├── lanelet2_map.osm          # read by Autoware
+└── map_projector_info.yaml   # read by Autoware
+```
+
+CARLA has no map of this area, so it builds the world from `kashiwanoha.xodr`. Both files describe the same roads, against the one origin in `map_projector_info.yaml`. The [dataset card](https://huggingface.co/datasets/AutowareFoundation/map-carla-kashiwanoha) carries the world build step and the provenance of each file.
 
 ## Run
 

--- a/ansible/roles/demo_artifacts/meta/main.yaml
+++ b/ansible/roles/demo_artifacts/meta/main.yaml
@@ -1,3 +1,4 @@
 dependencies:
   # Runs first: the download tasks below write into autoware_data as the user, not as root.
   - role: autoware.dev_env.autoware_data_ownership
+  - role: autoware.dev_env.huggingface_cli

--- a/ansible/roles/demo_artifacts/tasks/main.yaml
+++ b/ansible/roles/demo_artifacts/tasks/main.yaml
@@ -56,3 +56,22 @@
   ansible.builtin.unarchive:
     src: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/sample-rosbag.zip"
     dest: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/"
+
+# map-carla-kashiwanoha (CARLA docker-compose demo)
+# dest is relative to the maps directory. The demo video in the dataset is not part of the map.
+- name: Download the map datasets from Hugging Face
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/{{ item.repo }}
+      --repo-type dataset
+      --revision {{ item.revision }}
+      --exclude "*.mp4"
+      --local-dir "{{ demo_artifacts__autoware_data_dir }}/maps/{{ item.dest | default(item.repo) }}"
+  environment:
+    PATH: "{{ ansible_facts.env.PIPX_BIN_DIR | default(ansible_facts.env.HOME ~ '/.local/bin', true) }}:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
+  loop_control:
+    label: "{{ item.repo }} {{ item.revision }}"
+  loop:
+    - { repo: map-carla-kashiwanoha, revision: 0.2.0, dest: carla-kashiwanoha }


### PR DESCRIPTION
## Description

The `demo_artifacts` role now downloads the Kashiwanoha map for the CARLA demo. The map lives on Hugging Face as the dataset `AutowareFoundation/map-carla-kashiwanoha`, pinned to tag `0.2.0`. It lands in `~/autoware_data/maps/carla-kashiwanoha/`, beside the two sample maps.

The dataset is a complete Autoware map directory plus the CARLA side of the same roads:

| File | Read by |
| --- | --- |
| `lanelet2_map.osm` | Autoware |
| `map_projector_info.yaml` | Autoware |
| `kashiwanoha.xodr` | CARLA, to build the world |

CARLA has no map of this area. The world is built from the OpenDRIVE at run time. The dataset card carries that step and the provenance of each file: <https://huggingface.co/datasets/AutowareFoundation/map-carla-kashiwanoha>

The task uses the same `hf download` loop shape as the `artifacts` role, so the next map dataset is one more loop entry. It passes `--repo-type dataset`, because this is a dataset repository. It excludes the demo video in the dataset, which no node reads. The `huggingface_cli` role joins the dependencies of `demo_artifacts`, so `hf` is present on a clean host.

The role README gets the new directory in the layout tree and a short note on the three files.

The map was first proposed as files inside `autoware_universe`. That PR was closed, and the data moved to the Hub, the same route as the models.

- autowarefoundation/autoware_universe#13310

The CARLA demo compose file does not use this map yet. That change waits for the next release, because the published images carry an `autoware_carla_interface` from before the `carla_map` override.

- autowarefoundation/autoware#7283

## AI usage

**AI usage:** Written with Claude Code: the role change, the README, the dataset completion on Hugging Face, and the verification below. I read every line.

**Self-review:** It downloads fine, also ran carla on my local. Safe to merge.

<details>
<summary><strong>Verification:</strong> The task ran standalone against tag <code>0.2.0</code> and produced the three map files with matching checksums. The result directory then carried a full autonomous drive in CARLA.</summary>

### The download task, standalone against localhost

The new task, copied verbatim into a one host playbook. Ubuntu 24.04, `hf` 1.28.0 from pipx.

- Recap `ok=2 changed=0 unreachable=0 failed=0`, `rc: 0`, 3 s.
- Result directory: `kashiwanoha.xodr`, `lanelet2_map.osm`, `map_projector_info.yaml`, `README.md`, `.gitattributes`. No `.mp4`.
- `sha256sum lanelet2_map.osm` is `4fe358f2d1e182dc76de296e5619086f8d8ad2fcab3e6d8f99f6e3d724a84e6d`, equal to `planning/autoware_diffusion_planner/test_map/lanelet2_map.osm` in `autoware_universe`.
- `sha256sum kashiwanoha.xodr` is `fbd06aec46853270548a62f16d8754c8cdb669113b52726fc6477e9789302df5`, equal to the LFS object the Hub reports for the tag.
- Not run: the full `demo_artifacts` role. Its `unzip` task needs sudo, and this host has no passwordless sudo.

### The map files, loaded by Autoware nodes

- `ros2 launch autoware_map_projection_loader map_projection_loader.launch.xml` on the downloaded `map_projector_info.yaml`: the node logged `Loaded map projector info`, and `/map/map_projector_info` published `LocalCartesianUTM`, origin `35.9033135426554 / 139.93338978245356`, `scale_factor: 0.9996`.
- `lanelet2.io.loadRobust` on the downloaded `lanelet2_map.osm` with the Autoware regulatory elements registered: 0 errors, 190 lanelets, 51 regulatory elements.

### A drive on the downloaded directory

CARLA 0.9.16 in Docker, the `universe-cuda-jazzy-1.9.0` image with the `main` branch `autoware_carla_interface` overlaid, `planning_simulator.launch.xml` with ground truth localization. 2026-09-03.

- The world was built from `kashiwanoha.xodr` in 5.9 s: `Carla/Maps/OpenDriveMap`, 238 spawn points.
- Engage at 10:01:04 UTC, `ARRIVED` at 10:02:01, 143 m route at 4.2 m/s.
- Not run: the demo compose file as it is in the repository. It cannot load this map with the published images.

### Static checks

- `ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --syntax-check` passed.
- `pre-commit run` on the three files passed: `yamllint`, `prettier`, `markdownlint`.
- Not run: `ansible-lint`, not installed on this host. Not run: a Humble or 22.04 host.

</details>
