### PR TITLE
feat(ansible): add the CARLA 0.10 Town10HD_Opt map to demo_artifacts

### DIFF
--- a/ansible/roles/demo_artifacts/README.md
+++ b/ansible/roles/demo_artifacts/README.md
@@ -4,9 +4,16 @@ Downloads sample maps and rosbag recordings used by the Autoware demos:
 
 - [Planning simulation](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/) — uses `sample-map-planning`
 - [Rosbag replay simulation](https://autowarefoundation.github.io/autoware-documentation/main/demos/rosbag-replay-simulation/) — uses `sample-map-rosbag` and `sample-rosbag`
-- [CARLA simulation](../../../docker/examples/demos/carla/README.md) — uses `carla-kashiwanoha`
+- [CARLA simulation](../../../docker/examples/demos/carla/README.md) — uses `carla-kashiwanoha` on CARLA 0.9, and the CARLA towns themselves on CARLA 0.10
 
-The maps and the recordings are hosted on the `autoware-files` S3 bucket. The CARLA map is hosted on [Hugging Face](https://huggingface.co/datasets/AutowareFoundation/map-carla-kashiwanoha), pinned to tag `0.2.0`. The download drops the demo video in that dataset, which no node reads.
+The maps and the recordings are hosted on the `autoware-files` S3 bucket. The CARLA maps are hosted on Hugging Face, each pinned to a revision:
+
+| Dataset                                                                                             | Revision         | Dropped                                                 |
+| --------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------- |
+| [`map-carla-kashiwanoha`](https://huggingface.co/datasets/AutowareFoundation/map-carla-kashiwanoha) | tag `0.2.0`      | the demo video, which no node reads                     |
+| [`carla-ue5-maps`](https://huggingface.co/datasets/AutowareFoundation/carla-ue5-maps)               | commit `682ddd4` | every world but `Town10HD_Opt`, and the preview renders |
+
+`carla-ue5-maps` carries no tag yet, so it is pinned to the commit that published `Town10HD_Opt`. Add a world to the `include` patterns in `tasks/main.yaml` to pull more of them.
 
 ## Layout
 
@@ -15,6 +22,8 @@ After running the role, the following layout is created under `demo_artifacts__a
 ```console
 ~/autoware_data
 ├── maps
+│   ├── autoware_maps/
+│   │   └── Town10HD_Opt/
 │   ├── carla-kashiwanoha/
 │   ├── sample-map-planning/
 │   ├── sample-map-planning.zip
@@ -36,6 +45,19 @@ After running the role, the following layout is created under `demo_artifacts__a
 ```
 
 CARLA has no map of this area, so it builds the world from `kashiwanoha.xodr`. Both files describe the same roads, against the one origin in `map_projector_info.yaml`. The [dataset card](https://huggingface.co/datasets/AutowareFoundation/map-carla-kashiwanoha) carries the world build step and the provenance of each file.
+
+`autoware_maps/` holds one directory per CARLA world, named after the world CARLA loads:
+
+```console
+~/autoware_data/maps/autoware_maps/Town10HD_Opt
+├── lanelet2_map.osm          # read by Autoware
+├── map_projector_info.yaml   # read by Autoware
+└── pointcloud_map.pcd        # read by Autoware, for localization
+```
+
+Here CARLA already ships the town, so nothing in the directory is read by the simulator — pass the directory to Autoware as `map_path`, and its basename to CARLA as the world to load. The point clouds published alongside the CARLA towns were recorded on CARLA 0.9, whose towns are different geometry from the ones CARLA 0.10 re-authored in Unreal Engine 5; the ones here were recorded from 0.10 itself, so NDT has a map that matches the world.
+
+The dataset keeps the `autoware_maps/` prefix on its own files, and `hf download` preserves it, which is why the worlds land one level below `maps/` rather than beside `carla-kashiwanoha/`.
 
 ## Run
 

--- a/ansible/roles/demo_artifacts/README.md
+++ b/ansible/roles/demo_artifacts/README.md
@@ -4,7 +4,9 @@ Downloads sample maps and rosbag recordings used by the Autoware demos:
 
 - [Planning simulation](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/) — uses `sample-map-planning`
 - [Rosbag replay simulation](https://autowarefoundation.github.io/autoware-documentation/main/demos/rosbag-replay-simulation/) — uses `sample-map-rosbag` and `sample-rosbag`
-- [CARLA simulation](../../../docker/examples/demos/carla/README.md) — uses `carla-kashiwanoha` on CARLA 0.9, and the CARLA towns themselves on CARLA 0.10
+- [CARLA simulation](../../../docker/examples/demos/carla/README.md) — uses `carla-kashiwanoha`
+
+The role also downloads Autoware maps for the CARLA towns as CARLA 0.10 re-authored them. Nothing in this repository runs CARLA 0.10 yet — see [Maps for CARLA 0.10](../../../docker/examples/demos/carla/README.md#maps-for-carla-010) for what is still missing, and do not point the demo above at them.
 
 The maps and the recordings are hosted on the `autoware-files` S3 bucket. The CARLA maps are hosted on Hugging Face, each pinned to a revision:
 
@@ -56,6 +58,8 @@ CARLA has no map of this area, so it builds the world from `kashiwanoha.xodr`. B
 ```
 
 Here CARLA already ships the town, so nothing in the directory is read by the simulator — pass the directory to Autoware as `map_path`, and its basename to CARLA as the world to load. The point clouds published alongside the CARLA towns were recorded on CARLA 0.9, whose towns are different geometry from the ones CARLA 0.10 re-authored in Unreal Engine 5; the ones here were recorded from 0.10 itself, so NDT has a map that matches the world.
+
+That cuts both ways: **these maps need a CARLA 0.10 server**. Against the 0.9.16 server the [CARLA demo](../../../docker/examples/demos/carla/README.md) pins, the 0.10 point cloud describes geometry the world does not have, which is the same mismatch in the other direction. The role downloads the maps either way — they are ~24 MB and cost nothing to have on disk — but [Maps for CARLA 0.10](../../../docker/examples/demos/carla/README.md#maps-for-carla-010) lists what a 0.10 runtime still needs.
 
 The dataset keeps the `autoware_maps/` prefix on its own files, and `hf download` preserves it, which is why the worlds land one level below `maps/` rather than beside `carla-kashiwanoha/`.
 

--- a/ansible/roles/demo_artifacts/tasks/main.yaml
+++ b/ansible/roles/demo_artifacts/tasks/main.yaml
@@ -57,16 +57,22 @@
     src: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/sample-rosbag.zip"
     dest: "{{ demo_artifacts__autoware_data_dir }}/recordings/bags/"
 
-# map-carla-kashiwanoha (CARLA docker-compose demo)
-# dest is relative to the maps directory. The demo video in the dataset is not part of the map.
+# Maps for the CARLA demos.
+#
+# dest is relative to demo_artifacts__autoware_data_dir. hf keeps the repo-relative path of
+# every file it downloads under --local-dir, so a dataset that already namespaces its worlds
+# (carla-ue5-maps) points dest at maps/ itself instead of claiming a directory of its own.
+#
+# include/exclude drop what is not part of a map: the demo video, the preview renders.
 - name: Download the map datasets from Hugging Face
   ansible.builtin.command:
     cmd: >-
       hf download AutowareFoundation/{{ item.repo }}
       --repo-type dataset
       --revision {{ item.revision }}
-      --exclude "*.mp4"
-      --local-dir "{{ demo_artifacts__autoware_data_dir }}/maps/{{ item.dest | default(item.repo) }}"
+      {% for pattern in item.include | default([]) %}--include "{{ pattern }}" {% endfor %}
+      {% for pattern in item.exclude | default([]) %}--exclude "{{ pattern }}" {% endfor %}
+      --local-dir "{{ demo_artifacts__autoware_data_dir }}/{{ item.dest }}"
   environment:
     PATH: "{{ ansible_facts.env.PIPX_BIN_DIR | default(ansible_facts.env.HOME ~ '/.local/bin', true) }}:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -74,4 +80,15 @@
   loop_control:
     label: "{{ item.repo }} {{ item.revision }}"
   loop:
-    - { repo: map-carla-kashiwanoha, revision: 0.2.0, dest: carla-kashiwanoha }
+    # CARLA docker-compose demo.
+    - repo: map-carla-kashiwanoha
+      revision: 0.2.0
+      exclude: ["*.mp4"]
+      dest: maps/carla-kashiwanoha
+
+    # Autoware maps for the CARLA 0.10 towns, one directory per world. The dataset carries no
+    # tag yet, so the revision is the commit that published Town10HD_Opt.
+    - repo: carla-ue5-maps
+      revision: 682ddd48b4cf305507646cb2f2e563bbedac4c2e
+      include: [autoware_maps/Town10HD_Opt/*]
+      dest: maps

--- a/docker/examples/demos/carla/README.md
+++ b/docker/examples/demos/carla/README.md
@@ -16,6 +16,7 @@ Splitting the interface out makes it easier to restart just the bridge (e.g. whe
 ## Prerequisites
 
 - NVIDIA GPU with the NVIDIA Container Toolkit installed
+- CARLA **0.9.16** — the version this stack pins, for both the simulator image and the Python API. The maps under `~/autoware_data/maps/autoware_maps/` are for CARLA 0.10 and will not work here; see [Maps for CARLA 0.10](#maps-for-carla-010).
 - CARLA Lanelet2 map (e.g. `Town01`) extracted to `~/autoware_data/maps/Town01` — see the [autoware_carla_interface README](https://autowarefoundation.github.io/autoware_universe/main/simulator/autoware_carla_interface/#map-setup) for the expected layout (`lanelet2_map.osm`, `pointcloud_map.pcd`, `map_projector_info.yaml`)
 - Perception model data under `~/autoware_data/ml_models`
 - Docker Compose v2
@@ -64,7 +65,7 @@ Edit the `command:` block in `docker-compose.yaml` to change launch arguments.
 
 **`carla-interface`**:
 
-- **Map**: change `map_path` (e.g. `Town10HD`) — the basename is forwarded to CARLA as the world to load. Keep this in sync with the `map_path` on the `autoware` service.
+- **Map**: change `map_path` (e.g. `Town10HD`) — the basename is forwarded to CARLA as the world to load. Keep this in sync with the `map_path` on the `autoware` service. Use a map recorded on 0.9; not the 0.10 ones (see [Maps for CARLA 0.10](#maps-for-carla-010)).
 - **Light-weight sensors**: set `use_light_weight_sensor_mapping:=true` to use a single front camera at lower frequencies (lower GPU load).
 - **Timeout**: `timeout:=60` is the CARLA client connect timeout in seconds.
 
@@ -138,3 +139,33 @@ ros2 launch autoware_launch e2e_simulator.launch.xml \
 ```bash
 ./CarlaUE4.sh -prefernvidia -quality-level=Low -nosound
 ```
+
+## Maps for CARLA 0.10
+
+CARLA 0.10 re-authored the towns in Unreal Engine 5. The geometry moved, so a point cloud map
+recorded on one release does not describe the world of the other, in either direction: NDT scores a
+confident match against walls that are no longer there, drifts, and the MRM handler emergency-stops
+the route.
+
+The [`demo_artifacts`](../../../../ansible/roles/demo_artifacts/README.md) ansible role downloads
+maps recorded from 0.10 into `~/autoware_data/maps/autoware_maps/<World>/`. **They are not for this
+stack.** This one pins 0.9.16 in two places, and both would have to move together:
+
+|            | Pinned to               | Where                                                  |
+| ---------- | ----------------------- | ------------------------------------------------------ |
+| Simulator  | `carlasim/carla:0.9.16` | `docker-compose.yaml`, the `carla-simulator` service   |
+| Python API | `CARLA_VERSION=0.9.16`  | `docker-compose.yaml`, the `x-carla-python-api` anchor |
+
+Two things are missing before that pin can be raised:
+
+- **There is no CARLA 0.10 Python client to install.** `x-carla-python-api` resolves a wheel from
+  PyPI, and the `carla` project publishes nothing past 0.9.16 there; the 0.10.0 release ships no
+  client wheel either. A 0.10 client has to be built from the CARLA source tree against the same
+  Python and toolchain as the Autoware image.
+- **`autoware_carla_interface` does not handle 0.10 yet.** Its pedal map and vehicle catalogue are
+  0.9-era — `vehicle.toyota.prius`, the default ego, does not exist in 0.10, and the creep throttle
+  that starts a pull-out is too low for the 0.10 vehicles to move at all.
+
+`carlasim/carla:0.10.0` does exist on Docker Hub, so the simulator half is available; it is the
+client and the bridge that are not. Until both land, treat the 0.10 maps as data published ahead of
+the runtime that reads them.


### PR DESCRIPTION
## Description

The Autoware maps published alongside the CARLA towns were recorded on CARLA 0.9. CARLA 0.10 re-authored those towns in Unreal Engine 5, so the published point clouds no longer describe the world a vehicle drives in, and NDT scores a confident match on geometry that has moved. [`AutowareFoundation/carla-ue5-maps`](https://huggingface.co/datasets/AutowareFoundation/carla-ue5-maps) carries point clouds recorded from 0.10 itself, one directory per world, starting with `Town10HD_Opt`.

This adds that download to `demo_artifacts`, joining the `hf` loop the Kashiwanoha map already runs in — as #7301 anticipated ("the next map dataset is one more loop entry"). Two changes make room for it:

- **Filters are per entry.** The `--exclude "*.mp4"` that dropped the Kashiwanoha demo video was hardcoded; entries now carry `include`/`exclude` pattern lists. This dataset drops the preview renders and every world but `Town10HD_Opt`.
- **`dest` is relative to `autoware_data`, not `maps`.** The dataset already namespaces its worlds under `autoware_maps/`, and `hf download` preserves the repo-relative path, so this entry points `dest` at `maps` itself and unpacks into `maps/autoware_maps/Town10HD_Opt/` rather than claiming a directory of its own. That is the layout the dataset card documents, and the directory basename is the world name CARLA loads, matching the `map_path` convention the CARLA demo already uses.

The Kashiwanoha download is unchanged — same argv before and after.

The dataset carries no tag yet, so the revision is the commit that published `Town10HD_Opt` (`682ddd4`).

Resulting layout:

```console
~/autoware_data/maps/autoware_maps/Town10HD_Opt
├── lanelet2_map.osm          # read by Autoware
├── map_projector_info.yaml   # read by Autoware
└── pointcloud_map.pcd        # read by Autoware, for localization
```

Adding a world later is one more `include` pattern.

## How was this PR tested?

- Rendered the templated `hf` command through Ansible's own Jinja (`ansible-playbook` over the task's `loop` and `loop_control`) and compared the argv after `shlex` splitting. The `map-carla-kashiwanoha` invocation is byte-identical to `main`; the new one is:

  ```console
  hf download AutowareFoundation/carla-ue5-maps --repo-type dataset \
    --revision 682ddd48b4cf305507646cb2f2e563bbedac4c2e \
    --include "autoware_maps/Town10HD_Opt/*" \
    --local-dir "$HOME/autoware_data/maps"
  ```

- Ran that command for real against a scratch `--local-dir`. It fetches exactly the three map files at the pinned revision, no preview renders:

  ```console
  Fetching 3 files: 100%|██████████| 3/3 [00:04<00:00,  1.47s/it]

        22  maps/autoware_maps/Town10HD_Opt/map_projector_info.yaml
   2248269  maps/autoware_maps/Town10HD_Opt/lanelet2_map.osm
  22220444  maps/autoware_maps/Town10HD_Opt/pointcloud_map.pcd
  ```

  `map_projector_info.yaml` is `projector_type: Local`, and the point cloud header reports the 1 851 689 points the dataset card states.

- `pre-commit run --files ansible/roles/demo_artifacts/{tasks/main.yaml,README.md}` passes (`yamllint`, `prettier`, `markdownlint`, `check-yaml`).

Not exercised: a full `ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts` run — `demo_artifacts` is `never`-tagged and not covered by `health-check-ansible`, so the role was verified at the task level as above rather than end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb99yovCQZVXT47PYzAjXJ
