### PR TITLE
ci(health-check): trim the PR matrix to the amd64 main legs

### DIFF
--- a/.github/workflows/health-check-pr.yaml
+++ b/.github/workflows/health-check-pr.yaml
@@ -51,27 +51,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [main, nightly, main-arm64, main-jazzy-amd64, main-jazzy-arm64]
+        build-type: [main-humble-amd64, main-jazzy-amd64]
         include:
-          - build-type: main
+          - build-type: main-humble-amd64
             platform: amd64
             runner: "['ubuntu-24.04']"
-            ros-distro: humble
-          - build-type: nightly
-            platform: amd64
-            runner: "['ubuntu-24.04']"
-            ros-distro: humble
-          - build-type: main-arm64
-            platform: arm64
-            runner: "['ubuntu-24.04-arm']"
             ros-distro: humble
           - build-type: main-jazzy-amd64
             platform: amd64
             runner: "['ubuntu-24.04']"
-            ros-distro: jazzy
-          - build-type: main-jazzy-arm64
-            platform: arm64
-            runner: "['ubuntu-24.04-arm']"
             ros-distro: jazzy
     uses: ./.github/workflows/health-check-reusable.yaml
     with:

--- a/.github/workflows/health-check-reusable.yaml
+++ b/.github/workflows/health-check-reusable.yaml
@@ -1,10 +1,10 @@
-# Builds `universe-devel` on independent matrix routes:
-# `main/amd64`, `nightly/amd64`, `main-arm64/arm64`,
-# `main-jazzy-amd64/amd64`, `main-jazzy-arm64/arm64`.
-# Each route owns a self-contained cache lineage keyed on
-# `{build-type}-{ros-distro}-{platform}`; there is no cross-route
-# fallback. Within a lineage, registry tags are per-ref so consecutive
-# PR runs reuse their own layers.
+# Builds `universe-devel` on independent matrix routes, one per
+# `build-type`: `main-humble-amd64`, `nightly-humble-amd64`,
+# `main-humble-arm64`, `main-jazzy-amd64`, `main-jazzy-arm64`.
+# The build-type names the ROS distro and the platform, and each route
+# owns a self-contained cache lineage keyed on `{build-type}`; there is
+# no cross-route fallback. Within a lineage, registry tags are per-ref
+# so consecutive PR runs reuse their own layers.
 #
 #   - GHA mount cache (actions/cache). Caches BuildKit RUN mounts (apt,
 #     ccache, pip, pipx) as a tarball keyed per route+sha. Only main
@@ -26,7 +26,7 @@ on:
   workflow_call:
     inputs:
       build-type:
-        description: Build-type label (e.g. main, nightly, main-arm64); drives caching lineage and conditional steps
+        description: Build-type label (e.g. main-humble-amd64, nightly-humble-amd64); names the cache lineage and drives conditional steps
         type: string
         required: true
       platform:
@@ -59,8 +59,8 @@ jobs:
       packages: write
       actions: write
     env:
-      CACHE_KEY_PREFIX: buildkit-mounts-health-check-${{ inputs.build-type }}-${{ inputs.ros-distro }}-${{ inputs.platform }}-
-      CACHE_REF_PREFIX: ghcr.io/${{ github.repository }}-buildcache:health-check-${{ inputs.build-type }}-${{ inputs.ros-distro }}-${{ inputs.platform }}
+      CACHE_KEY_PREFIX: buildkit-mounts-health-check-${{ inputs.build-type }}-
+      CACHE_REF_PREFIX: ghcr.io/${{ github.repository }}-buildcache:health-check-${{ inputs.build-type }}
       IS_MAIN_PUSH: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     steps:
       - name: 🔧 Change permission of workspace
@@ -88,7 +88,7 @@ jobs:
           echo "::endgroup::"
 
       - name: 🧹 Free disk space
-        if: inputs.build-type != 'main'
+        if: inputs.build-type != 'main-humble-amd64'
         uses: ./.github/actions/free-disk-space
 
       - name: 💾 Create additional swap
@@ -107,7 +107,7 @@ jobs:
           vcs import --shallow src < repositories/autoware.repos
 
       - name: 📦 Overlay nightly repos
-        if: inputs.build-type == 'nightly'
+        if: startsWith(inputs.build-type, 'nightly')
         run: |
           vcs import --shallow --force src < repositories/autoware-nightly.repos
 

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -17,17 +17,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [main, nightly, main-arm64, main-jazzy-amd64, main-jazzy-arm64]
+        build-type:
+          - main-humble-amd64
+          - nightly-humble-amd64
+          - main-humble-arm64
+          - main-jazzy-amd64
+          - main-jazzy-arm64
         include:
-          - build-type: main
+          - build-type: main-humble-amd64
             platform: amd64
             runner: "['ubuntu-24.04']"
             ros-distro: humble
-          - build-type: nightly
+          - build-type: nightly-humble-amd64
             platform: amd64
             runner: "['ubuntu-24.04']"
             ros-distro: humble
