### PR TITLE
fix(acados): pin CasADi to 3.7.2 for Humble ARM64

### DIFF
--- a/ansible/roles/acados/defaults/main.yaml
+++ b/ansible/roles/acados/defaults/main.yaml
@@ -1,5 +1,6 @@
 acados_version: v0.5.3
 acados_tera_renderer_version: v0.2.0
 acados_pip_packages:
-  - casadi
+  # CasADi 3.8.0 ARM64 wheels require a newer libstdc++ than Ubuntu 22.04 provides.
+  - casadi==3.7.2
   - sympy


### PR DESCRIPTION
## Description

Pin CasADi to 3.7.2 in the acados role. The 3.8.0 ARM64 wheel requires `GLIBCXX_3.4.32`, which Ubuntu 22.04 does not provide. This breaks the path optimizer code generator and blocks Humble image publication. One default version keeps both architectures aligned.

The upstream fix is available in nightly wheels. The latest stable release remains 3.8.0.

- Upstream report and nightly fix: casadi/casadi#4402
- Failed image build: https://github.com/autowarefoundation/autoware/actions/runs/33874094887/job/101031315317

The separate GeographicLib setup failure in the CUDA ARM64 job still needs a successful CI run before Humble image publication can complete.

## AI usage

**AI usage:** Written with Codex after an investigation of the failed Core and image workflows, with local reproduction and compatibility tests.

**Self-review:** Simple PR, done.

<details>
<summary><strong>Verification:</strong> CasADi 3.8.0 reproduced the ARM64 import failure, and 3.7.2 passed import, solver, and Humble AMD64 code generation tests. Repository checks passed, but the full image workflow did not run locally.</summary>

### ARM64 wheel inspection

- Binary inspection with `readelf` showed that 3.8.0 requires `GLIBCXX_3.4.32` in both `_casadi.so` and `libcasadi.so.3.7`.
- The corresponding 3.7.2 requirements were `GLIBCXX_3.4.14` and `GLIBCXX_3.4.19`.

### Humble AMD64 code generation

- The real path optimizer code generator completed in the existing `ghcr.io/autowarefoundation/autoware:universe-humble` image with CasADi 3.7.2, exit status 0.
- The generator produced `acados_solver_curvilinear_bicycle_model_spatial.c` and its header.
- The full Ansible role and solver compilation did not run.

### ARM64 import and solver

Debian 12, Python 3.10, QEMU 8.2.2 userspace emulation.

- The first container launch failed with exit status 125 because a read-only mount lacked its mountpoint. The retry used an existing mountpoint.
- CasADi 3.8.0 failed at import with `GLIBCXX_3.4.32`, exit status 1.
- CasADi 3.7.2 printed `aarch64 3.7.2` and `rootfinder result: 1.4142135623730951`, exit status 0.
- Native ARM64 builds did not run.

### Repository checks

- YAML parsing passed and selected `casadi==3.7.2`.
- `pre-commit run --files ansible/roles/acados/defaults/main.yaml` passed all eight applicable hooks. The other hooks skipped this YAML file.
- `git diff --check` passed.
- GitHub Actions and Docker image publication did not run on this branch.

</details>
