### PR TITLE
fix(docker): build simple planning simulator with core

### DIFF
--- a/docker/core.Dockerfile
+++ b/docker/core.Dockerfile
@@ -31,7 +31,9 @@ ENV CXX="/usr/lib/ccache/g++"
 ENV CCACHE_DIR="/home/aw/.ccache"
 
 COPY --parents --chown=${USERNAME}:${USERNAME} src/core/**/package.xml /tmp/autoware/
-RUN rm -rf /tmp/autoware/src/core/autoware_core /tmp/autoware/src/core/autoware_rviz_plugins
+RUN rm -rf /tmp/autoware/src/core/autoware_core \
+           /tmp/autoware/src/core/autoware_rviz_plugins \
+           /tmp/autoware/src/core/autoware_simple_planning_simulator
 
 RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-${ROS_DISTRO},target=/var/lib/apt/lists,sharing=locked \
@@ -49,7 +51,8 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
 RUN --mount=type=bind,source=src/core,target=/tmp/autoware/src/core,rw \
     --mount=type=cache,id=ccache-${ROS_DISTRO},target=/home/aw/.ccache,uid=1000,gid=1000 \
     rm -rf /tmp/autoware/src/core/autoware_core \
-           /tmp/autoware/src/core/autoware_rviz_plugins && \
+           /tmp/autoware/src/core/autoware_rviz_plugins \
+           /tmp/autoware/src/core/autoware_simple_planning_simulator && \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
     colcon build \
       --base-paths /tmp/autoware/src/core \
@@ -63,6 +66,7 @@ ARG ROS_DISTRO
 COPY --parents --chown=${USERNAME}:${USERNAME} \
     src/core/autoware_core/**/package.xml \
     src/core/autoware_rviz_plugins/**/package.xml \
+    src/core/autoware_simple_planning_simulator/**/package.xml \
     /tmp/autoware/
 
 RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=locked \
@@ -81,12 +85,14 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
 
 RUN --mount=type=bind,source=src/core/autoware_core,target=/tmp/autoware/src/core/autoware_core \
     --mount=type=bind,source=src/core/autoware_rviz_plugins,target=/tmp/autoware/src/core/autoware_rviz_plugins \
+    --mount=type=bind,source=src/core/autoware_simple_planning_simulator,target=/tmp/autoware/src/core/autoware_simple_planning_simulator \
     --mount=type=cache,id=ccache-${ROS_DISTRO},target=/home/aw/.ccache,uid=1000,gid=1000 \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
     . /opt/autoware/setup.sh && \
     colcon build \
       --base-paths /tmp/autoware/src/core/autoware_core \
                    /tmp/autoware/src/core/autoware_rviz_plugins \
+                   /tmp/autoware/src/core/autoware_simple_planning_simulator \
       --install-base /opt/autoware \
       --cmake-args -DCMAKE_BUILD_TYPE=Release && \
     rm -rf build log


### PR DESCRIPTION
## Description

- Move `autoware_simple_planning_simulator` from the generic Core dependency build into the Core source overlay.
- Build it with `autoware_core` and `autoware_rviz_plugins` in `core-devel`.
- Prevent rosdep from satisfying its `autoware_core` dependency with released Autoware Debian packages.

## Why

`autoware_simple_planning_simulator` depends on `autoware_core`. Exposing its manifests in `core-dependencies` while hiding `autoware_core` causes rosdep to install released Core packages. In the [failing Humble nightly job](https://github.com/autowarefoundation/autoware/actions/runs/34104016537/job/101684888476), this installed `ros-humble-autoware-point-types` 1.9.0, and the later source build found stale headers under `/opt/ros/humble` while compiling `autoware_euclidean_cluster`.

Building the simulator repository in the same source overlay as `autoware_core` preserves the intended dependency boundary and prevents those released packages from entering the image.

---

## Test plan

- [x] Run `docker buildx bake -f docker/docker-bake.hcl core-devel --print`.
- [x] Run `ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl core-devel --progress=plain`.
- [x] Run `ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl universe-devel --progress=plain`.
- [x] Confirm the final Humble images contain the workspace packages and no `ros-humble-autoware-*` Debian packages.

## AI usage

**AI usage:** Investigated and implemented with Codex from the reported failing nightly job and the requested Docker stage boundary.

**Self-review:** Not reviewed yet.

<details>
<summary><strong>Verification:</strong> Built the Humble `core-devel` and `universe-devel` images; `universe-devel` finished all 538 packages, including `autoware_simple_planning_simulator` and `autoware_euclidean_cluster`, and the final images contained no `ros-humble-autoware-*` Debian packages.</summary>

### Docker bake validation

- `docker buildx bake -f docker/docker-bake.hcl core-devel --print` exited with status 0 and resolved the `autoware:core-devel-humble` target.
- Jazzy and ARM64 image configurations were not validated.

### Humble Core image build

- `ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl core-devel --progress=plain` exited with status 0.
- The dependency stage finished 52 packages, and the source-overlay stage finished 84 packages.
- The resulting image contained the workspace `PointCloudClassification` header and no `ros-humble-autoware-*` Debian packages.

### Humble Universe image build

- `ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl universe-devel --progress=plain` exited with status 0.
- The build reported `538 packages finished [26min 45s]`; `autoware_simple_planning_simulator` and `autoware_euclidean_cluster` finished successfully.
- The resulting image contained both workspace package manifests and no `ros-humble-autoware-*` Debian packages.
- A separate `colcon test` run and the GitHub Actions job were not run.

</details>