-          - build-type: main-arm64
+          - build-type: main-humble-arm64
             platform: arm64
             runner: "['ubuntu-24.04-arm']"
             ros-distro: humble


### PR DESCRIPTION
## Description

The `health-check-pr` workflow runs five `universe-devel` builds on every labeled PR. Only `health-check (main) / docker-build` is a required check. The other four legs cost runner time, and two of them fail on every run for reasons that no PR can fix.

- `main-arm64` fails after about 30 minutes in `autoware_path_optimizer`. The casadi wheel in the acados venv needs `GLIBCXX_3.4.32`, and Ubuntu 22.04 arm64 does not ship it. The last green run was on August 22.
- `nightly` fails on every run. Universe `main` does not compile against the pinned core (`PointXYZCPE` is not declared in `autoware_euclidean_cluster`). The leg holds a runner for 74 to 310 minutes.

This PR makes three changes.

1. The humble legs get explicit names, in the same form as the jazzy legs: `main` becomes `main-humble-amd64`, `nightly` becomes `nightly-humble-amd64`, and `main-arm64` becomes `main-humble-arm64`.
2. The PR workflow runs only `main-humble-amd64` and `main-jazzy-amd64`. These are the release targets, and both become required checks.
3. The `health-check` workflow keeps all five legs on push to `main`, on the daily schedule, and on manual dispatch. The Software Working Group reviews these results weekly.

Since a build-type now names the distro and the platform, the cache lineage is keyed on the build-type alone. The old key appended the distro and the platform again. Without this change, the new jazzy key reads `main-jazzy-amd64-jazzy-amd64`. With this change, the two required humble legs keep their current cache keys unchanged. The jazzy and arm64 legs get new registry tags, so their first build runs without layer cache. The old mount-cache entries of the jazzy legs match the new key prefix, so the ccache stays warm, and the first push to `main` prunes them.

The `Free disk space` step keeps its exclusion for the humble amd64 main leg under the new name. The `Overlay nightly repos` step now matches any build-type that starts with `nightly`.

## Follow-up outside this PR

The ruleset `main - status checks` (id 1203217) requires `health-check (main) / docker-build`. When this PR merges, no job reports that name any more. Before the merge, an admin replaces the entry with two entries:

- `health-check (main-humble-amd64) / docker-build`
- `health-check (main-jazzy-amd64) / docker-build`

The required wait per PR grows. The jazzy amd64 leg takes 74 to 100 minutes, against 62 to 74 minutes for humble amd64.

PRs that are open at merge time report the old check names. Each of them needs a new push or a label change to report under the new names.

- Example of a `.repos` bump that paid for all five legs: #7304

## AI usage

**AI usage:** written with Claude Code from a description of the plan, after an analysis of the health-check runs of the last two weeks.

**Self-review:** The 2 required new checks completed, checked out the changes, look alright.

<details>
<summary><strong>Verification:</strong> Static checks only: pre-commit and actionlint pass on the three workflow files, and the cache keys were compared by script. No health-check job ran on this branch yet.</summary>

### pre-commit on the three workflow files

Ubuntu 24.04 host, `pre-commit` from pipx.

- `pre-commit run --files .github/workflows/health-check.yaml .github/workflows/health-check-pr.yaml .github/workflows/health-check-reusable.yaml`: `prettier` reported `files were modified by this hook` once and wrapped the matrix list into a bracket block. The list is now in block style, and the second run reports `prettier` and `yamllint` as `Passed`. Every other hook reports `Passed` or `Skipped` for no files.
- Not run: the pre-commit.ci job. It runs on the PR.

### actionlint 1.7.12 in the `rhysd/actionlint` Docker image

- Three findings, all on lines that this PR does not touch: two `SC2086` hints in the `Change permission of workspace` script, and a missing `description` in `.github/actions/free-disk-space/action.yaml`. Zero findings on the changed lines.
- Not run in CI: actionlint is not part of the pre-commit config of this repository.

### Cache lineage keys, before and after

Derived by string comparison of the `CACHE_KEY_PREFIX` expression, not by a CI run.

| Leg | Key before | Key after | First run after merge |
|---|---|---|---|
| main-humble-amd64 | `main-humble-amd64` | `main-humble-amd64` | unchanged, warm |
| nightly-humble-amd64 | `nightly-humble-amd64` | `nightly-humble-amd64` | unchanged, warm |
| main-humble-arm64 | `main-arm64-humble-arm64` | `main-humble-arm64` | cold mounts, cold layers |
| main-jazzy-amd64 | `main-jazzy-amd64-jazzy-amd64` | `main-jazzy-amd64` | warm mounts by prefix restore, cold layers |
| main-jazzy-arm64 | `main-jazzy-arm64-jazzy-arm64` | `main-jazzy-arm64` | warm mounts by prefix restore, cold layers |

- Not run: no health-check job ran on this branch. The first labeled run on this PR is the real test. It must report `health-check (main-humble-amd64) / docker-build` and `health-check (main-jazzy-amd64) / docker-build` as green.
- Not run: the push-to-main run with the five renamed legs. It happens after the merge.

</details>
